### PR TITLE
Fix pessimizing move

### DIFF
--- a/src/widgets/DisassemblerGraphView.h
+++ b/src/widgets/DisassemblerGraphView.h
@@ -128,7 +128,7 @@ public:
                     result += t.text;
                 }
             }
-            return std::move(result);
+            return result;
         }
     };
 


### PR DESCRIPTION
moving a return value generally is unnecessary, as it prevents return value optimization.

The standard defines, that (named) return value optimization, i.e. copy elision
is only possible when returning a value from a non-volatile automatic object
or when it's a temporary that has not been bound to a reference.
(N)RVO is not possible when wrapping it with std::move, because the compiler
is not allowed to do copy elision from arbitrary function calls.

I think this was the intended purpose of this code. Also, it is cleaner.