### PR TITLE
Remove cutter win32

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,15 +19,9 @@ environment:
   NINJA_URL: https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-win.zip
   QTDIR: 'C:\Qt\5.9.1\msvc2015_64'
 
-install:
-  - cmd: git submodule init && git submodule update
-  - cmd: if defined BDIR ( %PYTHON%\python.exe -m pip install meson && COPY %PYTHON%\Scripts\meson.py radare2\meson.py )
-  - cmd: if defined NINJA_URL ( powershell -Command wget %NINJA_URL% -OutFile radare2\ninja.zip && unzip radare2\ninja.zip -d radare2\ )
-
 before_build:
-  # Build r2 and generate sln
-  - cmd: cd radare2 && set "PATH=%PYTHON%;%PATH%" && call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64 && meson.bat --release --shared && sys\meson_install.bat --with-static dist && cd ..
-  # Build cutter
+  - cmd: prepare_r2.bat
+  # Generate cutter (TODO: also generate x86 and switch to JOM)
   - cmd: set "PATH=%PATH%;%QTDIR%\bin;" && call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64  && cd src && qmake -config release -tp vc cutter.pro && cd ..
 
 # Build config
@@ -36,11 +30,7 @@ build:
 
 after_build:
   # Install r2
-  - cmd: move radare2\dist cutter
-  - cmd: cd cutter && dir
-  - cmd: for %%v in (*.dll) do echo %%v
-  - cmd: for %%v in (*.dll) do ren %%v lib%%v
-  - cmd: cd ..
+  - cmd: move dist64 cutter
   # Install cutter
   - cmd: windeployqt src\release\cutter.exe --dir cutter
   - cmd: move src\release\cutter.exe cutter\

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,7 +30,7 @@ build:
 
 after_build:
   # Install r2
-  - cmd: xcopy /Y dist64 cutter\dist64
+  - cmd: xcopy /Y dist64 cutter
   # Install cutter
   - cmd: windeployqt src\release\cutter.exe --dir cutter
   - cmd: move src\release\cutter.exe cutter\

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,7 +30,7 @@ build:
 
 after_build:
   # Install r2
-  - cmd: move dist64 cutter
+  - cmd: xcopy /Y dist64 cutter\dist64
   # Install cutter
   - cmd: windeployqt src\release\cutter.exe --dir cutter
   - cmd: move src\release\cutter.exe cutter\

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,35 +14,28 @@ branches:
 
 # Environment
 environment:
-  PYTHON: 'C:\\Python36-x64'
-  BDIR: build-cmake
-  NINJA_URL: https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-win.zip
+  PYTHON: 'C:\Python36-x64'
+  NINJA_URL: https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-win.zip
   QTDIR: 'C:\Qt\5.9.1\msvc2015_64'
+  QT32PATH: 'C:\Qt\5.9.1\msvc2015'
+  QT64PATH: 'C:\Qt\5.9.1\msvc2015_64'
+  VSVARSALLPATH: 'C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat'
 
 before_build:
   - cmd: prepare_r2.bat
-  # Generate cutter (TODO: also generate x86 and switch to JOM)
-  - cmd: set "PATH=%PATH%;%QTDIR%\bin;" && call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64  && cd src && qmake -config release -tp vc cutter.pro && cd ..
 
 # Build config
-build:
-  project: src\cutter.vcxproj
-
-after_build:
-  # Install r2
-  - cmd: move /Y .\dist64 cutter
-  # Install cutter
-  - cmd: windeployqt src\release\cutter.exe --dir cutter
-  - cmd: move src\release\cutter.exe cutter\
-  - cmd: set "PATH=C:\mingw\bin;C:\mingw\msys\1.0\bin;%PATH%" && zip -r cutter.zip cutter
+build_script:
+  - cmd: build.bat 32
+  - cmd: build.bat 64
 
 # Tests
 test: off
 
 # Artifacts
 artifacts:
