### PR TITLE
Add asm.cpu and pdb loading to OptionsDialog

### DIFF
--- a/src/createnewdialog.cpp
+++ b/src/createnewdialog.cpp
@@ -64,7 +64,7 @@ void createNewDialog::on_exampleButton_clicked()
     {
         str = "48656c6c6f20576f726c6400";
     }
-    else fprintf(stderr, tr("Unknown combo value selected").toLocal8Bit().constData());
+    else fprintf(stderr, "%s", tr("Unknown combo value selected").toLocal8Bit().constData());
     if (str.length() > 0)
         ui->plainTextEdit->setPlainText(str);
     // }

--- a/src/cutter.cpp
+++ b/src/cutter.cpp
@@ -403,30 +403,6 @@ bool CutterCore::tryFile(QString path, bool rw)
     return true;
 }
 
-/*QList<QString> CutterCore::getList(const QString &type, const QString &subtype)
-{
-    CORE_LOCK();
-    QList<QString> ret = QList<QString>();
-
-    if (type == "bin")
-    {
-        if (subtype == "types")
-        {
-            ret << "raw";
-            auto ft = sdb_const_get(DB, "try.filetype", 0);
-            if (ft && *ft)
-                ret << ft;
-        }
-        else if (subtype == "entrypoints")
-        {
-            if (math("entry0") != 0)
-                ret << "entry0";
-        }
-    }
-
-    return ret;
-}*/
-
 ut64 CutterCore::math(const QString &expr)
 {
     CORE_LOCK();

--- a/src/cutter.cpp
+++ b/src/cutter.cpp
@@ -323,13 +323,13 @@ void CutterCore::renameFunction(QString prev_name, QString new_name)
     emit functionRenamed(prev_name, new_name);
 }
 
+
 void CutterCore::setComment(RVA addr, QString cmt)
 {
     //r_meta_add (core->anal, 'C', addr, 1, cmt.toUtf8());
     cmd("CC " + cmt + " @ " + QString::number(addr));
     emit commentsChanged();
 }
-
 
 void CutterCore::delComment(ut64 addr)
 {
@@ -358,19 +358,21 @@ QMap<QString, QList<QList<QString>>> CutterCore::getNestedComments()
     return ret;
 }
 
+
+
 void CutterCore::seek(QString addr)
 {
     if (addr.length() > 0)
         seek(this->math(addr.toUtf8().constData()));
 }
 
-
-
 void CutterCore::seek(ut64 offset)
 {
     CORE_LOCK();
     r_core_seek(this->core_, offset, true);
 }
+
+
 
 bool CutterCore::tryFile(QString path, bool rw)
 {
@@ -399,9 +401,7 @@ bool CutterCore::tryFile(QString path, bool rw)
     return true;
 }
 
-
-
-QList<QString> CutterCore::getList(const QString &type, const QString &subtype)
+/*QList<QString> CutterCore::getList(const QString &type, const QString &subtype)
 {
     CORE_LOCK();
     QList<QString> ret = QList<QString>();
@@ -421,21 +421,9 @@ QList<QString> CutterCore::getList(const QString &type, const QString &subtype)
                 ret << "entry0";
         }
     }
-    else if (type == "asm")
-    {
-        if (subtype == "cpus")
-        {
-            QString funcs = cmd("e asm.cpu=?");
-            QStringList lines = funcs.split("\n");
-            for (auto cpu : lines)
-            {
-                ret << cpu;
-            }
-        }
-    }
 
     return ret;
-}
+}*/
 
 ut64 CutterCore::math(const QString &expr)
 {
@@ -720,6 +708,10 @@ void CutterCore::getOpcodes()
     this->regs.removeLast();
 }
 
