### PR TITLE
fixed issue #179 Strings not visible as yellow on white 

### DIFF
--- a/src/utils/Configuration.cpp
+++ b/src/utils/Configuration.cpp
@@ -126,9 +126,9 @@ void Configuration::loadDarkTheme()
     QColor color4 = QColor(128, 235, 200);
     QColor color5 = QColor(95, 95, 175);
     QColor color6 = QColor(255, 235, 95);
-    QColor color7 = QColor(255, 200, 0);
+    QColor color7 = QColor(255, 130, 0);
     QColor color8 = QColor(108, 108, 108);
-    QColor color9 = QColor(255, 200, 0);
+    QColor color9 = QColor(255, 130, 0);
 
     QColor highlightColor = QColor(64, 115, 115);
 


### PR DESCRIPTION
fixed issue #179 Strings not visible as yellow on white 
Update Configuration.cpp
changed the color7&9  to RGB(255,130,0) to achieve a greater  constract both in default theme and the dark one.