-  - path: cutter.zip
-    name: Cutter
+  - path: build32\cutter32
+  - path: build64\cutter64
 
 #deploy:
 #  release: cutter-1.0-$(appveyor_build_version)

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,7 +30,7 @@ build:
 
 after_build:
   # Install r2
-  - cmd: xcopy /Y dist64 cutter
+  - cmd: move /Y .\dist64 cutter
   # Install cutter
   - cmd: windeployqt src\release\cutter.exe --dir cutter
   - cmd: move src\release\cutter.exe cutter\

--- a/.gitignore
+++ b/.gitignore
@@ -59,4 +59,15 @@ Win32/
 x64/
 *.dir/
 build*/
+release/
+debug/
 *.orig
+/src/*.vcxproj
+/src/*.vcxproj.filters
+/src/cutter_resource.rc
+
+#prepare_r2
+meson.py
+ninja.exe
+/dist32/
+/dist64/

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ meson.py
 ninja.exe
 /dist32/
 /dist64/
+*.pdb

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "radare2"]
 	path = radare2
 	url = https://github.com/radare/radare2
-[submodule "cutter_win32"]
-	path = cutter_win32
-	url = https://github.com/radareorg/cutter_win32

--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,43 @@
+@echo off
+
+echo Setting path
+if "%OLDPATH%"=="" set OLDPATH=%PATH%
+if "%QT32PATH%"=="" set QT32PATH=C:\Qt\5.9.1\msvc2015
+if "%QT64PATH%"=="" set QT64PATH=C:\Qt\5.9.1\msvc2015_64
+if "%VSVARSALLPATH%"=="" set VSVARSALLPATH=C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat
+
+if "%1"=="32" (
+    set "PATH=%QT32PATH%\bin;%PATH%"
+    call "%VSVARSALLPATH%" x86
+    set MSBUILDPLATFORM=Win32
+) else if "%1"=="64" (
+    set "PATH=%QT64PATH%\bin;%PATH%"
+    call "%VSVARSALLPATH%" x64
+    set MSBUILDPLATFORM=x64
+) else (
+    echo Usage: build.bat 32/64
+    goto restorepath
+)
+
+echo Preparing directory
+rmdir /s /q build%1
+mkdir build%1
+cd build%1
+
+echo Building cutter
+qmake ..\src\cutter.pro -config release -tp vc
+if not %ERRORLEVEL%==0 exit
+msbuild /m cutter.vcxproj /p:Configuration=Release;Platform=%MSBUILDPLATFORM%
+if not %ERRORLEVEL%==0 exit
+
+echo Deploying cutter
+mkdir cutter%1
+move release\cutter.exe cutter%1\cutter.exe
+xcopy /s ..\dist%1 cutter%1\
+windeployqt cutter%1\cutter.exe
+cd ..
+
+:restorepath
+echo Restoring path
+set PATH=%OLDPATH%
+set OLDPATH=

--- a/cutter_win32/include/r_addr_interval_msvc.h
+++ b/cutter_win32/include/r_addr_interval_msvc.h
@@ -1,0 +1,57 @@
+#ifndef R_ADDR_INTERVAL_H
+#define R_ADDR_INTERVAL_H
+
+#pragma message("r_addr_interval_msvc.h(4): warning C1337: hacky implementation of r_addr_interval, be wary!")
+//MSVC (C++) implementation of radare2/include/libr/r_util/r_addr_interval.h
+//DO NOT REMOVE THE WARNING BEFORE R2 IS FIXED!
+
+#include <r_types.h>
+
+// An interval in 64-bit address space which is aware of address space wraparound
+// Precondition: 0 <= size < 2**64 and addr + size <= 2**64
+typedef struct r_addr_interval_t {
+    // public:
+    ut64 addr;
+    ut64 size;
+} RAddrInterval;
+
+static inline ut64 r_itv_begin(RAddrInterval itv) {
+    return itv.addr;
+}
+
+// Returns the right endpoint address (not included)
+static inline ut64 r_itv_end(RAddrInterval itv) {
+    return itv.addr + itv.size;
+}
+
+// Returns true if itv contained addr
+static inline bool r_itv_contain(RAddrInterval itv, ut64 addr) {
+    ut64 end = itv.addr + itv.size;
+    return itv.addr <= addr && (!end || addr < end);
+}
+
+// Returns true if x is a subset of itv
+static inline bool r_itv_include(RAddrInterval itv, RAddrInterval x) {
+    ut64 end = itv.addr + itv.size;
+    return itv.addr <= x.addr && (!end || (x.addr + x.size && x.addr + x.size <= end));
+}
+
+// Returns true if itv and x overlap (implying they are non-empty)
+static inline bool r_itv_overlap(RAddrInterval itv, RAddrInterval x) {
+    ut64 end = itv.addr + itv.size, end1 = x.addr + x.size;
+    return (!end1 || itv.addr < end1) && (!end || x.addr < end);
+}
+
+static inline bool r_itv_overlap2(RAddrInterval itv, ut64 addr, ut64 size) {
+    return r_itv_overlap (itv, RAddrInterval{addr, size});
+}
+
+// Precondition: itv and x overlap
+// Returns the intersection of itv and x
+static inline RAddrInterval r_itv_intersect(RAddrInterval itv, RAddrInterval x) {
+    ut64 addr = R_MAX (itv.addr, x.addr),
+            end = R_MIN (itv.addr + itv.size - 1, x.addr + x.size - 1) + 1;
+    return RAddrInterval{addr, end - addr};
+}
+
+#endif  // R_ADDR_INTERVAL_H

--- a/cutter_win32/include/unistd.h
+++ b/cutter_win32/include/unistd.h
@@ -1,0 +1,10 @@
+//http://stackoverflow.com/a/826027/1806760
+
+#ifndef UNISTD_H
+#define UNISTD_H
+
+#include <stdlib.h>
+#include <io.h>
+#include <stdio.h>
+
+#endif

--- a/cutter_win32/radare2/include/.gitignore
+++ b/cutter_win32/radare2/include/.gitignore
@@ -1,0 +1,2 @@
+# Relevant files will be placed here after running prepare_r2.bat
+/libr/

--- a/cutter_win32/radare2/lib32/.gitignore
+++ b/cutter_win32/radare2/lib32/.gitignore
@@ -1,0 +1,2 @@
+# Relevant files will be placed here after running prepare_r2.bat
+/*.lib

--- a/cutter_win32/radare2/lib64/.gitignore
+++ b/cutter_win32/radare2/lib64/.gitignore
@@ -1,0 +1,2 @@
+# Relevant files will be placed here after running prepare_r2.bat
+/*.lib

--- a/prepare_r2.bat
+++ b/prepare_r2.bat
@@ -1,0 +1,45 @@
+@echo off
+
+if "%PYTHON%"=="" set PYTHON=C:\Python36-x64
+if "%NINJA_URL%"=="" set NINJA_URL=https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-win.zip
+
+set "PYTHONHOME=%PYTHON%"
+set "PATH=%PYTHON%;%PATH%"
+
+git submodule update --init
+
+echo Downloading meson and ninja
+python -m pip install meson && COPY %PYTHON%\Scripts\meson.py meson.py
+if defined NINJA_URL ( powershell -Command wget %NINJA_URL% -OutFile ninja.zip && unzip -o ninja.zip -d .\ && del ninja.zip )
+
+cd radare2
+
+echo Building radare2 (x86)
+git clean -xfd
+copy ..\ninja.exe .\
+copy ..\meson.py .\
+rmdir /s /q ..\dist32
+call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86
+call meson.bat --release --shared
+call sys\meson_install.bat --with-static ..\dist32
+copy /Y build\r_userconf.h ..\dist32\include
+copy /Y build\r_version.h ..\dist32\include
+
+echo Building radare2 (x64)
+git clean -xfd
+copy ..\ninja.exe .\
+copy ..\meson.py .\
+rmdir /s /q ..\dist64
+call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64
+call meson.bat --release --shared
+call sys\meson_install.bat --with-static ..\dist64
+
+cd ..
+
+echo Copying relevant files in cutter_win32
+xcopy /Y dist32\include\libr cutter_win32\radare2\include\libr
+copy /Y dist32\*.lib cutter_win32\radare2\lib32\
+copy /Y dist64\*.lib cutter_win32\radare2\lib64\
+
+del ninja.exe
+del meson.py

--- a/prepare_r2.bat
+++ b/prepare_r2.bat
@@ -24,6 +24,7 @@ call meson.bat --release --shared
 call sys\meson_install.bat --with-static ..\dist32
 copy /Y build\r_userconf.h ..\dist32\include
 copy /Y build\r_version.h ..\dist32\include
+copy /Y build\shlr\liblibr2sdb.a ..\dist32\r_sdb.lib
 
 echo Building radare2 (x64)
 git clean -xfd
@@ -33,6 +34,7 @@ rmdir /s /q ..\dist64
 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64
 call meson.bat --release --shared
 call sys\meson_install.bat --with-static ..\dist64
+copy /Y build\shlr\liblibr2sdb.a ..\dist64\r_sdb.lib
 
 cd ..
 

--- a/prepare_r2.bat
+++ b/prepare_r2.bat
@@ -1,7 +1,9 @@
 @echo off
 
+if "%OLDPATH%"=="" set OLDPATH=%PATH%
 if "%PYTHON%"=="" set PYTHON=C:\Python36-x64
 if "%NINJA_URL%"=="" set NINJA_URL=https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-win.zip
+if "%VSVARSALLPATH%"=="" set VSVARSALLPATH=C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat
 
 set "PYTHONHOME=%PYTHON%"
 set "PATH=%PYTHON%;%PATH%"
@@ -19,11 +21,12 @@ git clean -xfd
 copy ..\ninja.exe .\
 copy ..\meson.py .\
 rmdir /s /q ..\dist32
-call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86
+call "%VSVARSALLPATH%" x86
 call meson.bat --release --shared
+if not %ERRORLEVEL%==0 exit
 call sys\meson_install.bat --with-static ..\dist32
-copy /Y build\r_userconf.h ..\dist32\include
-copy /Y build\r_version.h ..\dist32\include
+copy /Y build\r_userconf.h ..\dist32\include\libr\
+copy /Y build\r_version.h ..\dist32\include\libr\
 copy /Y build\shlr\liblibr2sdb.a ..\dist32\r_sdb.lib
 
 echo Building radare2 (x64)
@@ -31,17 +34,21 @@ git clean -xfd
 copy ..\ninja.exe .\
 copy ..\meson.py .\
 rmdir /s /q ..\dist64
-call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64
+call "%VSVARSALLPATH%" x64
 call meson.bat --release --shared
+if not %ERRORLEVEL%==0 exit
 call sys\meson_install.bat --with-static ..\dist64
 copy /Y build\shlr\liblibr2sdb.a ..\dist64\r_sdb.lib
 
 cd ..
 
 echo Copying relevant files in cutter_win32
-xcopy /Y dist32\include\libr cutter_win32\radare2\include\libr
+xcopy /s /Y dist32\include\libr cutter_win32\radare2\include\libr\
 copy /Y dist32\*.lib cutter_win32\radare2\lib32\
 copy /Y dist64\*.lib cutter_win32\radare2\lib64\
 
 del ninja.exe
 del meson.py
+
+set PATH=%OLDPATH%
+set OLDPATH=

--- a/src/cutter.cpp
+++ b/src/cutter.cpp
@@ -65,12 +65,7 @@ CutterCore::CutterCore(QObject *parent) :
 
     default_bits = 0;
 
-#if WIN32
-    this->db = nullptr;
-#pragma message("cutter.cpp: warning C1337: sdb does not work on windows")
-#else
     this->db = sdb_new(NULL, NULL, 0);  // WTF NOES
-#endif //WIN32
 }
 
 
@@ -120,9 +115,6 @@ QList<QString> CutterCore::sdbList(QString path)
 {
     CORE_LOCK();
     QList<QString> list = QList<QString>();
-#if WIN32
-#pragma message("cutter.cpp: warning C1337: sdb does not work on windows")
-#else
     Sdb *root = sdb_ns_path(core_->sdb, path.toUtf8().constData(), 0);
     if (root)
     {
@@ -134,7 +126,6 @@ QList<QString> CutterCore::sdbList(QString path)
             list << nsi->name;
         }
     }
-#endif //WIN32
     return list;
 }
 
@@ -142,9 +133,6 @@ QList<QString> CutterCore::sdbListKeys(QString path)
 {
     CORE_LOCK();
     QList<QString> list = QList<QString>();
-#if WIN32
-#pragma message("cutter.cpp: warning C1337: sdb does not work on windows")
-#else
     Sdb *root = sdb_ns_path(core_->sdb, path.toUtf8().constData(), 0);
     if (root)
     {
@@ -157,16 +145,12 @@ QList<QString> CutterCore::sdbListKeys(QString path)
             list << nsi->key;
         }
     }
-#endif //WIN32
     return list;
 }
 
 QString CutterCore::sdbGet(QString path, QString key)
 {
     CORE_LOCK();
-#if WIN32
-#pragma message("cutter.cpp: warning C1337: sdb does not work on windows")
-#else
     Sdb *db = sdb_ns_path(core_->sdb, path.toUtf8().constData(), 0);
     if (db)
     {
@@ -174,21 +158,15 @@ QString CutterCore::sdbGet(QString path, QString key)
         if (val && *val)
             return val;
     }
-#endif //WIN32
     return QString("");
 }
 
 bool CutterCore::sdbSet(QString path, QString key, QString val)
 {
     CORE_LOCK();
-#if WIN32
-#pragma message("cutter.cpp: warning C1337: sdb does not work on windows")
-    return false;
-#else
     Sdb *db = sdb_ns_path(core_->sdb, path.toUtf8().constData(), 1);
     if (!db) return false;
     return sdb_set(db, key.toUtf8().constData(), val.toUtf8().constData(), 0);
-#endif //WIN32
 }
 
 CutterCore::~CutterCore()
@@ -442,13 +420,9 @@ bool CutterCore::tryFile(QString path, bool rw)
 
     //r_core_file_close (this->core, cf);
 
-#if WIN32
-#pragma message("cutter.cpp: warning C1337: sdb does not work on windows")
-#else
     sdb_bool_set(DB, "try.is_writable", is_writable, 0);
     sdb_set(DB, "try.filetype", "elf.i386", 0);
     sdb_set(DB, "try.filename", path.toUtf8().constData(), 0);
-#endif //WIN32
     return true;
 }
 

--- a/src/cutter.cpp
+++ b/src/cutter.cpp
@@ -65,7 +65,12 @@ CutterCore::CutterCore(QObject *parent) :
 
     default_bits = 0;
 
+#if WIN32
+    this->db = nullptr;
+#pragma message("cutter.cpp: warning C1337: sdb does not work on windows")
+#else
     this->db = sdb_new(NULL, NULL, 0);  // WTF NOES
+#endif //WIN32
 }
 
 
@@ -115,6 +120,9 @@ QList<QString> CutterCore::sdbList(QString path)
 {
     CORE_LOCK();
     QList<QString> list = QList<QString>();
+#if WIN32
+#pragma message("cutter.cpp: warning C1337: sdb does not work on windows")
+#else
     Sdb *root = sdb_ns_path(core_->sdb, path.toUtf8().constData(), 0);
     if (root)
     {
@@ -126,6 +134,7 @@ QList<QString> CutterCore::sdbList(QString path)
             list << nsi->name;
         }
     }
+#endif //WIN32
     return list;
 }
 
@@ -133,6 +142,9 @@ QList<QString> CutterCore::sdbListKeys(QString path)
 {
     CORE_LOCK();
     QList<QString> list = QList<QString>();
+#if WIN32
+#pragma message("cutter.cpp: warning C1337: sdb does not work on windows")
+#else
     Sdb *root = sdb_ns_path(core_->sdb, path.toUtf8().constData(), 0);
     if (root)
     {
@@ -145,12 +157,16 @@ QList<QString> CutterCore::sdbListKeys(QString path)
             list << nsi->key;
         }
     }
+#endif //WIN32
     return list;
 }
 
 QString CutterCore::sdbGet(QString path, QString key)
 {
     CORE_LOCK();
+#if WIN32
+#pragma message("cutter.cpp: warning C1337: sdb does not work on windows")
+#else
     Sdb *db = sdb_ns_path(core_->sdb, path.toUtf8().constData(), 0);
     if (db)
     {
@@ -158,15 +174,21 @@ QString CutterCore::sdbGet(QString path, QString key)
         if (val && *val)
             return val;
     }
+#endif //WIN32
     return QString("");
 }
 
 bool CutterCore::sdbSet(QString path, QString key, QString val)
 {
     CORE_LOCK();
+#if WIN32
+#pragma message("cutter.cpp: warning C1337: sdb does not work on windows")
+    return false;
+#else
     Sdb *db = sdb_ns_path(core_->sdb, path.toUtf8().constData(), 1);
     if (!db) return false;
     return sdb_set(db, key.toUtf8().constData(), val.toUtf8().constData(), 0);
+#endif //WIN32
 }
 
 CutterCore::~CutterCore()
@@ -420,9 +442,13 @@ bool CutterCore::tryFile(QString path, bool rw)
 
     //r_core_file_close (this->core, cf);
 
+#if WIN32
+#pragma message("cutter.cpp: warning C1337: sdb does not work on windows")
+#else
     sdb_bool_set(DB, "try.is_writable", is_writable, 0);
     sdb_set(DB, "try.filetype", "elf.i386", 0);
     sdb_set(DB, "try.filename", path.toUtf8().constData(), 0);
+#endif //WIN32
     return true;
 }
 

--- a/src/cutter.h
+++ b/src/cutter.h
@@ -1,6 +1,9 @@
 #ifndef CUTTER_H
 #define CUTTER_H
 
+// Workaround for compile errors on Windows
+#include <r_addr_interval_msvc.h>
+
 #include "r_core.h"
 
 // Workaround for compile errors on Windows

--- a/src/cutter.h
+++ b/src/cutter.h
@@ -1,19 +1,6 @@
 #ifndef CUTTER_H
 #define CUTTER_H
 
-#include <QMap>
-#include <QDebug>
-#include <QObject>
-#include <QStringList>
-#include <QMessageBox>
-#include <QJsonDocument>
-
-
-// Workaround for compile errors on Windows
-#ifdef _WIN32
-#include <r2hacks.h>
-#endif
-
 #include "r_core.h"
 
 // Workaround for compile errors on Windows
@@ -21,6 +8,13 @@
 #undef min
 #undef max
 #endif //_WIN32
+
+#include <QMap>
+#include <QDebug>
+#include <QObject>
+#include <QStringList>
+#include <QMessageBox>
+#include <QJsonDocument>
 
 #define HAVE_LATEST_LIBR2 false
 

--- a/src/cutter.h
+++ b/src/cutter.h
@@ -2,7 +2,9 @@
 #define CUTTER_H
 
 // Workaround for compile errors on Windows
+#ifdef _WIN32
 #include <r_addr_interval_msvc.h>
+#endif //_WIN32
 
 #include "r_core.h"
 

--- a/src/lib_radare2.pri
+++ b/src/lib_radare2.pri
@@ -32,7 +32,8 @@ win32 {
         -lr_socket \
         -lr_fs \
         -lr_magic \
-        -lr_crypto
+        -lr_crypto \
+        -lr_sdb
 } else {
     USE_PKGCONFIG = 1
     R2_USER_PKGCONFIG = $$(HOME)/bin/prefix/radare2/lib/pkgconfig

--- a/src/utils/Highlighter.cpp
+++ b/src/utils/Highlighter.cpp
@@ -1,7 +1,7 @@
-#include <QtGui>
-
 #include "Highlighter.h"
 #include "MainWindow.h"
+
+#include <QtGui>
 
 Highlighter::Highlighter(QTextDocument *parent) :
     QSyntaxHighlighter(parent)

--- a/src/utils/Highlighter.h
+++ b/src/utils/Highlighter.h
@@ -1,9 +1,9 @@
 #ifndef HIGHLIGHTER_H
 #define HIGHLIGHTER_H
 
-#include <QSyntaxHighlighter>
-
 #include "cutter.h"
+
+#include <QSyntaxHighlighter>
 #include <QHash>
 #include <QTextCharFormat>
 

--- a/src/widgets/DisassemblyWidget.h
+++ b/src/widgets/DisassemblyWidget.h
@@ -1,9 +1,9 @@
 #ifndef DISASSEMBLYVIEW_H
 #define DISASSEMBLYVIEW_H
 
+#include "cutter.h"
 #include <QDockWidget>
 #include <QTextEdit>
-#include "cutter.h"
 
 class DisassemblyWidget : public QDockWidget
 {

--- a/src/widgets/ExportsWidget.h
+++ b/src/widgets/ExportsWidget.h
@@ -1,10 +1,10 @@
 #ifndef EXPORTSWIDGET_H
 #define EXPORTSWIDGET_H
 
+#include "cutter.h"
 #include <QAbstractListModel>
 #include <QSortFilterProxyModel>
 #include <memory>
-#include "cutter.h"
 #include "DockWidget.h"
 
 class MainWindow;

--- a/src/widgets/PieView.cpp
+++ b/src/widgets/PieView.cpp
@@ -38,6 +38,7 @@
 **
 ****************************************************************************/
 
