### PR TITLE
Separate platform from use of APPIMAGE

### DIFF
--- a/src/cutter.pro
+++ b/src/cutter.pro
@@ -201,5 +201,6 @@ unix {
         appimage_root.files = $$icon_file $$desktop_file
 
         INSTALLS += appimage_root
+        DEFINES += APPIMAGE
     }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,7 +7,7 @@
 #include "dialogs/NewFileDialog.h"
 #include "dialogs/OptionsDialog.h"
 
-#ifdef __unix__
+#ifdef APPIMAGE
 #define PREFIX "/tmp/.cutter_usr"
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -109,13 +109,13 @@ int main(int argc, char *argv[])
     }
 
     // Hack to make it work with AppImage
-#ifdef __unix__
+#ifdef APPIMAGE
     set_appimage_symlink();
 #endif
 
     int ret = a.exec();
 
-#ifdef __unix__
+#ifdef APPIMAGE
     remove(PREFIX);
 #endif
 


### PR DESCRIPTION
Instead of checking for `__unix__`, define `APPIMAGE` and check for that.