### PR TITLE
Fixes #157: Add support for multiline comments.

### DIFF
--- a/src/dialogs/CommentsDialog.cpp
+++ b/src/dialogs/CommentsDialog.cpp
@@ -7,6 +7,9 @@ CommentsDialog::CommentsDialog(QWidget *parent) :
 {
     ui->setupUi(this);
     setWindowFlags(windowFlags() & (~Qt::WindowContextHelpButtonHint));
+
+    // Event filter for capturing Ctrl/Cmd+Return
+    ui->textEdit->installEventFilter(this);
 }
 
 CommentsDialog::~CommentsDialog() {}
@@ -22,11 +25,29 @@ void CommentsDialog::on_buttonBox_rejected()
 
 QString CommentsDialog::getComment()
 {
-    QString ret = ui->lineEdit->text();
+    QString ret = ui->textEdit->document()->toPlainText();
     return ret;
 }
 
 void CommentsDialog::setComment(const QString &comment)
 {
-    ui->lineEdit->setText(comment);
+    ui->textEdit->document()->setPlainText(comment);
+}
+
+bool CommentsDialog::eventFilter(QObject *obj, QEvent *event)
+{
+    if(event -> type() == QEvent::KeyPress)
+    {
+        QKeyEvent *keyEvent = static_cast <QKeyEvent*> (event);
+
+        // Confirm comment by pressing Ctrl/Cmd+Return
+        if((keyEvent -> modifiers() & Qt::ControlModifier) &&
+          ((keyEvent -> key() == Qt::Key_Enter) || (keyEvent -> key() == Qt::Key_Return)))
+        {
+            this->accept();
+            return true;
+        }
+    }
+
+    return false;
 }

--- a/src/dialogs/CommentsDialog.h
+++ b/src/dialogs/CommentsDialog.h
@@ -27,6 +27,8 @@ private slots:
 
 private:
     std::unique_ptr<Ui::CommentsDialog> ui;
+
+    bool eventFilter(QObject *obj, QEvent *event);
 };
 
 #endif // COMMENTSDIALOG_H

--- a/src/dialogs/CommentsDialog.ui
+++ b/src/dialogs/CommentsDialog.ui
@@ -7,40 +7,35 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>75</height>
+    <height>118</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Comment</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
+   <property name="spacing">
+    <number>2</number>
+   </property>
+   <property name="leftMargin">
+    <number>2</number>
+   </property>
+   <property name="topMargin">
+    <number>5</number>
+   </property>
+   <property name="rightMargin">
+    <number>2</number>
+   </property>
+   <property name="bottomMargin">
+    <number>2</number>
+   </property>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <property name="topMargin">
       <number>0</number>
      </property>
      <item>
-      <widget class="QLabel" name="label">
-       <property name="font">
-        <font>
-         <weight>75</weight>
-         <bold>true</bold>
-        </font>
-       </property>
-       <property name="text">
-        <string>Comment:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLineEdit" name="lineEdit">
-       <property name="frame">
-        <bool>false</bool>
-       </property>
-       <property name="placeholderText">
-        <string notr="true"/>
-       </property>
-      </widget>
+      <widget class="QPlainTextEdit" name="textEdit"/>
      </item>
     </layout>
    </item>

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -132,9 +132,8 @@ void DisassemblyContextMenu::aboutToShowSlot()
     bool immBase = keys.contains("val") || keys.contains("ptr");
     setBaseMenuAction->setVisible(immBase);
 
-    QJsonObject disasObject = Core()->cmdj("pdj 1 @ " + QString::number(offset)).array().first().toObject();
-    QString comment = disasObject["comment"].toString();
-    if (comment.isNull() || QByteArray::fromBase64(comment.toUtf8()).isEmpty())
+    QString comment = Core()->cmd("CC." + RAddressString(offset));
+    if (comment.isNull() || comment.isEmpty())
     {
         actionAddComment.setText(tr("Add Comment"));
     }
@@ -235,7 +234,7 @@ void DisassemblyContextMenu::on_actionAddComment_triggered()
     oldComment.remove(oldComment.length()-1, 1);
     CommentsDialog *c = new CommentsDialog(this);
 
-    if (oldComment.isNull() || QByteArray::fromBase64(oldComment.toUtf8()).isEmpty())
+    if (oldComment.isNull() || oldComment.isEmpty())
     {
         c->setWindowTitle(tr("Add Comment at %1").arg(RAddressString(offset)));
     }

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -230,9 +230,9 @@ void DisassemblyContextMenu::on_actionCopy_triggered()
 
 void DisassemblyContextMenu::on_actionAddComment_triggered()
 {
-    QJsonObject disasObject = Core()->cmdj("pdj 1 @ " + QString::number(offset)).array().first().toObject();
-    QString oldComment = QString::fromUtf8(QByteArray::fromBase64(disasObject["comment"].toString().toUtf8()));
-
+    QString oldComment = Core()->cmd("CC." + RAddressString(offset));
+    // Remove newline at the end added by cmd
+    oldComment.remove(oldComment.length()-1, 1);
     CommentsDialog *c = new CommentsDialog(this);
 
     if (oldComment.isNull() || QByteArray::fromBase64(oldComment.toUtf8()).isEmpty())


### PR DESCRIPTION
The new comments can be confirmed with Ctrl/Cmd+Enter. Fixes #157.