### PR TITLE
Fix #148: Show elapsed time of running analysis.

### DIFF
--- a/src/dialogs/OptionsDialog.cpp
+++ b/src/dialogs/OptionsDialog.cpp
@@ -139,10 +139,42 @@ void OptionsDialog::setupAndStartAnalysis(int level, QList<QString> advanced)
 
     core->resetDefaultAsmOptions();
 
+    // Timer for showing elapsed analysis time.
+    analTimer.setInterval(1000);
+    analTimer.setSingleShot(false);
+    analTimer.start();
+    analElapsedTimer.start();
+    updateProgressTimer();
+    connect(&analTimer, SIGNAL(timeout()), this, SLOT(updateProgressTimer()));
+
     // Threads stuff
     // connect signal/slot
     connect(&analThread, &AnalThread::updateProgress, this, &OptionsDialog::updateProgress);
     analThread.start(main, level, advanced);
+}
+
+void OptionsDialog::updateProgressTimer()
+{
+    int secondsElapsed = (analElapsedTimer.elapsed()+500)/1000;
+    int minutesElapsed = secondsElapsed / 60;
+    int hoursElapsed = minutesElapsed / 60;
+    int daysElapsed = hoursElapsed / 24;
+    int yearsElapsed = daysElapsed / 365;
+    int decadesElapsed = yearsElapsed / 10;
+    int centuriesElapsed = decadesElapsed / 10;
+
+    QString label = tr("Running since") + " ";
+    if(hoursElapsed)
+    {
+        label += tr("%n hour", "%n hours", hoursElapsed);
+    }
+    if(minutesElapsed)
+    {
+        label += tr("%n minute", "%n minutes", minutesElapsed % 60);
+        label += " ";
+    }
+    label += tr("%n seconds", "%n second", secondsElapsed % 60);
+    ui->elapsedLabel->setText(label);
 }
 
 void OptionsDialog::updateProgress(const QString &status)

--- a/src/dialogs/OptionsDialog.cpp
+++ b/src/dialogs/OptionsDialog.cpp
@@ -167,6 +167,7 @@ void OptionsDialog::updateProgressTimer()
     if(hoursElapsed)
     {
         label += tr("%n hour", "%n hours", hoursElapsed);
+        label += " ";
     }
     if(minutesElapsed)
     {

--- a/src/dialogs/OptionsDialog.cpp
+++ b/src/dialogs/OptionsDialog.cpp
@@ -24,6 +24,7 @@ OptionsDialog::OptionsDialog(MainWindow *main):
     setWindowFlags(windowFlags() & (~Qt::WindowContextHelpButtonHint));
     ui->progressBar->setVisible(0);
     ui->statusLabel->setVisible(0);
+    ui->elapsedLabel->setVisible(0);
 
     QString logoFile = (palette().window().color().value() < 127) ? ":/img/cutter_white_plain.svg" : ":/img/cutter_plain.svg";
     ui->logoSvgWidget->load(logoFile);
@@ -131,6 +132,7 @@ void OptionsDialog::setupAndStartAnalysis(int level, QList<QString> advanced)
     ui->statusLabel->setEnabled(1);
     ui->progressBar->setVisible(1);
     ui->statusLabel->setVisible(1);
+    ui->elapsedLabel->setVisible(1);
 
     ui->statusLabel->setText(tr("Starting analysis"));
     //ui->progressBar->setValue(5);
@@ -144,6 +146,7 @@ void OptionsDialog::setupAndStartAnalysis(int level, QList<QString> advanced)
     analTimer.setSingleShot(false);
     analTimer.start();
     analElapsedTimer.start();
+
     updateProgressTimer();
     connect(&analTimer, SIGNAL(timeout()), this, SLOT(updateProgressTimer()));
 
@@ -158,10 +161,6 @@ void OptionsDialog::updateProgressTimer()
     int secondsElapsed = (analElapsedTimer.elapsed()+500)/1000;
     int minutesElapsed = secondsElapsed / 60;
     int hoursElapsed = minutesElapsed / 60;
-    int daysElapsed = hoursElapsed / 24;
-    int yearsElapsed = daysElapsed / 365;
-    int decadesElapsed = yearsElapsed / 10;
-    int centuriesElapsed = decadesElapsed / 10;
 
     QString label = tr("Running since") + " ";
     if(hoursElapsed)

--- a/src/dialogs/OptionsDialog.h
+++ b/src/dialogs/OptionsDialog.h
@@ -3,6 +3,8 @@
 
 #include <QDialog>
 #include <QStringList>
+#include <QTimer>
+#include <QElapsedTimer>
 #include <memory>
 #include "cutter.h"
 #include "AnalThread.h"
@@ -32,6 +34,8 @@ private slots:
     void on_archComboBox_currentIndexChanged(int index);
     void on_pdbSelectButton_clicked();
 
+    void updateProgressTimer();
+
     void updatePDBLayout();
 
     void anal_finished();
@@ -51,6 +55,8 @@ public:
     QString getSelectedCPU();
     int getSelectedBits();
     QString getSelectedOS();
+    QTimer analTimer;
+    QElapsedTimer analElapsedTimer;
     void reject() override;
 };
 

--- a/src/dialogs/OptionsDialog.ui
+++ b/src/dialogs/OptionsDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>598</width>
-    <height>460</height>
+    <height>524</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -900,6 +900,25 @@
      <property name="topMargin">
       <number>0</number>
      </property>
+     <item>
+      <widget class="QLabel" name="elapsedLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>150</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Timer label</string>
+       </property>
+      </widget>
+     </item>
      <item>
       <spacer name="horizontalSpacer_3">
        <property name="orientation">


### PR DESCRIPTION
Fixes #148.
<img width="710" alt="screen shot 2017-12-11 at 2 41 24 pm" src="https://user-images.githubusercontent.com/208596/33834582-ae82b384-de83-11e7-99f4-87472b9a0aa1.png">
