### PR TITLE
DisassemblyWidget

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -491,7 +491,7 @@ void MainWindow::updateFrames()
     static bool first_time = true;
 
     //TODO Send signal rather than that
-    disassemblyDock->refreshDisasm();
+    disassemblyDock->refreshDisasm(core->getOffset());
 
     if (first_time)
     {

--- a/src/cutter.cpp
+++ b/src/cutter.cpp
@@ -401,10 +401,35 @@ RVA CutterCore::prevOpAddr(RVA startAddr, int count)
     RVA prev;
     if (!r_core_prevop_addr(core_, startAddr, count, &prev))
     {
-        printf("fail\n");
         prev = startAddr - count;
     }
     return prev;
+}
+
+RVA CutterCore::nextOpAddr(RVA startAddr, int count)
+{
+    CORE_LOCK();
+
+    QJsonArray array = Core()->cmdj("pdj " + QString::number(count) + "@" + QString::number(startAddr)).array();
+    if (array.isEmpty())
+    {
+        return startAddr + 1;
+    }
+
+    QJsonValue instValue = array.last();
+    if (!instValue.isObject())
+    {
+        return startAddr + 1;
+    }
+
+    bool ok;
+    RVA offset = instValue.toObject()["offset"].toVariant().toULongLong(&ok);
+    if (!ok)
+    {
+        return startAddr + 1;
+    }
+
+    return offset;
 }
 
 RVA CutterCore::getOffset()

--- a/src/cutter.cpp
+++ b/src/cutter.cpp
@@ -346,8 +346,8 @@ void CutterCore::setComment(RVA addr, QString cmt)
 
 void CutterCore::delComment(ut64 addr)
 {
-    CORE_LOCK();
-    r_meta_del(core_->anal, 'C', addr, 1, NULL);
+    cmd("CC- @ " + QString::number(addr));
+    emit commentsChanged();
 }
 
 QMap<QString, QList<QList<QString>>> CutterCore::getNestedComments()
@@ -393,6 +393,18 @@ void CutterCore::seekPrev()
 void CutterCore::seekNext()
 {
     cmd("s+");
+}
+
+RVA CutterCore::prevOpAddr(RVA startAddr, int count)
+{
+    CORE_LOCK();
+    RVA prev;
+    if (!r_core_prevop_addr(core_, startAddr, count, &prev))
+    {
+        printf("fail\n");
+        prev = startAddr - count;
+    }
+    return prev;
 }
 
 RVA CutterCore::getOffset()

--- a/src/cutter.cpp
+++ b/src/cutter.cpp
@@ -377,7 +377,7 @@ void CutterCore::seek(QString addr)
     // here, or refactor radare2 API.
     CORE_LOCK();
     cmd(QString("s %1").arg(addr));
-    emit seekChanged(core_->offset);
+    // cmd already does emit seekChanged(core_->offset);
 }
 
 void CutterCore::seek(ut64 offset)

--- a/src/cutter.h
+++ b/src/cutter.h
@@ -215,6 +215,8 @@ public:
     void seekNext();
     RVA getOffset();
 
+    RVA prevOpAddr(RVA startAddr, int count);
+
     // Graph - Disassembly view priority
     bool graphPriority = false;
     bool graphDisplay = false;

--- a/src/cutter.h
+++ b/src/cutter.h
@@ -216,6 +216,7 @@ public:
     RVA getOffset();
 
     RVA prevOpAddr(RVA startAddr, int count);
+    RVA nextOpAddr(RVA startAddr, int count);
 
     // Graph - Disassembly view priority
     bool graphPriority = false;

--- a/src/cutter.h
+++ b/src/cutter.h
@@ -216,7 +216,7 @@ public:
     RVA getOffset();
 
     // Graph - Disassembly view priority
-    bool graphPriority = true;
+    bool graphPriority = false;
     bool graphDisplay = false;
 
     ut64 math(const QString &expr);

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -72,6 +72,7 @@ DisassemblyWidget::DisassemblyWidget(QWidget *parent) :
 
     // Seek signal
     connect(CutterCore::getInstance(), SIGNAL(seekChanged(RVA)), this, SLOT(on_seekChanged(RVA)));