+
+
+
+
 void CutterCore::setSettings()
 {
     config("scr.color", "false");
@@ -785,8 +777,6 @@ void CutterCore::setSettings()
 
 
 
-
-
 QList<RVA> CutterCore::getSeekHistory()
 {
     CORE_LOCK();
@@ -798,8 +788,6 @@ QList<RVA> CutterCore::getSeekHistory()
 
     return ret;
 }
-
-
 
 QStringList CutterCore::getAsmPluginNames()
 {
@@ -815,6 +803,7 @@ QStringList CutterCore::getAsmPluginNames()
 
     return ret;
 }
+
 
 QStringList CutterCore::getAnalPluginNames()
 {
@@ -832,6 +821,7 @@ QStringList CutterCore::getAnalPluginNames()
 }
 
 
+
 QStringList CutterCore::getProjectNames()
 {
     CORE_LOCK();
@@ -843,7 +833,6 @@ QStringList CutterCore::getProjectNames()
 
     return ret;
 }
-
 
 
 QList<FunctionDescription> CutterCore::getAllFunctions()
@@ -870,6 +859,7 @@ QList<FunctionDescription> CutterCore::getAllFunctions()
 }
 
 
+
 QList<ImportDescription> CutterCore::getAllImports()
 {
     CORE_LOCK();
@@ -894,7 +884,6 @@ QList<ImportDescription> CutterCore::getAllImports()
 
     return ret;
 }
-
 
 
 QList<ExportDescription> CutterCore::getAllExports()
@@ -962,7 +951,6 @@ QList<SymbolDescription> CutterCore::getAllSymbols()
     return ret;
 }
 
-
 QList<CommentDescription> CutterCore::getAllComments(const QString &filterType)
 {
     CORE_LOCK();
@@ -1014,6 +1002,7 @@ QList<RelocDescription> CutterCore::getAllRelocs()
 
     return ret;
 }
+
 
 QList<StringDescription> CutterCore::getAllStrings()
 {
@@ -1108,7 +1097,6 @@ QList<SectionDescription> CutterCore::getAllSections()
     }
     return ret;
 }
-
 
 QList<EntrypointDescription> CutterCore::getAllEntrypoint()
 {

--- a/src/cutter.cpp
+++ b/src/cutter.cpp
@@ -311,7 +311,8 @@ void CutterCore::analyze(int level,  QList<QString> advanced)
     }
     else if (level == 3)
     {
-        foreach(QString option, advanced){
+        foreach (QString option, advanced)
+        {
             r_core_cmd0(core_, option.toStdString().c_str());
         }
     }
@@ -388,8 +389,9 @@ bool CutterCore::tryFile(QString path, bool rw)
     }
 
     bool is_writable = false;
-    if (cf->core && cf->core->io && cf->core->io->desc) {
-	    is_writable = cf->core->io->desc->flags & R_IO_WRITE;
+    if (cf->core && cf->core->io && cf->core->io->desc)
+    {
+        is_writable = cf->core->io->desc->flags & R_IO_WRITE;
     }
     // if rbin works, tell entry0, and symbols (main, constructor, ..)
 
@@ -1163,4 +1165,9 @@ void CutterCore::addFlag(RVA offset, QString name, RVA size)
     name = sanitizeStringForCommand(name);
     cmd(QString("f %1 %2 @ %3").arg(name).arg(size).arg(offset));
     emit flagsChanged();
+}
+
+void CutterCore::loadPDB(const QString &file)
+{
+    cmd("idp " + sanitizeStringForCommand(file));
 }

--- a/src/cutter.h
+++ b/src/cutter.h
@@ -186,6 +186,7 @@ public:
     int fcnEndBbs(RVA addr);
     QString cmd(const QString &str);
     QJsonDocument cmdj(const QString &str);
+    QStringList cmdList(const QString &str)     { auto l = cmd(str).split("\n"); l.removeAll(""); return l; }
     void renameFunction(QString prev_name, QString new_name);
     void setComment(RVA addr, QString cmt);
     void delComment(ut64 addr);
@@ -231,7 +232,7 @@ public:
     QList<QString> regs;
     void setSettings();
 
-    QList<QString> getList(const QString &type, const QString &subtype = "");
+    //QList<QString> getList(const QString &type, const QString &subtype = "");
 
     QList<RVA> getSeekHistory();
 

