### PR TITLE
Dynamic Memory Widget Priority

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -211,6 +211,12 @@ void MainWindow::initUI()
             Core()->setMemoryWidgetPriority(CutterCore::MemoryWidgetType::Graph);
         }
     });
+    connect(Core(), &CutterCore::raisePrioritizedMemoryWidget, graphDock, [=](CutterCore::MemoryWidgetType type) {
+        if (type == CutterCore::MemoryWidgetType::Graph)
+        {
+            graphDock->raise();
+        }
+    });
     dockWidgets.push_back(graphDock);
 
     // Add Sections dock panel

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -215,6 +215,7 @@ void MainWindow::initUI()
         if (type == CutterCore::MemoryWidgetType::Graph)
         {
             graphDock->raise();
+            graphView->setFocus();
         }
     });
     dockWidgets.push_back(graphDock);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -828,6 +828,8 @@ void MainWindow::resetToDefaultLayout()
 
     restoreFunctionDock.restoreWidth(functionsDock->widget());
     restoreSidebarDock.restoreWidth(sidebarDock->widget());
+
+    Core()->setMemoryWidgetPriority(CutterCore::MemoryWidgetType::Disassembly);
 }
 
 void MainWindow::on_actionDefaut_triggered()

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -205,6 +205,12 @@ void MainWindow::initUI()
     graphDock->setAllowedAreas(Qt::AllDockWidgetAreas);
     graphView = new DisassemblerGraphView(graphDock);
     graphDock->setWidget(graphView);
+    connect(graphDock, &QDockWidget::visibilityChanged, graphDock, [](bool visibility) {
+        if (visibility)
+        {
+            Core()->setMemoryWidgetPriority(CutterCore::MemoryWidgetType::Graph);
+        }
+    });
     dockWidgets.push_back(graphDock);
 
     // Add Sections dock panel

--- a/src/cutter.cpp
+++ b/src/cutter.cpp
@@ -192,6 +192,7 @@ QString CutterCore::cmd(const QString &str)
     if (offset != core_->offset)
     {
         emit seekChanged(core_->offset);
+        triggerRaisePrioritizedMemoryWidget();
     }
     return o;
 }

--- a/src/cutter.h
+++ b/src/cutter.h
@@ -218,9 +218,10 @@ public:
     RVA prevOpAddr(RVA startAddr, int count);
     RVA nextOpAddr(RVA startAddr, int count);
 
-    // Graph - Disassembly view priority
-    bool graphPriority = false;
-    bool graphDisplay = false;
+    // Disassembly/Graph/Hexdump view priority
+    enum class MemoryWidgetType { Disassembly, Graph, Hexdump };
+    MemoryWidgetType getMemoryWidgetPriority() const            { return memoryWidgetPriority; }
+    void setMemoryWidgetPriority(MemoryWidgetType type)         { memoryWidgetPriority = type; }
 
     ut64 math(const QString &expr);
     QString itoa(ut64 num, int rdx = 16);
@@ -335,6 +336,8 @@ private:
     QString default_arch;
     QString default_cpu;
     int default_bits;
+
+    MemoryWidgetType memoryWidgetPriority;
 
     QString notes;
 

--- a/src/cutter.h
+++ b/src/cutter.h
@@ -222,6 +222,7 @@ public:
     enum class MemoryWidgetType { Disassembly, Graph, Hexdump };
     MemoryWidgetType getMemoryWidgetPriority() const            { return memoryWidgetPriority; }
     void setMemoryWidgetPriority(MemoryWidgetType type)         { memoryWidgetPriority = type; }
+    void triggerRaisePrioritizedMemoryWidget()                  { emit raisePrioritizedMemoryWidget(memoryWidgetPriority); }
 
     ut64 math(const QString &expr);
     QString itoa(ut64 num, int rdx = 16);
@@ -329,6 +330,8 @@ signals:
      * \param offset
      */
     void seekChanged(RVA offset);
