### PR TITLE
Fix CMake build again

### DIFF
--- a/src/analthread.cpp
+++ b/src/analthread.cpp
@@ -3,7 +3,6 @@
 #include "analthread.h"
 #include "MainWindow.h"
 #include "Settings.h"
-#include "ui_OptionsDialog.h"
 #include "dialogs/OptionsDialog.h"
 
 AnalThread::AnalThread(OptionsDialog *parent) :

--- a/src/dialogs/OptionsDialog.h
+++ b/src/dialogs/OptionsDialog.h
@@ -5,13 +5,9 @@
 #include <QStringList>
 #include "cutter.h"
 #include "analthread.h"
+#include "ui_OptionsDialog.h"
 
 class MainWindow;
-
-namespace Ui
-{
-    class OptionsDialog;
-}
 
 class OptionsDialog : public QDialog
 {


### PR DESCRIPTION
Qt with CMake doesn't seem as robust as qmake is.
It didn't work to include ui_* files from a different directory.