### PR TITLE
Fixes #132: Make File->New create a new cutter instance.

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -770,8 +770,7 @@ void MainWindow::addDebugOutput(const QString &msg)
 
 void MainWindow::on_actionNew_triggered()
 {
-    if (close())
-        on_actionLoad_triggered();
+    on_actionLoad_triggered();
 }
 
 void MainWindow::on_actionSave_triggered()


### PR DESCRIPTION
This allows users on OSX to create new instances and changes the behavior of File -> New.
Note that on OSX this will start Cutter as two completely independent instances, making it appear twice in the Dock. Fixes #132.
<img width="47" alt="screen shot 2017-12-10 at 6 45 06 pm" src="https://user-images.githubusercontent.com/208596/33807653-62f17666-ddda-11e7-90e2-05323c75c8ec.png">
