### PR TITLE
VisualNavbar: fix use of std::isnan

### DIFF
--- a/src/widgets/VisualNavbar.cpp
+++ b/src/widgets/VisualNavbar.cpp
@@ -3,6 +3,7 @@
 #include "MainWindow.h"
 #include "utils/TempConfig.h"
 
+#include <cmath>
 #include <QGraphicsView>
 #include <QComboBox>
 #include <QGraphicsScene>
@@ -213,7 +214,7 @@ void VisualNavbar::drawCursor()
         delete cursorGraphicsItem;
         cursorGraphicsItem = nullptr;
     }
-    if (isnan(cursor_x))
+    if (std::isnan(cursor_x))
     {
         return;
     }


### PR DESCRIPTION
This is needed to fix build on GCC 6, at least.