+
+    void raisePrioritizedMemoryWidget(CutterCore::MemoryWidgetType type);
 
 public slots:
 

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -1645,11 +1645,15 @@ void DisassemblerGraphView::on_seekChanged(RVA addr)
 {
     Q_UNUSED(addr);
     loadCurrentGraph();
-    Function f = this->analysis.functions[this->function];
-    Core()->graphDisplay = f.blocks.size() > 0;
-    if (Core()->graphDisplay && Core()->graphPriority) {
-        this->parentWidget()->raise();
+
+    //Function f = this->analysis.functions[this->function];
+    //Core()->graphDisplay = f.blocks.size() > 0;
+
+    if (Core()->getMemoryWidgetPriority() == CutterCore::MemoryWidgetType::Graph)
+    {
+        raise();
     }
+
     this->renderFunction(this->analysis.functions[this->function]);
 }
 

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -1646,14 +1646,6 @@ void DisassemblerGraphView::on_seekChanged(RVA addr)
     Q_UNUSED(addr);
     loadCurrentGraph();
 
-    //Function f = this->analysis.functions[this->function];
-    //Core()->graphDisplay = f.blocks.size() > 0;
-
-    if (Core()->getMemoryWidgetPriority() == CutterCore::MemoryWidgetType::Graph)
-    {
-        raise();
-    }
-
     this->renderFunction(this->analysis.functions[this->function]);
 }
 

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -77,6 +77,15 @@ DisassemblerGraphView::DisassemblerGraphView(QWidget *parent)
     //Setup context menu
     setupContextMenu();
 
+
+    // Space to switch to disassembly
+    QShortcut *disassemblyShortcut = new QShortcut(QKeySequence(Qt::Key_Space), this);
+    disassemblyShortcut->setContext(Qt::WidgetShortcut);
+    connect(disassemblyShortcut, &QShortcut::activated, this, []{
+        Core()->setMemoryWidgetPriority(CutterCore::MemoryWidgetType::Disassembly);
+        Core()->triggerRaisePrioritizedMemoryWidget();
+    });
+
     //Connect to bridge
     connect(Core(), SIGNAL(seekChanged(RVA)), this, SLOT(on_seekChanged(RVA)));
     //connect(Bridge::getBridge(), SIGNAL(loadGraph(BridgeCFGraphList*, duint)), this, SLOT(loadGraphSlot(BridgeCFGraphList*, duint)));

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -53,6 +53,16 @@ DisassemblyWidget::DisassemblyWidget(QWidget *parent)
     maxLines = 0;
     updateMaxLines();
 
+
+    // Space to switch to graph
+    QShortcut *graphShortcut = new QShortcut(QKeySequence(Qt::Key_Space), this);
+    graphShortcut->setContext(Qt::WidgetWithChildrenShortcut);
+    connect(graphShortcut, &QShortcut::activated, this, []{
+        Core()->setMemoryWidgetPriority(CutterCore::MemoryWidgetType::Graph);
+        Core()->triggerRaisePrioritizedMemoryWidget();
+    });
+
+
     connect(mDisasScrollArea, SIGNAL(scrollLines(int)), this, SLOT(scrollInstructions(int)));
     connect(mDisasScrollArea, SIGNAL(disassemblyResized()), this, SLOT(updateMaxLines()));
 
@@ -414,6 +424,7 @@ void DisassemblyWidget::raisePrioritizedMemoryWidget(CutterCore::MemoryWidgetTyp
     if (type == CutterCore::MemoryWidgetType::Disassembly)
     {
         raise();
+        setFocus();
     }
 }
 
@@ -469,4 +480,9 @@ void DisassemblyTextEdit::scrollContentsBy(int dx, int dy)
     {
         QPlainTextEdit::scrollContentsBy(dx, dy);
     }
+}
+
+void DisassemblyTextEdit::keyPressEvent(QKeyEvent *event)
+{
+    //QPlainTextEdit::keyPressEvent(event);
 }

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -64,9 +64,10 @@ DisassemblyWidget::DisassemblyWidget(QWidget *parent)
         }
     });
 