+#include "cutter.h"
 #include <math.h>
 #include <QtWidgets>
 #include <QDebug>
@@ -46,7 +47,6 @@
 #define M_PI 3.1415927
 #endif
 
-#include "cutter.h"
 #include "PieView.h"
 
 PieView::PieView(QWidget *parent)

--- a/src/widgets/PreviewWidget.h
+++ b/src/widgets/PreviewWidget.h
@@ -1,6 +1,7 @@
 #ifndef PREVIEWWIDGET_H
 #define PREVIEWWIDGET_H
 
+#include "cutter.h"
 #include <QDebug>
 #include <QTextEdit>
 #include <QDockWidget>
@@ -10,7 +11,6 @@
 #include <QPlainTextEdit>
 #include <QMouseEvent>
 #include <memory>
-#include "cutter.h"
 #include "utils/Highlighter.h"
 #include "utils/HexAsciiHighlighter.h"
 #include "utils/HexHighlighter.h"


### PR DESCRIPTION
To do:

- testing
- documentation
- make appveyor call `prepare_r2.bat` + use jom to compile `cutter.pro` instead of this shitty vcxproj generation
- radare2's `meson.bat` doesn't actually support XP (static libraries also need to be fixed)
- radare2's `meson.bat` doesn't actually support msbuild (it builds, but doesn't output anything in the destination folder)

Quick guide:

1. run `prepare_r2.bat` it will compile r2 and extract the relevant files in the `cutter_win32` directory (submodule was removed, but r2 doesn't like windows so it's required)
2. Open `cutter.pro` with Qt creator and compile it with msvc2015 qt 5.9 in release mode
3. Once compiled (quite magic, r2 is not suitable at all for dynamic linking), copy the contents of `dist32` in the `build-cutter-Qt-blahblah\release` so you have `cutter.exe` next to `radare.exe`
4. open cutter.exe and feel the hacks crumble to dust in your hands

There are tons of problems on windows (`share` folder not recognized whatsoever, sdb is fishy as fuck because it's statically compiled in multiple dlls, cutter crashes when restoring a previously-saved file, ui is bugged, fonts don't work, etc, etc).

PS `prepare_r2.bat` wasn't mean to be beautiful, but ninja/meson are kinda broken so git clean is required