+    connect(CutterCore::getInstance(), SIGNAL(commentsChanged()), this, SLOT(refreshDisasm()));
     connect(Config(), SIGNAL(fontsUpdated()), this, SLOT(fontsUpdatedSlot()));
 }
 

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -167,25 +167,34 @@ void DisassemblyWidget::scrollInstructions(int count)
         return;
     }
 
-    QJsonArray array = Core()->cmdj("pdj " + QString::number(count) + "@" + QString::number(topOffset)).array();
-    if (array.isEmpty())
+    RVA offset;
+    if (count > 0)
     {
-        return;
+        QJsonArray array = Core()->cmdj("pdj " + QString::number(count) + "@" + QString::number(topOffset)).array();
+        if (array.isEmpty())
+        {
+            return;
+        }
+
+        QJsonValue instValue = (count < 0 ? array.first() : array.last());
+        if (!instValue.isObject())
+        {
+            return;
+        }
+
+        bool ok;
+        offset = instValue.toObject()["offset"].toVariant().toULongLong(&ok);
+        if (!ok)
+        {
+            return;
+        }
+    }
+    else
+    {
+        offset = Core()->prevOpAddr(topOffset, -count);
     }
 
-    QJsonValue instValue = (count < 0 ? array.first() : array.last());
-    if (!instValue.isObject())
-    {
-        return;
-    }
-
-    bool ok;
-    RVA offset = instValue.toObject()["offset"].toVariant().toULongLong(&ok);
-
-    if (ok)
-    {
-        refreshDisasm(offset);
-    }
+    refreshDisasm(offset);
 }
 
 

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -142,8 +142,6 @@ void DisassemblyWidget::refreshDisasm()
     mDisasTextEdit->clear();
     mDisasTextEdit->appendHtml(disas);
     mDisasTextEdit->verticalScrollBar()->setValue(0);
-
-    printf("size: %d, %d\n", minimumWidth(), minimumHeight());
 }
 
 

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -160,24 +160,7 @@ void DisassemblyWidget::scrollInstructions(int count)
     RVA offset;
     if (count > 0)
     {
-        QJsonArray array = Core()->cmdj("pdj " + QString::number(count) + "@" + QString::number(topOffset)).array();
-        if (array.isEmpty())
-        {
-            return;
-        }
-
-        QJsonValue instValue = (count < 0 ? array.first() : array.last());
-        if (!instValue.isObject())
-        {
-            return;
-        }
-
-        bool ok;
-        offset = instValue.toObject()["offset"].toVariant().toULongLong(&ok);
-        if (!ok)
-        {
-            return;
-        }
+        offset = Core()->nextOpAddr(topOffset, count);
     }
     else
     {

--- a/src/widgets/DisassemblyWidget.h
+++ b/src/widgets/DisassemblyWidget.h
@@ -21,7 +21,6 @@ public:
 public slots:
     void highlightCurrentLine();
     void showDisasContextMenu(const QPoint &pt);
-    void cursorPositionChanged();
     void on_seekChanged(RVA offset);
     void refreshDisasm(RVA offset = RVA_INVALID);
     void fontsUpdatedSlot();
@@ -30,6 +29,8 @@ public slots:
 private slots:
     void scrollInstructions(int count);
     void updateMaxLines();
+
+    void cursorPositionChanged();
 
 private:
     DisassemblyScrollArea *mDisasScrollArea;
@@ -42,10 +43,11 @@ private:
     QString readDisasm(RVA offset, bool backwards = false, bool skipFirstInstruction = false);
     QString readDisasm(const QString &cmd, bool stripLastNewline);
     RVA readCurrentDisassemblyOffset();
-    void highlightDisasms();
     bool eventFilter(QObject *obj, QEvent *event);
 
     void updateCursorPosition();
+
+    void connectCursorPositionChanged(bool disconnect);
 };
 
 class DisassemblyScrollArea : public QAbstractScrollArea

