### PR TITLE
Fixed #98 Rename in a non-function

### DIFF
--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -132,6 +132,11 @@ void DisassemblyContextMenu::on_actionRename_triggered()
 {
     // Get function for clicked offset
     RAnalFunction *fcn = CutterCore::getInstance()->functionAt(offset);
+    if( nullptr == fcn )
+    {
+        return;
+    }
+
     RenameDialog *dialog = new RenameDialog(this);
     // Get function based on click position
     dialog->setFunctionName(fcn->name);


### PR DESCRIPTION
Fixed #98:  "Rename in a non-function segfault"

r_anal_get_fcn_in returns nullptr in non function offsets