-    // Seek signal
-    connect(CutterCore::getInstance(), SIGNAL(seekChanged(RVA)), this, SLOT(on_seekChanged(RVA)));
-    connect(CutterCore::getInstance(), SIGNAL(commentsChanged()), this, SLOT(refreshDisasm()));
+    connect(Core(), SIGNAL(seekChanged(RVA)), this, SLOT(on_seekChanged(RVA)));
+    connect(Core(), SIGNAL(raisePrioritizedMemoryWidget(CutterCore::MemoryWidgetType)), this, SLOT(raisePrioritizedMemoryWidget(CutterCore::MemoryWidgetType)));
+    connect(Core(), SIGNAL(commentsChanged()), this, SLOT(refreshDisasm()));
+
     connect(Config(), SIGNAL(fontsUpdated()), this, SLOT(fontsUpdatedSlot()));
 
     connect(this, &QDockWidget::visibilityChanged, this, [](bool visibility) {
@@ -394,11 +395,6 @@ bool DisassemblyWidget::eventFilter(QObject *obj, QEvent *event)
 
 void DisassemblyWidget::on_seekChanged(RVA offset)
 {
-    if (Core()->getMemoryWidgetPriority() == CutterCore::MemoryWidgetType::Disassembly)
-    {
-        raise();
-    }
-
     if (topOffset != RVA_INVALID && bottomOffset != RVA_INVALID
         && offset >= topOffset && offset <= bottomOffset)
     {
@@ -411,6 +407,14 @@ void DisassemblyWidget::on_seekChanged(RVA offset)
         refreshDisasm(offset);
     }
     mCtxMenu->setOffset(offset);
+}
+
+void DisassemblyWidget::raisePrioritizedMemoryWidget(CutterCore::MemoryWidgetType type)
+{
+    if (type == CutterCore::MemoryWidgetType::Disassembly)
+    {
+        raise();
+    }
 }
 
 void DisassemblyWidget::fontsUpdatedSlot()

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -68,6 +68,13 @@ DisassemblyWidget::DisassemblyWidget(QWidget *parent)
     connect(CutterCore::getInstance(), SIGNAL(seekChanged(RVA)), this, SLOT(on_seekChanged(RVA)));
     connect(CutterCore::getInstance(), SIGNAL(commentsChanged()), this, SLOT(refreshDisasm()));
     connect(Config(), SIGNAL(fontsUpdated()), this, SLOT(fontsUpdatedSlot()));
+
+    connect(this, &QDockWidget::visibilityChanged, this, [](bool visibility) {
+        if (visibility)
+        {
+            Core()->setMemoryWidgetPriority(CutterCore::MemoryWidgetType::Disassembly);
+        }
+    });
 }
 
 DisassemblyWidget::DisassemblyWidget(const QString &title, QWidget *parent) :
@@ -387,11 +394,10 @@ bool DisassemblyWidget::eventFilter(QObject *obj, QEvent *event)
 
 void DisassemblyWidget::on_seekChanged(RVA offset)
 {
-    Q_UNUSED(offset);
-    if (!Core()->graphDisplay || !Core()->graphPriority) {
-        this->raise();
+    if (Core()->getMemoryWidgetPriority() == CutterCore::MemoryWidgetType::Disassembly)
+    {
+        raise();
     }
-
 
     if (topOffset != RVA_INVALID && bottomOffset != RVA_INVALID
         && offset >= topOffset && offset <= bottomOffset)

--- a/src/widgets/DisassemblyWidget.h
+++ b/src/widgets/DisassemblyWidget.h
@@ -23,11 +23,13 @@ public:
 public slots:
     void highlightCurrentLine();
     void showDisasContextMenu(const QPoint &pt);
-    void on_seekChanged(RVA offset);
     void refreshDisasm(RVA offset = RVA_INVALID);
     void fontsUpdatedSlot();
 
 private slots:
+    void on_seekChanged(RVA offset);
+    void raisePrioritizedMemoryWidget(CutterCore::MemoryWidgetType type);
+
     void scrollInstructions(int count);
     void updateMaxLines();
 

--- a/src/widgets/DisassemblyWidget.h
+++ b/src/widgets/DisassemblyWidget.h
@@ -86,6 +86,7 @@ public:
 protected:
     bool viewportEvent(QEvent *event) override;
     void scrollContentsBy(int dx, int dy) override;
+    void keyPressEvent(QKeyEvent *event) override;
 
 private:
     bool lockScroll;

--- a/src/widgets/HexdumpWidget.cpp
+++ b/src/widgets/HexdumpWidget.cpp
@@ -75,6 +75,7 @@ HexdumpWidget::HexdumpWidget(QWidget *parent, Qt::WindowFlags flags) :
     connect(this->hexASCIIText->verticalScrollBar(), SIGNAL(valueChanged(int)), this, SLOT(hexScrolled()));
 
     connect(core, SIGNAL(seekChanged(RVA)), this, SLOT(on_seekChanged(RVA)));
+    connect(Core(), SIGNAL(raisePrioritizedMemoryWidget(CutterCore::MemoryWidgetType)), this, SLOT(raisePrioritizedMemoryWidget(CutterCore::MemoryWidgetType)));
 
     connect(this, &QDockWidget::visibilityChanged, this, [](bool visibility) {
         if (visibility)
@@ -96,12 +97,17 @@ HexdumpWidget::HexdumpWidget(const QString &title, QWidget *parent, Qt::WindowFl
 void HexdumpWidget::on_seekChanged(RVA addr)
 {
     refresh(addr);
+}
 
-    if (Core()->getMemoryWidgetPriority() == CutterCore::MemoryWidgetType::Hexdump)
+
+void HexdumpWidget::raisePrioritizedMemoryWidget(CutterCore::MemoryWidgetType type)
+{
+    if (type == CutterCore::MemoryWidgetType::Hexdump)
     {
         raise();
     }
 }
+
 
 HexdumpWidget::~HexdumpWidget() {}
 

--- a/src/widgets/HexdumpWidget.cpp
+++ b/src/widgets/HexdumpWidget.cpp
@@ -76,6 +76,13 @@ HexdumpWidget::HexdumpWidget(QWidget *parent, Qt::WindowFlags flags) :
 
     connect(core, SIGNAL(seekChanged(RVA)), this, SLOT(on_seekChanged(RVA)));
 
+    connect(this, &QDockWidget::visibilityChanged, this, [](bool visibility) {
+        if (visibility)
+        {
+            Core()->setMemoryWidgetPriority(CutterCore::MemoryWidgetType::Hexdump);
+        }
+    });
+
     fillPlugins();
 }
 
@@ -89,6 +96,11 @@ HexdumpWidget::HexdumpWidget(const QString &title, QWidget *parent, Qt::WindowFl
 void HexdumpWidget::on_seekChanged(RVA addr)
 {
     refresh(addr);
+
+    if (Core()->getMemoryWidgetPriority() == CutterCore::MemoryWidgetType::Hexdump)
+    {
+        raise();
+    }
 }
 
 HexdumpWidget::~HexdumpWidget() {}

--- a/src/widgets/HexdumpWidget.h
+++ b/src/widgets/HexdumpWidget.h
@@ -68,6 +68,7 @@ private:
 
 private slots:
     void on_seekChanged(RVA addr);
+    void raisePrioritizedMemoryWidget(CutterCore::MemoryWidgetType type);
 
     void highlightHexCurrentLine();
     void setFonts(QFont font);


### PR DESCRIPTION
If the user selects Disassembly/Graph/Hexdump, this widget will get priority. Then, when seeking somewhere, it gets raised automatically.
Also added the space shortcut to switch between disassembly and graph.

Fixes #85 