### PR TITLE
Improve codebase

### DIFF
--- a/src/cutter.cpp
+++ b/src/cutter.cpp
@@ -211,8 +211,8 @@ QJsonDocument CutterCore::cmdj(const QString &str)
 
 bool CutterCore::loadFile(QString path, uint64_t loadaddr, uint64_t mapaddr, bool rw, int va, int idx, bool loadbin, const QString &forceBinPlugin)
 {
-    CUTTERNOTUSED(loadaddr);
-    CUTTERNOTUSED(idx);
+    Q_UNUSED(loadaddr);
+    Q_UNUSED(idx);
 
     CORE_LOCK();
     RCoreFile *f;
@@ -541,7 +541,7 @@ QString CutterCore::getConfig(const QString &k)
 
 void CutterCore::setOptions(QString key)
 {
-    CUTTERNOTUSED(key);
+    Q_UNUSED(key);
 
     // va
     // lowercase

--- a/src/cutter.h
+++ b/src/cutter.h
@@ -44,8 +44,6 @@ public:
     RCore *operator->() const;
 };
 
-#define CUTTERNOTUSED(x) do { (void)(x); } while ( 0 );
-
 typedef ut64 RVA;
 
 #define RVA_INVALID UT64_MAX

--- a/src/dialogs/renamedialog.cpp
+++ b/src/dialogs/renamedialog.cpp
@@ -30,8 +30,7 @@ void RenameDialog::setFunctionName(QString fcnName)
     ui->nameEdit->setText(fcnName);
 }
 
-QString RenameDialog::getFunctionName()
+QString RenameDialog::getFunctionName() const
 {
-    QString ret = ui->nameEdit->text();
-    return ret;
+    return ui->nameEdit->text();
 }

--- a/src/dialogs/renamedialog.h
+++ b/src/dialogs/renamedialog.h
@@ -17,7 +17,7 @@ public:
     ~RenameDialog();
 
     void setFunctionName(QString fcnName);
-    QString getFunctionName();
+    QString getFunctionName() const;
 
 private slots:
     void on_buttonBox_accepted();

--- a/src/dialogs/xrefsdialog.cpp
+++ b/src/dialogs/xrefsdialog.cpp
@@ -7,14 +7,13 @@
 
 XrefsDialog::XrefsDialog(MainWindow *main, QWidget *parent) :
     QDialog(parent),