--- a/src/cutter.h
+++ b/src/cutter.h
@@ -1,4 +1,4 @@
-#ifndef CUTTER_H 
+#ifndef CUTTER_H
 #define CUTTER_H
 
 #include <QMap>
@@ -231,6 +231,8 @@ public:
     QList<QString> opcodes;
     QList<QString> regs;
     void setSettings();
+
+    void loadPDB(const QString &file);
 
     //QList<QString> getList(const QString &type, const QString &subtype = "");
 

--- a/src/cutter.h
+++ b/src/cutter.h
@@ -234,8 +234,6 @@ public:
 
     void loadPDB(const QString &file);
 
-    //QList<QString> getList(const QString &type, const QString &subtype = "");
-
     QList<RVA> getSeekHistory();
 
     QStringList getAsmPluginNames();

--- a/src/dialogs/aboutdialog.cpp
+++ b/src/dialogs/aboutdialog.cpp
@@ -9,12 +9,12 @@ AboutDialog::AboutDialog(QWidget *parent) :
     ui->setupUi(this);
     setWindowFlags(windowFlags() & (~Qt::WindowContextHelpButtonHint));
     ui->label->setText(tr("<h1>Cutter</h1>"
-                       "Version 1.0 alpha<br />"
-                       "Using r2-" R2_GITTAP
-                       "<h2>License</h2>"
-                       "This Software is released under the GNU General Public License v3.0"
-                       "<h2>Authors</h2>"
-                       "Hugo Teso &lt;hugo.teso@gmail.org&gt;\nSoon to be thousands more!"));
+                          "Version 1.0 alpha<br />"
+                          "Using r2-" R2_GITTAP
+                          "<h2>License</h2>"
+                          "This Software is released under the GNU General Public License v3.0"
+                          "<h2>Authors</h2>"
+                          "Hugo Teso &lt;hugo.teso@gmail.org&gt;\nSoon to be thousands more!"));
 }
 
 AboutDialog::~AboutDialog()

--- a/src/dialogs/flagdialog.cpp
+++ b/src/dialogs/flagdialog.cpp
@@ -1,3 +1,4 @@
+
 #include "ui_flagdialog.h"
 #include "flagdialog.h"
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -93,6 +93,7 @@ MainWindow::MainWindow(QWidget *parent) :
     highlighter(nullptr),
     hex_highlighter(nullptr),
     graphicsBar(nullptr),
+    entrypointDock(nullptr),
     functionsDock(nullptr),
     importsDock(nullptr),
     exportsDock(nullptr),
@@ -107,7 +108,6 @@ MainWindow::MainWindow(QWidget *parent) :
     sidebar_action(nullptr),
     sectionsDock(nullptr),
     consoleWidget(nullptr),