--- a/src/widgets/DisassemblyWidget.h
+++ b/src/widgets/DisassemblyWidget.h
@@ -29,7 +29,7 @@ public slots:
 private:
     QTextEdit *mDisasTextEdit;
 
-    QString readDisasm(RVA offset = RVA_INVALID, bool skipFirstInstruction = false);
+    QString readDisasm(RVA offset, bool backwards = false, bool skipFirstInstruction = false);
     RVA readCurrentDisassemblyOffset();
     bool loadMoreDisassembly();
     void highlightDisasms();

--- a/src/widgets/DisassemblyWidget.h
+++ b/src/widgets/DisassemblyWidget.h
@@ -29,7 +29,7 @@ public slots:
 private:
     QTextEdit *mDisasTextEdit;
 
-    QString readDisasm(RVA offset = RVA_INVALID);
+    QString readDisasm(RVA offset = RVA_INVALID, bool skipFirstInstruction = false);
     RVA readCurrentDisassemblyOffset();
     bool loadMoreDisassembly();
     void highlightDisasms();

--- a/src/widgets/DisassemblyWidget.h
+++ b/src/widgets/DisassemblyWidget.h
@@ -36,6 +36,7 @@ private:
     DisassemblyTextEdit *mDisasTextEdit;
 
     RVA topOffset;
+    RVA bottomOffset;
     int maxLines;
 
     QString readDisasm(RVA offset, bool backwards = false, bool skipFirstInstruction = false);
@@ -43,6 +44,8 @@ private:
     RVA readCurrentDisassemblyOffset();
     void highlightDisasms();
     bool eventFilter(QObject *obj, QEvent *event);
+
+    void updateCursorPosition();
 };
 
 class DisassemblyScrollArea : public QAbstractScrollArea

--- a/src/widgets/DisassemblyWidget.h
+++ b/src/widgets/DisassemblyWidget.h
@@ -1,10 +1,14 @@
-#ifndef DISASSEMBLYVIEW_H
-#define DISASSEMBLYVIEW_H
+#ifndef DISASSEMBLYWIDGET_H
+#define DISASSEMBLYWIDGET_H
 
 #include "cutter.h"
 #include <QDockWidget>
-#include <QTextEdit>
+#include <QPlainTextEdit>
 #include <QShortcut>
+
+
+class DisassemblyTextEdit;
+class DisassemblyScrollArea;
 
 class DisassemblyWidget : public QDockWidget
 {
@@ -14,11 +18,8 @@ public:
     explicit DisassemblyWidget(const QString &title, QWidget *parent = nullptr);
     QWidget* getTextWidget();
 
-signals:
-
 public slots:
     void highlightCurrentLine();
-    void disasmScrolled();
     void showDisasContextMenu(const QPoint &pt);
     void cursorPositionChanged();
     void on_seekChanged(RVA offset);
@@ -26,14 +27,47 @@ public slots:
     void fontsUpdatedSlot();
     void showXrefsDialog();
 
+private slots:
+    void scrollInstructions(int count);
+
 private:
-    QTextEdit *mDisasTextEdit;
+    DisassemblyScrollArea *mDisasScrollArea;
+    DisassemblyTextEdit *mDisasTextEdit;
 
     QString readDisasm(RVA offset, bool backwards = false, bool skipFirstInstruction = false);
+    QString readDisasm(const QString &cmd);
     RVA readCurrentDisassemblyOffset();
-    bool loadMoreDisassembly();
     void highlightDisasms();
     bool eventFilter(QObject *obj, QEvent *event);
 };
 
-#endif // DISASSEMBLYVIEW_H
+class DisassemblyScrollArea : public QAbstractScrollArea
+{
+    Q_OBJECT
+
+public:
+    explicit DisassemblyScrollArea(QWidget *parent = nullptr);
+
+signals:
+    void scrollLines(int lines);
+
+protected:
+    bool viewportEvent(QEvent *event) override;
+
+private:
+    void resetScrollBars();
+};
+
+
+class DisassemblyTextEdit: public QPlainTextEdit
+{
+    Q_OBJECT
+
+public:
+    explicit DisassemblyTextEdit(QWidget *parent = nullptr) : QPlainTextEdit(parent) {}
+
+protected:
+    bool viewportEvent(QEvent *event) override;
+};
+
+#endif // DISASSEMBLYWIDGET_H

