### PR TITLE
Set objectName for Graph Widget

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -201,6 +201,7 @@ void MainWindow::initUI()
 
     // Add graph view as dockable
     graphDock = new QDockWidget(tr("Graph"), this);
+	graphDock->setObjectName("Graph");
     graphDock->setAllowedAreas(Qt::AllDockWidgetAreas);
     DisassemblerGraphView *gv = new DisassemblerGraphView(graphDock);
     graphDock->setWidget(gv);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -201,7 +201,7 @@ void MainWindow::initUI()
 
     // Add graph view as dockable
     graphDock = new QDockWidget(tr("Graph"), this);
-	graphDock->setObjectName("Graph");
+    graphDock->setObjectName("Graph");
     graphDock->setAllowedAreas(Qt::AllDockWidgetAreas);
     DisassemblerGraphView *gv = new DisassemblerGraphView(graphDock);
     graphDock->setWidget(gv);


### PR DESCRIPTION
Fixes `QMainWindow::saveState(): 'objectName' not set for QDockWidget 0x1e1e990 'Graph;` warning and makes remembering QDockWidget layout work with the graph widget.