-    entrypointDock(nullptr),
     webserver(core)
 {
     doLock = false;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -183,14 +183,17 @@ void MainWindow::initUI()
     // Asm syntaxes
     QList<QString> list = core->cmd("e asm.syntax =?").split("\n");
     QString checked = core->getConfig("asm.syntax");
-    for (QString syntax : list) {
-        if (syntax == "") {
+    for (QString syntax : list)
+    {
+        if (syntax == "")
+        {
             break;
         }
-        QAction* action = new QAction(ui->menuAsm_syntax);
-	action->setText(syntax);
+        QAction *action = new QAction(ui->menuAsm_syntax);
+        action->setText(syntax);
         action->setCheckable(true);
-        if (syntax == checked) {
+        if (syntax == checked)
+        {
             action->setChecked(true);
         }
         connect(action, SIGNAL(triggered()), this, SLOT(actionAsm_syntax_triggered()));
@@ -1113,13 +1116,14 @@ void MainWindow::on_actionDisplay_Offsets_triggered()
 
 void MainWindow::actionAsm_syntax_triggered()
 {
-    QObject* sender = QObject::sender();
+    QObject *sender = QObject::sender();
     // Uncheck every other choices
-    for (QAction* action : asmSyntaxes) {
+    for (QAction *action : asmSyntaxes)
+    {
         action->setChecked(false);
     }
     // Check selected choice
-    QAction* action = (QAction*) sender;
+    QAction *action = (QAction *) sender;
     action->setChecked(true);
     // Set r2 config
     core->config("asm.syntax", action->text());

--- a/src/optionsdialog.cpp
+++ b/src/optionsdialog.cpp
@@ -11,6 +11,7 @@
 
 #include <QSettings>
 #include <QFileInfo>
+#include <QFileDialog>
 
 OptionsDialog::OptionsDialog(MainWindow *main):
     QDialog(0), // parent may not be main
@@ -55,6 +56,10 @@ OptionsDialog::OptionsDialog(MainWindow *main):
     ui->hideFrame->setVisible(false);
     ui->analoptionsFrame->setVisible(false);
 
+    updatePDBLayout();
+
+    connect(ui->pdbCheckBox, SIGNAL(stateChanged(int)), this, SLOT(updatePDBLayout()));
+
     // Add this so the dialog resizes when widgets are shown/hidden
     //this->layout()->setSizeConstraint(QLayout::SetFixedSize);
 
@@ -78,7 +83,7 @@ void OptionsDialog::updateCPUComboBox()
     QString cmd = "e asm.cpu=?";
 
     QString arch = getCurrentSelectedArch();
-    if(!arch.isNull())
+    if (!arch.isNull())
         cmd += " @a:" + arch;
 
     ui->cpuComboBox->addItem("");
@@ -96,7 +101,7 @@ QString OptionsDialog::getCurrentSelectedArch()
 QString OptionsDialog::getCurrentSelectedCPU()
 {
     QString cpu = ui->cpuComboBox->currentText();
-    if(cpu.isNull() || cpu.isEmpty())
+    if (cpu.isNull() || cpu.isEmpty())
         return nullptr;
     return cpu;
 }
@@ -188,9 +193,15 @@ void OptionsDialog::setupAndStartAnalysis(int level, QList<QString> advanced)
 
 
     QString os = getCurrentSelectedOS();
-    if(!os.isNull())
+    if (!os.isNull())
     {
         main->core->cmd("e asm.os=" + os);
+    }
+
+
+    if (ui->pdbCheckBox->isChecked())
+    {
+        main->core->loadPDB(ui->pdbLineEdit->text());
     }
 
 
@@ -207,38 +218,50 @@ void OptionsDialog::on_closeButton_clicked()
 void OptionsDialog::on_okButton_clicked()
 {
     QList<QString> advanced = QList<QString>();
-    if (ui->analSlider->value() == 3){
-        if (ui->aa_symbols->isChecked()){
+    if (ui->analSlider->value() == 3)
+    {
+        if (ui->aa_symbols->isChecked())
+        {
             advanced << "aa";
         }
-        if (ui->aar_references->isChecked()){
+        if (ui->aar_references->isChecked())
+        {
             advanced << "aar";
         }
-        if (ui->aac_calls->isChecked()){
+        if (ui->aac_calls->isChecked())
+        {
             advanced << "aac";
         }
-        if (ui->aan_rename->isChecked()){
+        if (ui->aan_rename->isChecked())
+        {
             advanced << "aan";
         }
-        if (ui->aae_emulate->isChecked()){
+        if (ui->aae_emulate->isChecked())
+        {
             advanced << "aae";
         }
-        if (ui->aat_consecutive->isChecked()){
+        if (ui->aat_consecutive->isChecked())
+        {
             advanced << "aat";
         }
-        if (ui->afta_typeargument->isChecked()){
+        if (ui->afta_typeargument->isChecked())
+        {
             advanced << "afta";
         }
-        if (ui->aaT_aftertrap->isChecked()){
+        if (ui->aaT_aftertrap->isChecked())
+        {
             advanced << "aaT";
         }
-        if (ui->aap_preludes->isChecked()){
+        if (ui->aap_preludes->isChecked())
+        {
             advanced << "aap";
         }
-        if (ui->jmptbl->isChecked()){
+        if (ui->jmptbl->isChecked())
+        {
             advanced << "e! anal.jmptbl";
         }
-        if (ui->pushret->isChecked()){
+        if (ui->pushret->isChecked())
+        {
             advanced << "e! anal.pushret";
         }
     }
@@ -306,7 +329,7 @@ void OptionsDialog::on_analSlider_valueChanged(int value)
     {
         ui->analCheckBox->setChecked(true);
         ui->analCheckBox->setText(tr("Analysis: Enabled"));
-        if (value==3)
+        if (value == 3)
         {
             ui->analoptionsFrame->setVisible(true);
         }
@@ -341,4 +364,28 @@ void OptionsDialog::on_analCheckBox_clicked(bool checked)
 void OptionsDialog::on_archComboBox_currentIndexChanged(int)
 {
     updateCPUComboBox();
+}
+
+void OptionsDialog::updatePDBLayout()
+{
+    ui->pdbWidget->setEnabled(ui->pdbCheckBox->isChecked());
+}
+
+void OptionsDialog::on_pdbSelectButton_clicked()
+{
+    QFileDialog dialog(this);
+    dialog.setWindowTitle(tr("Select PDB file"));
+    dialog.setNameFilters({ tr("PDB file (*.pdb)"), tr("All files (*)") });
+
+    if (!dialog.exec())
+    {
+        return;
+    }
+
+    QString fileName = dialog.selectedFiles().first();
+
+    if (!fileName.isEmpty())
+    {
+        ui->pdbLineEdit->setText(fileName);
+    }
 }

--- a/src/optionsdialog.cpp
+++ b/src/optionsdialog.cpp
@@ -82,7 +82,7 @@ void OptionsDialog::updateCPUComboBox()
 
     QString cmd = "e asm.cpu=?";
 
-    QString arch = getCurrentSelectedArch();
+    QString arch = getSelectedArch();
     if (!arch.isNull())
         cmd += " @a:" + arch;
 
@@ -92,13 +92,13 @@ void OptionsDialog::updateCPUComboBox()
     ui->cpuComboBox->lineEdit()->setText(currentText);
 }
 
-QString OptionsDialog::getCurrentSelectedArch()
+QString OptionsDialog::getSelectedArch()
 {
     QVariant archValue = ui->archComboBox->currentData();
     return archValue.isValid() ? archValue.toString() : nullptr;
 }
 
-QString OptionsDialog::getCurrentSelectedCPU()
+QString OptionsDialog::getSelectedCPU()
 {
     QString cpu = ui->cpuComboBox->currentText();
     if (cpu.isNull() || cpu.isEmpty())
@@ -106,7 +106,7 @@ QString OptionsDialog::getCurrentSelectedCPU()
     return cpu;
 }
 
-int OptionsDialog::getCurrentSelectedBits()
+int OptionsDialog::getSelectedBits()
 {
     QString sel_bits = ui->bitsComboBox->currentText();
     if (sel_bits != "Auto")
@@ -117,7 +117,7 @@ int OptionsDialog::getCurrentSelectedBits()
     return 0;
 }
 
-QString OptionsDialog::getCurrentSelectedOS()
+QString OptionsDialog::getSelectedOS()
 {
     QVariant os = ui->kernelComboBox->currentData();
     return os.isValid() ? os.toString() : nullptr;
@@ -160,7 +160,7 @@ void OptionsDialog::setupAndStartAnalysis(int level, QList<QString> advanced)
     // Advanced Options
     //
 
-    main->core->setCPU(getCurrentSelectedArch(), getCurrentSelectedCPU(), getCurrentSelectedBits());
+    main->core->setCPU(getSelectedArch(), getSelectedCPU(), getSelectedBits());
 
     bool rw = false;
     bool load_bininfo = ui->binCheckBox->isChecked();
@@ -192,7 +192,7 @@ void OptionsDialog::setupAndStartAnalysis(int level, QList<QString> advanced)
     ui->statusLabel->setText(tr("Analysis in progress"));
 
 
-    QString os = getCurrentSelectedOS();
+    QString os = getSelectedOS();
     if (!os.isNull())
     {
         main->core->cmd("e asm.os=" + os);

--- a/src/optionsdialog.h
+++ b/src/optionsdialog.h
@@ -48,10 +48,10 @@ private:
     QString analysisDescription(int level);
 
     void updateCPUComboBox();
-    QString getCurrentSelectedArch();
-    QString getCurrentSelectedCPU();
-    int getCurrentSelectedBits();
-    QString getCurrentSelectedOS();
+    QString getSelectedArch();
+    QString getSelectedCPU();
+    int getSelectedBits();
+    QString getSelectedOS();
 };
 
 #endif // OPTIONSDIALOG_H

--- a/src/optionsdialog.h
+++ b/src/optionsdialog.h
@@ -33,6 +33,9 @@ private slots:
     void on_AdvOptButton_clicked();
     void on_analCheckBox_clicked(bool checked);
     void on_archComboBox_currentIndexChanged(int index);
+    void on_pdbSelectButton_clicked();
+
+    void updatePDBLayout();
 
     void anal_finished();
 

--- a/src/optionsdialog.h
+++ b/src/optionsdialog.h
@@ -27,18 +27,14 @@ public:
 
 private slots:
     void on_closeButton_clicked();
-
     void on_okButton_clicked();
-
     void on_cancelButton_clicked();
+    void on_analSlider_valueChanged(int value);
+    void on_AdvOptButton_clicked();
+    void on_analCheckBox_clicked(bool checked);
+    void on_archComboBox_currentIndexChanged(int index);
 
     void anal_finished();
-
-    void on_analSlider_valueChanged(int value);
-
-    void on_AdvOptButton_clicked();
-
-    void on_analCheckBox_clicked(bool checked);
 
 private:
     Ui::OptionsDialog *ui;
@@ -47,6 +43,12 @@ private:
     int defaultAnalLevel;
 
     QString analysisDescription(int level);
+
+    void updateCPUComboBox();
+    QString getCurrentSelectedArch();
+    QString getCurrentSelectedCPU();
+    int getCurrentSelectedBits();
+    QString getCurrentSelectedOS();
 };
 
 #endif // OPTIONSDIALOG_H

--- a/src/optionsdialog.ui
+++ b/src/optionsdialog.ui
@@ -922,6 +922,48 @@ color: rgb(0, 0, 0);</string>
                  </property>
                 </widget>
                </item>
+               <item row="3" column="0">
+                <widget class="QCheckBox" name="pdbCheckBox">
+                 <property name="text">
+                  <string>Load PDB</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="1">
+                <widget class="QWidget" name="pdbWidget" native="true">
+                 <property name="enabled">
+                  <bool>true</bool>
+                 </property>
+                 <layout class="QHBoxLayout" name="pdbLayout">
+                  <property name="leftMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>0</number>
+                  </property>
+                  <item>
+                   <widget class="QLineEdit" name="pdbLineEdit">
+                    <property name="placeholderText">
+                     <string>pdb file</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QPushButton" name="pdbSelectButton">
+                    <property name="text">
+                     <string>Select</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
               </layout>
              </item>
             </layout>

--- a/src/optionsdialog.ui
+++ b/src/optionsdialog.ui
@@ -26,7 +26,7 @@
    <string>Load Options</string>
   </property>
   <property name="windowIcon">
-   <iconset resource="resources.qrc">
+   <iconset>
     <normaloff>:/img/logo-small.png</normaloff>:/img/logo-small.png</iconset>
   </property>
   <property name="autoFillBackground">
@@ -94,7 +94,7 @@
           <string/>
          </property>
          <property name="pixmap">
-          <pixmap resource="resources.qrc">:/img/logo-small.png</pixmap>
+          <pixmap>:/img/logo-small.png</pixmap>
          </property>
          <property name="alignment">
           <set>Qt::AlignCenter</set>
@@ -602,22 +602,7 @@ color: rgb(0, 0, 0);</string>
           </item>
           <item>
            <widget class="QFrame" name="hideFrame">
-            <layout class="QVBoxLayout" name="hideLayout">
-             <property name="spacing">
-              <number>10</number>
-             </property>
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
+            <layout class="QVBoxLayout" name="verticalLayout_8">
              <item>
               <widget class="QLabel" name="label_2">
                <property name="sizePolicy">
@@ -646,7 +631,7 @@ color: rgb(0, 0, 0);</string>
              <item>
               <layout class="QHBoxLayout" name="horizontalLayout_2">
                <item>
-                <widget class="QLabel" name="processorLabel">
+                <widget class="QLabel" name="archLabel">
                  <property name="sizePolicy">
                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                    <horstretch>0</horstretch>
@@ -659,7 +644,7 @@ color: rgb(0, 0, 0);</string>
                 </widget>
                </item>
                <item>
-                <widget class="QComboBox" name="processorComboBox">
+                <widget class="QComboBox" name="archComboBox">
                  <property name="currentText">
                   <string notr="true">Auto</string>
                  </property>
@@ -671,7 +656,38 @@ color: rgb(0, 0, 0);</string>
                 </widget>
                </item>
                <item>
-                <widget class="QLabel" name="bitLabel">
+                <widget class="QLabel" name="cpuLabel">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>CPU:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QComboBox" name="cpuComboBox">
+                 <property name="minimumSize">
+                  <size>
+                   <width>70</width>
+                   <height>0</height>
+                  </size>
+                 </property>
+                 <property name="editable">
+                  <bool>true</bool>
+                 </property>
+                 <item>
+                  <property name="text">
+                   <string/>
+                  </property>
+                 </item>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLabel" name="bitsLabel">
                  <property name="sizePolicy">
                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                    <horstretch>0</horstretch>
@@ -743,26 +759,6 @@ color: rgb(0, 0, 0);</string>
                  <item>
                   <property name="text">
                    <string>Auto</string>
-                  </property>
-                 </item>
-                 <item>
-                  <property name="text">
-                   <string>Linux</string>
-                  </property>
-                 </item>
-                 <item>
-                  <property name="text">
-                   <string>BSD</string>
-                  </property>
-                 </item>
-                 <item>
-                  <property name="text">
-                   <string>OS X</string>
-                  </property>
-                 </item>
-                 <item>
-                  <property name="text">
-                   <string>Windows</string>
                   </property>
                  </item>
                 </widget>

--- a/src/widgets/consolewidget.cpp
+++ b/src/widgets/consolewidget.cpp
@@ -183,7 +183,7 @@ void ConsoleWidget::on_inputLineEdit_returnPressed()
     QString input = ui->inputLineEdit->text();
     if (!input.isEmpty() && core != nullptr)
     {
-        if (!isForbidden(input))
+        if (true || !isForbidden(input))
         {
             ui->outputTextEdit->appendPlainText(this->core->cmd(input));
             scrollOutputToEnd();

--- a/src/widgets/memorywidget.cpp
+++ b/src/widgets/memorywidget.cpp
@@ -469,7 +469,7 @@ void MemoryWidget::replaceTextDisasm(QString txt)
 bool MemoryWidget::loadMoreDisassembly()
 {
     /*
-z         * Add more disasm as the user scrolls
+    z         * Add more disasm as the user scrolls
          * Not working properly when scrolling upwards
          * r2 doesn't handle properly 'pd-' for archs with variable instruction size
          */
@@ -2005,11 +2005,15 @@ void MemoryWidget::updateViews(RVA offset)
     }
 }
 
-void MemoryWidget::showOffsets(bool show) {
-    if (show) {
+void MemoryWidget::showOffsets(bool show)
+{
+    if (show)
+    {
         this->hexOffsetText->show();
         main->core->config("asm.offset", 1);
-    } else {
+    }
+    else
+    {
         this->hexOffsetText->hide();
         main->core->config("asm.offset", 0);
     }


### PR DESCRIPTION
- Add an editable combo box to OptionsDialog for asm.cpu. Proposed values change dynamically when selecting a value for asm.arch. Fixes #2
- Add tooltips to some things in OptionsDialog displaying info from `e? ...`
- Possibility to select a PDB file (untested, I don't have any binary with a PDB file atm). Fixes #3 
- Fix Kernel (asm.os) option. It was not implemented yet.