--- a/src/widgets/DisassemblyWidget.h
+++ b/src/widgets/DisassemblyWidget.h
@@ -23,18 +23,20 @@ public slots:
     void showDisasContextMenu(const QPoint &pt);
     void cursorPositionChanged();
     void on_seekChanged(RVA offset);
-    void refreshDisasm();
+    void refreshDisasm(RVA offset = RVA_INVALID);
     void fontsUpdatedSlot();
     void showXrefsDialog();
 
 private slots:
     void scrollInstructions(int count);
+    void updateMaxLines();
 
 private:
     DisassemblyScrollArea *mDisasScrollArea;
     DisassemblyTextEdit *mDisasTextEdit;
 
     RVA topOffset;
+    int maxLines;
 
     QString readDisasm(RVA offset, bool backwards = false, bool skipFirstInstruction = false);
     QString readDisasm(const QString &cmd, bool stripLastNewline);
@@ -52,6 +54,7 @@ public:
 
 signals:
     void scrollLines(int lines);
+    void disassemblyResized();
 
 protected:
     bool viewportEvent(QEvent *event) override;

--- a/src/widgets/DisassemblyWidget.h
+++ b/src/widgets/DisassemblyWidget.h
@@ -40,7 +40,6 @@ private:
     RVA bottomOffset;
     int maxLines;
 
-    QString readDisasm(RVA offset, bool backwards = false, bool skipFirstInstruction = false);
     QString readDisasm(const QString &cmd, bool stripLastNewline);
     RVA readCurrentDisassemblyOffset();
     bool eventFilter(QObject *obj, QEvent *event);
@@ -74,10 +73,18 @@ class DisassemblyTextEdit: public QPlainTextEdit
     Q_OBJECT
 
 public:
-    explicit DisassemblyTextEdit(QWidget *parent = nullptr) : QPlainTextEdit(parent) {}
+    explicit DisassemblyTextEdit(QWidget *parent = nullptr)
+            : QPlainTextEdit(parent),
+              lockScroll(false) {}
+
+    void setLockScroll(bool lock)           { this->lockScroll = lock; }
 
 protected:
     bool viewportEvent(QEvent *event) override;
+    void scrollContentsBy(int dx, int dy) override;
+
+private:
+    bool lockScroll;
 };
 
 #endif // DISASSEMBLYWIDGET_H

--- a/src/widgets/DisassemblyWidget.h
+++ b/src/widgets/DisassemblyWidget.h
@@ -34,8 +34,10 @@ private:
     DisassemblyScrollArea *mDisasScrollArea;
     DisassemblyTextEdit *mDisasTextEdit;
 
+    RVA topOffset;
+
     QString readDisasm(RVA offset, bool backwards = false, bool skipFirstInstruction = false);
-    QString readDisasm(const QString &cmd);
+    QString readDisasm(const QString &cmd, bool stripLastNewline);
     RVA readCurrentDisassemblyOffset();
     void highlightDisasms();
     bool eventFilter(QObject *obj, QEvent *event);

--- a/src/widgets/HexdumpWidget.cpp
+++ b/src/widgets/HexdumpWidget.cpp
@@ -309,7 +309,7 @@ void HexdumpWidget::resizeHexdump()
 {
     this->hexOffsetText->setMinimumWidth(this->hexOffsetText->document()->size().width());
     this->hexHexText->setMinimumWidth(this->hexHexText->document()->size().width());
-    this->hexASCIIText->setMinimumWidth(this->hexASCIIText->document()->size().width());
+    //this->hexASCIIText->setMinimumWidth(this->hexASCIIText->document()->size().width());
 }
 
 void HexdumpWidget::hexScrolled()


### PR DESCRIPTION
Fixes #61

Works more like visual mode. Current cursor position is always synced with r2 seek. Scrolling works by finding next or previous instructions and refreshing the whole disassembly.

Contains a lot of hacks to get QPlainTextEdit to do what we want, but seems to work fine for now.