-    ui(new Ui::XrefsDialog)
+    addr(0),
+    func_name(QString::null),
+    ui(new Ui::XrefsDialog),
+    main(main)
 {
-    addr = 0;
-    func_name = QString::null;
-
     ui->setupUi(this);
     setWindowFlags(windowFlags() & (~Qt::WindowContextHelpButtonHint));
-    this->main = main;
 
     // Increase asm text edit margin
     QTextDocument *asm_docu = ui->previewTextEdit->document();
@@ -80,7 +79,7 @@ void XrefsDialog::fillRefs(QList<XrefDescription> refs, QList<XrefDescription> x
 
 void XrefsDialog::on_fromTreeWidget_itemDoubleClicked(QTreeWidgetItem *item, int column)
 {
-    CUTTERNOTUSED(column);
+    Q_UNUSED(column);
 
     XrefDescription xref = item->data(0, Qt::UserRole).value<XrefDescription>();
     RAnalFunction *fcn = this->main->core->functionAt(xref.to);
@@ -91,7 +90,7 @@ void XrefsDialog::on_fromTreeWidget_itemDoubleClicked(QTreeWidgetItem *item, int
 
 void XrefsDialog::on_toTreeWidget_itemDoubleClicked(QTreeWidgetItem *item, int column)
 {
-    CUTTERNOTUSED(column);
+    Q_UNUSED(column);
 
     XrefDescription xref = item->data(0, Qt::UserRole).value<XrefDescription>();
     RAnalFunction *fcn = this->main->core->functionAt(xref.from);
@@ -100,7 +99,7 @@ void XrefsDialog::on_toTreeWidget_itemDoubleClicked(QTreeWidgetItem *item, int c
     this->close();
 }
 
-QString XrefsDialog::normalizeAddr(QString addr)
+QString XrefsDialog::normalizeAddr(const QString& addr) const
 {
     QString base = addr.split("0x")[1].trimmed();
     int len = base.length();

--- a/src/dialogs/xrefsdialog.h
+++ b/src/dialogs/xrefsdialog.h
@@ -29,7 +29,7 @@ private slots:
 
     void on_toTreeWidget_itemDoubleClicked(QTreeWidgetItem *item, int column);
 
-    QString normalizeAddr(QString addr);
+    QString normalizeAddr(const QString& addr) const;
 
     void highlightCurrentLine();
     void on_fromTreeWidget_itemSelectionChanged();

--- a/src/newfiledialog.cpp
+++ b/src/newfiledialog.cpp
@@ -10,9 +10,9 @@
 
 const int NewFileDialog::MaxRecentFiles;
 
-static QColor getColorFor(QString str, int pos)
+static QColor getColorFor(const QString& str, int pos)
 {
-    CUTTERNOTUSED(str);
+    Q_UNUSED(str);
 
     QList<QColor> Colors;
     Colors << QColor(29, 188, 156); // Turquoise
@@ -26,7 +26,7 @@ static QColor getColorFor(QString str, int pos)
 
 }
 
-static QIcon getIconFor(QString str, int pos)
+static QIcon getIconFor(const QString& str, int pos)
 {
     // Add to the icon list
     int w = 64;

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -11,17 +11,17 @@
 
 DisassemblerGraphView::DisassemblerGraphView(QWidget *parent, CutterCore *core)
     : QAbstractScrollArea(parent),
-      mFontMetrics(nullptr),
       //currentGraph(duint(0)),
       //disasm(ConfigUint("Disassembler", "MaxModuleSize")),
-      mCip(0),
-      mGoto(nullptr),
+      mCore(core),
+      mFontMetrics(nullptr),
       syncOrigin(false),
+      mCip(0),
       forceCenter(false),
-      layoutType(LayoutType::Medium),
       mHistoryLock(false),
-      mXrefDlg(nullptr),
-      mCore(core)
+      layoutType(LayoutType::Medium),
+      mGoto(nullptr),
+      mXrefDlg(nullptr)
 {
     this->status = "Loading...";
 
@@ -533,6 +533,8 @@ duint DisassemblerGraphView::getInstrForMouseEvent(QMouseEvent* event)
 
 bool DisassemblerGraphView::getTokenForMouseEvent(QMouseEvent* event, Token & tokenOut)
 {
+  Q_UNUSED(event);
+  Q_UNUSED(tokenOut);
     /* TODO
     //Convert coordinates to system used in blocks
     int xofs = this->horizontalScrollBar()->value();
@@ -715,6 +717,7 @@ void DisassemblerGraphView::mouseReleaseEvent(QMouseEvent* event)
 
 void DisassemblerGraphView::mouseDoubleClickEvent(QMouseEvent* event)
 {
+  Q_UNUSED(event);
     if(drawOverview)
     {
         toggleOverviewSlot();
@@ -1717,6 +1720,7 @@ void DisassemblerGraphView::loadCurrentGraph()
 
 void DisassemblerGraphView::graphAtSlot(duint addr)
 {
+  Q_UNUSED(addr);
     //Bridge::getBridge()->setResult(this->navigate(addr) ? this->currentGraph.entryPoint : 0);
 }
 
@@ -1727,6 +1731,8 @@ void DisassemblerGraphView::updateGraphSlot()
 
 void DisassemblerGraphView::addReferenceAction(QMenu* menu, duint addr)
 {
+  Q_UNUSED(menu);
+  Q_UNUSED(addr);
     /*QAction* action = new QAction(menu);
     action->setData(ToPtrString(addr));
     action->setText(getSymbolicName(addr));
@@ -1837,6 +1843,7 @@ void DisassemblerGraphView::setupContextMenu()
 
 void DisassemblerGraphView::keyPressEvent(QKeyEvent* event)
 {
+  Q_UNUSED(event);
     /*
     if(event->modifiers() != 0)
         return;

--- a/src/widgets/codegraphic.cpp
+++ b/src/widgets/codegraphic.cpp
@@ -12,9 +12,11 @@
 #include <QJsonParseError>
 
 GraphicsBar::GraphicsBar(MainWindow *main, QWidget *parent) :
-    QToolBar(main)
+    QToolBar(main),
+    codeGraphic(new QGraphicsView),
+    main(main)
 {
-    CUTTERNOTUSED(parent);
+    Q_UNUSED(parent);
 
     setObjectName("codeGraphics");
     setWindowTitle(tr("Code bar"));
@@ -24,9 +26,6 @@ GraphicsBar::GraphicsBar(MainWindow *main, QWidget *parent) :
     // and the result is wrong. Something to do with overwriting the style sheet :/
     //setStyleSheet("QToolBar { border: 0px; border-bottom: 0px; border-top: 0px; border-width: 0px;}");
 
-    this->codeGraphic = new QGraphicsView();
-    // Radare core found in:
-    this->main = main;
     this->codeGraphic->setAlignment(Qt::AlignLeft);
     this->codeGraphic->setMinimumHeight(20);
     this->codeGraphic->setMaximumHeight(20);
@@ -44,7 +43,7 @@ GraphicsBar::GraphicsBar(MainWindow *main, QWidget *parent) :
 
 void GraphicsBar::paintEvent(QPaintEvent *event)
 {
-    CUTTERNOTUSED(event);
+    Q_UNUSED(event);
 
     QPainter painter(this);
     this->fillData();

--- a/src/widgets/commentswidget.cpp
+++ b/src/widgets/commentswidget.cpp
@@ -49,7 +49,7 @@ void CommentsWidget::refresh()
 
 void CommentsWidget::on_commentsTreeWidget_itemDoubleClicked(QTreeWidgetItem *item, int column)
 {
-    CUTTERNOTUSED(column);
+    Q_UNUSED(column);
 
     // Get offset and name of item double clicked
     CommentDescription comment = item->data(0, Qt::UserRole).value<CommentDescription>();

--- a/src/widgets/dashboard.cpp
+++ b/src/widgets/dashboard.cpp
@@ -14,12 +14,10 @@
 
 Dashboard::Dashboard(MainWindow *main, QWidget *parent) :
     DockWidget(parent),
-    ui(new Ui::Dashboard)
+    ui(new Ui::Dashboard),
+    main(main)
 {
     ui->setupUi(this);
-
-    // Radare core found in:
-    this->main = main;
 
     //this->updateContents();
 }

--- a/src/widgets/entrypointwidget.cpp
+++ b/src/widgets/entrypointwidget.cpp
@@ -14,12 +14,10 @@
 
 EntrypointWidget::EntrypointWidget(MainWindow *main, QWidget *parent) :
     DockWidget(parent),
-    ui(new Ui::EntrypointWidget)
+    ui(new Ui::EntrypointWidget),
+    main(main)
 {
     ui->setupUi(this);
-
-    // Radare core found in:
-    this->main = main;
 
     // Delegate
     //CMyDelegate* delegate = new CMyDelegate(ui->importsTreeWidget);

--- a/src/widgets/flagswidget.cpp
+++ b/src/widgets/flagswidget.cpp
@@ -165,7 +165,7 @@ void FlagsWidget::on_flagsTreeView_doubleClicked(const QModelIndex &index)
 
 void FlagsWidget::on_flagspaceCombo_currentTextChanged(const QString &arg1)
 {
-    CUTTERNOTUSED(arg1);
+    Q_UNUSED(arg1);
 
     refreshFlags();
 }

--- a/src/widgets/notepad.cpp
+++ b/src/widgets/notepad.cpp
@@ -225,7 +225,7 @@ void Notepad::on_searchEdit_returnPressed()
 
 void Notepad::on_searchEdit_textEdited(const QString &arg1)
 {
-    CUTTERNOTUSED(arg1);
+    Q_UNUSED(arg1);
 
     QString searchString = ui->searchEdit->text();
     QTextDocument *document = ui->notepadTextEdit->document();
@@ -264,7 +264,7 @@ void Notepad::on_searchEdit_textEdited(const QString &arg1)
 
 void Notepad::on_searchEdit_textChanged(const QString &arg1)
 {
-    CUTTERNOTUSED(arg1);
+    Q_UNUSED(arg1);
 
     QString searchString = ui->searchEdit->text();
     QTextDocument *document = ui->notepadTextEdit->document();

--- a/src/widgets/pieview.cpp
+++ b/src/widgets/pieview.cpp
@@ -486,7 +486,7 @@ void PieView::scrollTo(const QModelIndex &index, ScrollHint)
 
 void PieView::setSelection(const QRect &rect, QItemSelectionModel::SelectionFlags command)
 {
-    CUTTERNOTUSED(command);
+    Q_UNUSED(command);
 
     // Use content widget coordinates because we will use the itemRegion()
     // function to check for intersections.
@@ -600,7 +600,7 @@ QRegion PieView::visualRegionForSelection(const QItemSelection &selection) const
 }
 
 /*Function to find minimum of x and y*/
-int PieView::getMin(int x, int y)
+int PieView::getMin(int x, int y) const
 {
     return y ^ ((x ^ y) & -(x < y));
 }

--- a/src/widgets/pieview.h
+++ b/src/widgets/pieview.h
@@ -92,7 +92,7 @@ private:
     QRegion itemRegion(const QModelIndex &index) const;
     int rows(const QModelIndex &index = QModelIndex()) const;
     void updateGeometries() override;
-    int getMin(int x, int y);
+    int getMin(int x, int y) const;
 
     int margin;
     int totalSize;

--- a/src/widgets/relocswidget.cpp
+++ b/src/widgets/relocswidget.cpp
@@ -36,7 +36,7 @@ void RelocsWidget::refresh()
 
 void RelocsWidget::on_relocsTreeWidget_itemDoubleClicked(QTreeWidgetItem *item, int column)
 {
-    CUTTERNOTUSED(column);
+    Q_UNUSED(column);
 
     // Get offset and name of item double clicked
     RelocDescription reloc = item->data(0, Qt::UserRole).value<RelocDescription>();

--- a/src/widgets/sectionswidget.cpp
+++ b/src/widgets/sectionswidget.cpp
@@ -11,7 +11,7 @@ SectionsWidget::SectionsWidget(MainWindow *main, QWidget *parent) :
     QSplitter(main),
     main(main)
 {
-    CUTTERNOTUSED(parent);
+    Q_UNUSED(parent);
 
     setupViews();
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);

--- a/src/widgets/stringswidget.cpp
+++ b/src/widgets/stringswidget.cpp
@@ -36,7 +36,7 @@ void StringsWidget::refresh()
 
 void StringsWidget::on_stringsTreeWidget_itemDoubleClicked(QTreeWidgetItem *item, int column)
 {
-    CUTTERNOTUSED(column);
+    Q_UNUSED(column);
 
     // Get offset and name of item double clicked
     // TODO: use this info to change disasm contents

--- a/src/widgets/symbolswidget.cpp
+++ b/src/widgets/symbolswidget.cpp
@@ -36,7 +36,7 @@ void SymbolsWidget::refresh()
 
 void SymbolsWidget::on_symbolsTreeWidget_itemDoubleClicked(QTreeWidgetItem *item, int column)
 {
-    CUTTERNOTUSED(column);
+    Q_UNUSED(column);
 
     // Get offset and name of item double clicked
     SymbolDescription symbol = item->data(0, Qt::UserRole).value<SymbolDescription>();


### PR DESCRIPTION
* `CUTTERNOTUSED` was using multiline macros wrong, and thus was replaced by `Q_UNUSED`
* `const` where possible
* `Q_UNUSED` where necessary
* Constructor initializer list where possible 

I haven't looked through all files yet, but this is a start.