### PR TITLE
reduced margins (#131)

### DIFF
--- a/src/dialogs/NewfileDialog.ui
+++ b/src/dialogs/NewfileDialog.ui
@@ -17,16 +17,16 @@
    <item>
     <layout class="QVBoxLayout" name="verticalLayout_6">
      <property name="leftMargin">
-      <number>8</number>
+      <number>2</number>
      </property>
      <property name="topMargin">
-      <number>8</number>
+      <number>2</number>
      </property>
      <property name="rightMargin">
-      <number>8</number>
+      <number>2</number>
      </property>
      <property name="bottomMargin">
-      <number>8</number>
+      <number>2</number>
      </property>
      <item alignment="Qt::AlignHCenter">
       <widget class="QSvgWidget" name="logoSvgWidget" native="true">
@@ -79,16 +79,16 @@
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_2">
         <property name="leftMargin">
-         <number>5</number>
+         <number>0</number>
         </property>
         <property name="topMargin">
          <number>0</number>
         </property>
         <property name="rightMargin">
-         <number>5</number>
+         <number>0</number>
         </property>
         <property name="bottomMargin">
-         <number>5</number>
+         <number>0</number>
         </property>
         <item>
          <widget class="QTabWidget" name="tabWidget">
@@ -422,7 +422,7 @@
 		</property>
 		<property name="sizeHint" stdset="0">
 		  <size>
-			<width>300</width>
+			<width>500</width>
 			<height>20</height>
 		  </size>
 		</property>


### PR DESCRIPTION
Original issue was on OSX (#131)
The picture shows the changes on Linux.

_**Left** is after. **Right** is before_

![screenshot from 2017-12-04 22-05-20](https://user-images.githubusercontent.com/9213716/33582211-04508170-d94c-11e7-9c2a-17d42e1a67a6.png)
