### PR TITLE
GraphView fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ Cutter is developed on OS X, Linux and Windows. The first release for users will
 | + | Zoom in |
 | - | Zoom out |
 | = | Reset zoom |
+| J | Next instruction |
+| K | Previous instruction |
 
 
 ## Help

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -17,7 +17,7 @@ DisassemblerGraphView::DisassemblerGraphView(QWidget *parent)
       mFontMetrics(nullptr),
       mMenu(new DisassemblyContextMenu(this))
 {
-    this->highlight_token = nullptr;
+    highlight_token = nullptr;
     // Signals that require a refresh all
     connect(Core(), SIGNAL(refreshAll()), this, SLOT(refreshView()));
     connect(Core(), SIGNAL(commentsChanged()), this, SLOT(refreshView()));
@@ -69,7 +69,7 @@ void DisassemblerGraphView::refreshView()
 {
     initFont();
     loadCurrentGraph();
-    this->viewport()->update();
+    viewport()->update();
 }
 
 void DisassemblerGraphView::loadCurrentGraph()
@@ -78,7 +78,7 @@ void DisassemblerGraphView::loadCurrentGraph()
     QJsonArray functions = functionsDoc.array();
 
     disassembly_blocks.clear();
-    this->blocks.clear();
+    blocks.clear();
 
     Analysis anal;
     anal.ready = true;
@@ -95,7 +95,7 @@ void DisassemblerGraphView::loadCurrentGraph()
     {
         windowTitle += " (" + funcName + ")";
     }
-    this->parentWidget()->setWindowTitle(windowTitle);
+    parentWidget()->setWindowTitle(windowTitle);
 
     RVA entry = func["offset"].toVariant().toULongLong();
 
@@ -157,11 +157,11 @@ void DisassemblerGraphView::loadCurrentGraph()
     if(func["blocks"].toArray().size() > 0)
     {
         computeGraph(entry);
-        this->viewport()->update();
+        viewport()->update();
 
         if(first_draw)
         {
-            showBlock(this->blocks[entry]);
+            showBlock(blocks[entry]);
             first_draw = false;
         }
     }
@@ -193,20 +193,20 @@ void DisassemblerGraphView::prepareGraphNode(GraphBlock &block)
             height += 1;
         }
     }
-    int extra = 4 * this->charWidth + 4;
-    block.width = width + extra + this->charWidth;
-    block.height = (height * this->charHeight) + extra;
+    int extra = 4 * charWidth + 4;
+    block.width = width + extra + charWidth;
+    block.height = (height * charHeight) + extra;
 }
 
 
 void DisassemblerGraphView::initFont()
 {
     setFont(Config()->getFont());
-    QFontMetricsF metrics(this->font());
-    this->baseline = int(metrics.ascent());
-    this->charWidth = metrics.width('X');
-    this->charHeight = metrics.height();
-    this->charOffset = 0;
+    QFontMetricsF metrics(font());
+    baseline = int(metrics.ascent());
+    charWidth = metrics.width('X');
+    charHeight = metrics.height();
+    charOffset = 0;
     if(mFontMetrics)
         delete mFontMetrics;
     mFontMetrics = new CachedFontMetrics(this, font());
@@ -263,7 +263,7 @@ void DisassemblerGraphView::drawBlock(QPainter & p, GraphView::GraphBlock &block
     // Draw different background for selected instruction
     if(selected_instruction != RVA_INVALID)
     {
-        int y = block.y + (2 * this->charWidth) + (db.header_text.lines.size() * this->charHeight);
+        int y = block.y + (2 * charWidth) + (db.header_text.lines.size() * charHeight);
         for(Instr & instr : db.instrs)
         {
             auto selected = instr.addr == selected_instruction;
@@ -271,13 +271,13 @@ void DisassemblerGraphView::drawBlock(QPainter & p, GraphView::GraphBlock &block
             auto traceCount = 0;
             if(selected && traceCount)
             {
-                p.fillRect(QRect(block.x + this->charWidth, y, block.width - (10 + 2 * this->charWidth),
-                                 int(instr.text.lines.size()) * this->charHeight), disassemblyTracedSelectionColor);
+                p.fillRect(QRect(block.x + charWidth, y, block.width - (10 + 2 * charWidth),
+                                 int(instr.text.lines.size()) * charHeight), disassemblyTracedSelectionColor);
             }
             else if(selected)
             {
-                p.fillRect(QRect(block.x + this->charWidth, y, block.width - (10 + 2 * this->charWidth),
-                                 int(instr.text.lines.size()) * this->charHeight), disassemblySelectionColor);
+                p.fillRect(QRect(block.x + charWidth, y, block.width - (10 + 2 * charWidth),
+                                 int(instr.text.lines.size()) * charHeight), disassemblySelectionColor);
             }
             else if(traceCount)
             {
@@ -291,40 +291,40 @@ void DisassemblerGraphView::drawBlock(QPainter & p, GraphView::GraphBlock &block
                 if(disassemblyTracedColor.blue() > 160)
                     colorDiff *= -1;
 
-                p.fillRect(QRect(block.x + this->charWidth, y, block.width - (10 + 2 * this->charWidth), int(instr.text.lines.size()) * this->charHeight),
+                p.fillRect(QRect(block.x + charWidth, y, block.width - (10 + 2 * charWidth), int(instr.text.lines.size()) * charHeight),
                            QColor(disassemblyTracedColor.red(),
                                   disassemblyTracedColor.green(),
                                   std::max(0, std::min(256, disassemblyTracedColor.blue() + colorDiff))));
             }
-            y += int(instr.text.lines.size()) * this->charHeight;
+            y += int(instr.text.lines.size()) * charHeight;
         }
     }
 
 
     // Render node text
-    auto x = block.x + (2 * this->charWidth);
-    int y = block.y + (2 * this->charWidth);
+    auto x = block.x + (2 * charWidth);
+    int y = block.y + (2 * charWidth);
     for(auto & line : db.header_text.lines)
     {
-        RichTextPainter::paintRichText(&p, x, y, block.width, this->charHeight, 0, line, mFontMetrics);
-        y += this->charHeight;
+        RichTextPainter::paintRichText(&p, x, y, block.width, charHeight, 0, line, mFontMetrics);
+        y += charHeight;
     }
     for(Instr & instr : db.instrs)
     {
         for(auto & line : instr.text.lines)
         {
-            int rectSize = qRound(this->charWidth);
+            int rectSize = qRound(charWidth);
             if(rectSize % 2)
             {
                 rectSize++;
             }
             // Assume charWidth <= charHeight
-            QRectF bpRect(x - rectSize / 3.0, y + (this->charHeight - rectSize) / 2.0, rectSize, rectSize);
+            QRectF bpRect(x - rectSize / 3.0, y + (charHeight - rectSize) / 2.0, rectSize, rectSize);
 
             // TODO: Breakpoint/Cip stuff
 
-            RichTextPainter::paintRichText(&p, x + this->charWidth, y, block.width - this->charWidth, this->charHeight, 0, line, mFontMetrics);
-            y += this->charHeight;
+            RichTextPainter::paintRichText(&p, x + charWidth, y, block.width - charWidth, charHeight, 0, line, mFontMetrics);
+            y += charHeight;
 
         }
     }
@@ -356,10 +356,10 @@ RVA DisassemblerGraphView::getInstrForMouseEvent(GraphBlock &block, QPoint* poin
     DisassemblyBlock &db = disassembly_blocks[block.entry];
 
     // Remove header and margin
-    int off_y = (2 * this->charWidth) + (db.header_text.lines.size() * this->charHeight);
+    int off_y = (2 * charWidth) + (db.header_text.lines.size() * charHeight);
     // Get mouse coordinate over the actual text
     int text_point_y = point->y() - off_y;
-    int mouse_row = text_point_y / this->charHeight;
+    int mouse_row = text_point_y / charHeight;
 
     int cur_row = db.header_text.lines.size();
     if (mouse_row < cur_row)
@@ -401,7 +401,7 @@ void DisassemblerGraphView::colorsUpdatedSlot()
 
 void DisassemblerGraphView::fontsUpdatedSlot()
 {
-    this->initFont();
+    initFont();
     refreshView();
 }
 
@@ -452,26 +452,26 @@ void DisassemblerGraphView::onSeekChanged(RVA addr)
 void DisassemblerGraphView::zoomIn()
 {
     current_scale += 0.1;
-    auto areaSize = this->viewport()->size();
-    this->adjustSize(areaSize.width(), areaSize.height());
-    this->viewport()->update();
+    auto areaSize = viewport()->size();
+    adjustSize(areaSize.width(), areaSize.height());
+    viewport()->update();
 }
 
 void DisassemblerGraphView::zoomOut()
 {
     current_scale -= 0.1;
     current_scale = std::max(current_scale, 0.3);
-    auto areaSize = this->viewport()->size();
-    this->adjustSize(areaSize.width(), areaSize.height());
-    this->viewport()->update();
+    auto areaSize = viewport()->size();
+    adjustSize(areaSize.width(), areaSize.height());
+    viewport()->update();
 }
 
 void DisassemblerGraphView::zoomReset()
 {
     current_scale = 1.0;
-    auto areaSize = this->viewport()->size();
-    this->adjustSize(areaSize.width(), areaSize.height());
-    this->viewport()->update();
+    auto areaSize = viewport()->size();
+    adjustSize(areaSize.width(), areaSize.height());
+    viewport()->update();
 }
 
 void DisassemblerGraphView::takeTrue()
@@ -506,7 +506,7 @@ void DisassemblerGraphView::seek(RVA addr, bool update_viewport)
     Core()->seek(addr);
     if(update_viewport)
     {
-        this->viewport()->update();
+        viewport()->update();
     }
 }
 
@@ -517,7 +517,7 @@ void DisassemblerGraphView::seekPrev()
 
 void DisassemblerGraphView::blockClicked(GraphView::GraphBlock &block, QMouseEvent *event, QPoint pos)
 {
-    RVA instr = this->getInstrForMouseEvent(block, &pos);
+    RVA instr = getInstrForMouseEvent(block, &pos);
     if(instr == RVA_INVALID)
     {
         return;
@@ -534,7 +534,7 @@ void DisassemblerGraphView::blockClicked(GraphView::GraphBlock &block, QMouseEve
 
 void DisassemblerGraphView::blockDoubleClicked(GraphView::GraphBlock &block, QMouseEvent *event, QPoint pos)
 {
-    RVA instr = this->getInstrForMouseEvent(block, &pos);
+    RVA instr = getInstrForMouseEvent(block, &pos);
     if(instr == RVA_INVALID)
     {
         return;

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -158,6 +158,12 @@ void DisassemblerGraphView::loadCurrentGraph()
     {
         computeGraph(entry);
         this->viewport()->update();
+
+        if(first_draw)
+        {
+            showBlock(this->blocks[entry]);
+            first_draw = false;
+        }
     }
 }
 

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -348,7 +348,13 @@ GraphView::EdgeConfiguration DisassemblerGraphView::edgeConfiguration(GraphView:
 RVA DisassemblerGraphView::getInstrForMouseEvent(GraphBlock &block, QPoint* point)
 {
     DisassemblyBlock &db = disassembly_blocks[block.entry];
-    int mouse_row = ((point->y()-(2*this->charWidth)) / this->charHeight);
+
+    // Remove header and margin
+    int off_y = (2 * this->charWidth) + (db.header_text.lines.size() * this->charHeight);
+    // Get mouse coordinate over the actual text
+    int text_point_y = point->y() - off_y;
+    int mouse_row = text_point_y / this->charHeight;
+
     int cur_row = db.header_text.lines.size();
     if (mouse_row < cur_row)
     {
@@ -434,7 +440,6 @@ void DisassemblerGraphView::onSeekChanged(RVA addr)
             }
         }
     }
-    sent_seek = false;
 }
 
 void DisassemblerGraphView::zoomIn()
@@ -529,6 +534,7 @@ void DisassemblerGraphView::blockDoubleClicked(GraphView::GraphBlock &block, QMo
     }
     QList<XrefDescription> refs = Core()->getXRefs(instr, false, false);
     if (refs.length()) {
+        sent_seek = false;
         Core()->seek(refs.at(0).to);
     }
     if (refs.length() > 1) {

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -440,6 +440,7 @@ void DisassemblerGraphView::onSeekChanged(RVA addr)
             }
         }
     }
+    sent_seek = false;
 }
 
 void DisassemblerGraphView::zoomIn()

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -509,7 +509,6 @@ void DisassemblerGraphView::blockClicked(GraphView::GraphBlock &block, QMouseEve
     if(instr == RVA_INVALID)
     {
         return;
-//
     }
 
     seek(instr, true);
@@ -518,6 +517,22 @@ void DisassemblerGraphView::blockClicked(GraphView::GraphBlock &block, QMouseEve
     {
         mMenu->setOffset(instr);
         mMenu->exec(event->globalPos());
+    }
+}
+
+void DisassemblerGraphView::blockDoubleClicked(GraphView::GraphBlock &block, QMouseEvent *event, QPoint pos)
+{
+    RVA instr = this->getInstrForMouseEvent(block, &pos);
+    if(instr == RVA_INVALID)
+    {
+        return;
+    }
+    QList<XrefDescription> refs = Core()->getXRefs(instr, false, false);
+    if (refs.length()) {
+        Core()->seek(refs.at(0).to);
+    }
+    if (refs.length() > 1) {
+        qWarning() << "Too many references here. Weird behaviour expected.";
     }
 }
 

--- a/src/widgets/DisassemblerGraphView.h
+++ b/src/widgets/DisassemblerGraphView.h
@@ -162,6 +162,7 @@ private slots:
     void seekPrev();
 
 private:
+    bool first_draw = true;
     bool transition_dont_seek = false;
     bool sent_seek = false;
 

--- a/src/widgets/DisassemblerGraphView.h
+++ b/src/widgets/DisassemblerGraphView.h
@@ -5,6 +5,7 @@
 
 #include <QWidget>
 #include <QPainter>
+#include <QShortcut>
 
 #include "widgets/GraphView.h"
 #include "menus/DisassemblyContextMenu.h"
@@ -136,6 +137,7 @@ class DisassemblerGraphView : public GraphView
 
 public:
     DisassemblerGraphView(QWidget *parent);
+    ~DisassemblerGraphView();
     std::unordered_map<ut64, DisassemblyBlock> disassembly_blocks;
     virtual void drawBlock(QPainter & p, GraphView::GraphBlock &block) override;
     virtual void blockClicked(GraphView::GraphBlock &block, QMouseEvent *event, QPoint pos) override;
@@ -158,6 +160,9 @@ public slots:
 
     void takeTrue();
     void takeFalse();
+
+    void nextInstr();
+    void prevInstr();
 private slots:
     void seekPrev();
 
@@ -181,6 +186,9 @@ private:
     RVA getInstrForMouseEvent(GraphBlock &block, QPoint* point);
     DisassemblyBlock *blockForAddress(RVA addr);
     void seek(RVA addr, bool update_viewport=true);
+    void seekInstruction(bool previous_instr);
+
+    QList<QShortcut*> shortcuts;
 
     QColor disassemblyBackgroundColor;
     QColor disassemblySelectedBackgroundColor;

--- a/src/widgets/DisassemblerGraphView.h
+++ b/src/widgets/DisassemblerGraphView.h
@@ -139,6 +139,7 @@ public:
     std::unordered_map<ut64, DisassemblyBlock> disassembly_blocks;
     virtual void drawBlock(QPainter & p, GraphView::GraphBlock &block) override;
     virtual void blockClicked(GraphView::GraphBlock &block, QMouseEvent *event, QPoint pos) override;
+    virtual void blockDoubleClicked(GraphView::GraphBlock &block, QMouseEvent *event, QPoint pos) override;
     virtual GraphView::EdgeConfiguration edgeConfiguration(GraphView::GraphBlock &from, GraphView::GraphBlock *to) override;
     virtual void blockTransitionedTo(GraphView::GraphBlock *to) override;
 

--- a/src/widgets/DisassemblerGraphView.h
+++ b/src/widgets/DisassemblerGraphView.h
@@ -169,7 +169,7 @@ private:
     // Font data
     CachedFontMetrics* mFontMetrics;
     qreal charWidth;
-    qreal charHeight;
+    int charHeight;
     int charOffset;
     int baseline;
 

--- a/src/widgets/GraphView.cpp
+++ b/src/widgets/GraphView.cpp
@@ -392,11 +392,30 @@ void GraphView::paintEvent(QPaintEvent* event)
     int render_width = this->viewport()->size().width() / current_scale;
     int render_height = this->viewport()->size().height() / current_scale;
 
+    // Do we have scrollbars?
+    bool hscrollbar = horizontalScrollBar()->pageStep() < this->width;
+    bool vscrollbar = verticalScrollBar()->pageStep() < this->height;
+
     // Draw background
     QRect viewportRect(this->viewport()->rect().topLeft(), this->viewport()->rect().bottomRight() - QPoint(1, 1));
     p.setBrush(backgroundColor);
     p.drawRect(viewportRect);
     p.setBrush(Qt::black);
+
+    unscrolled_render_offset_x = 0;
+    unscrolled_render_offset_y = 0;
+
+    // We do not have a scrollbar on this axis, so we center the view
+    if(!hscrollbar)
+    {
+        unscrolled_render_offset_x = (this->viewport()->size().width() - (this->width * current_scale)) / 2;
+        render_offset_x += unscrolled_render_offset_x;
+    }
+    if(!vscrollbar)
+    {
+        unscrolled_render_offset_y = (this->viewport()->size().height() - (this->height * current_scale)) / 2;
+        render_offset_y += unscrolled_render_offset_y;
+    }
 
     p.translate(render_offset_x, render_offset_y);
     p.scale(current_scale, current_scale);
@@ -810,8 +829,8 @@ void GraphView::resizeEvent(QResizeEvent* event)
 // Mouse events
 void GraphView::mousePressEvent(QMouseEvent *event)
 {
-    int x = (event->pos().x() / current_scale) + horizontalScrollBar()->value();
-    int y = (event->pos().y() / current_scale) + verticalScrollBar()->value();
+    int x = ((event->pos().x() - unscrolled_render_offset_x) / current_scale) + horizontalScrollBar()->value();
+    int y = ((event->pos().y() - unscrolled_render_offset_y) / current_scale) + verticalScrollBar()->value();
 
     // Check if a block was clicked
     for(auto & blockIt : blocks)
@@ -886,8 +905,8 @@ void GraphView::mouseMoveEvent(QMouseEvent* event)
 
 void GraphView::mouseDoubleClickEvent(QMouseEvent *event)
 {
-    int x = (event->pos().x() / current_scale) + horizontalScrollBar()->value();
-    int y = (event->pos().y() / current_scale) + verticalScrollBar()->value();
+    int x = ((event->pos().x() - unscrolled_render_offset_x) / current_scale) + horizontalScrollBar()->value();
+    int y = ((event->pos().y() - unscrolled_render_offset_y) / current_scale) + verticalScrollBar()->value();
 
     // Check if a block was clicked
     for(auto & blockIt : blocks)

--- a/src/widgets/GraphView.cpp
+++ b/src/widgets/GraphView.cpp
@@ -279,15 +279,15 @@ void GraphView::computeGraph(ut64 entry)
     initVec(row_y, entryb.row_count, 0);
     initVec(this->col_edge_x, entryb.col_count + 1, 0);
     initVec(this->row_edge_y, entryb.row_count + 1, 0);
-    int x = 16;
+    int x = block_padding;
     for(int i = 0; i < entryb.col_count; i++)
     {
         this->col_edge_x[i] = x;
-        x += 8 * col_edge_count[i];
+        x += block_margin * col_edge_count[i];
         col_x[i] = x;
         x += col_width[i];
     }
-    int y = 16;
+    int y = block_padding;
     for(int i = 0; i < entryb.row_count; i++)
     {
         this->row_edge_y[i] = y;
@@ -296,14 +296,14 @@ void GraphView::computeGraph(ut64 entry)
         {
             row_edge_count[i] = 1;
         }
-        y += block_vertical_margin * row_edge_count[i];
+        y += block_margin * row_edge_count[i];
         row_y[i] = y;
         y += row_height[i];
     }
     this->col_edge_x[entryb.col_count] = x;
     this->row_edge_y[entryb.row_count] = y;
-    this->width = x + 16 + (8 * col_edge_count[entryb.col_count]);
-    this->height = y + 16 + (8 * row_edge_count[entryb.row_count]);
+    this->width = x + block_padding + (block_margin * col_edge_count[entryb.col_count]);
+    this->height = y + block_padding + (block_margin * row_edge_count[entryb.row_count]);
 
     //Compute node positions
     for(auto & blockIt : this->blocks)
@@ -312,10 +312,10 @@ void GraphView::computeGraph(ut64 entry)
         block.x = int(
                       (col_x[block.col] + col_width[block.col] + 4 * col_edge_count[block.col + 1]) - (block.width / 2));
         if((block.x + block.width) > (
-                    col_x[block.col] + col_width[block.col] + col_width[block.col + 1] + 8 * col_edge_count[
+                    col_x[block.col] + col_width[block.col] + col_width[block.col + 1] + block_margin * col_edge_count[
                         block.col + 1]))
         {
-            block.x = int((col_x[block.col] + col_width[block.col] + col_width[block.col + 1] + 8 * col_edge_count[
+            block.x = int((col_x[block.col] + col_width[block.col] + col_width[block.col + 1] + block_margin * col_edge_count[
                                block.col + 1]) - block.width);
         }
         block.y = row_y[block.row];
@@ -331,7 +331,7 @@ void GraphView::computeGraph(ut64 entry)
             auto start = edge.points[0];
             auto start_col = start.col;
             auto last_index = edge.start_index;
-            auto first_pt = QPoint(this->col_edge_x[start_col] + (8 * last_index) + 4,
+            auto first_pt = QPoint(this->col_edge_x[start_col] + (block_margin * last_index) + 4,
                                    block.y + block.height);
             auto last_pt = first_pt;
             QPolygonF pts;
@@ -346,9 +346,9 @@ void GraphView::computeGraph(ut64 entry)
                 QPoint new_pt;
                 // block_vertical_margin/2 gives the margin from block to the horizontal lines
                 if(start_col == end_col)
-                    new_pt = QPoint(last_pt.x(), this->row_edge_y[end_row] + (8 * last_index) + (block_vertical_margin/2));
+                    new_pt = QPoint(last_pt.x(), this->row_edge_y[end_row] + (block_margin * last_index) + (block_margin/2));
                 else
-                    new_pt = QPoint(this->col_edge_x[end_col] + (8 * last_index) + 4, last_pt.y());
+                    new_pt = QPoint(this->col_edge_x[end_col] + (block_margin * last_index) + 4, last_pt.y());
                 pts.push_back(new_pt);
                 last_pt = new_pt;
                 start_col = end_col;

--- a/src/widgets/GraphView.cpp
+++ b/src/widgets/GraphView.cpp
@@ -283,6 +283,11 @@ void GraphView::computeGraph(ut64 entry)
     for(int i = 0; i < entryb.row_count; i++)
     {
         this->row_edge_y[i] = y;
+        // TODO: The 1 when row_edge_count is 0 is not needed on the original.. not sure why it's required for us
+        if(!row_edge_count[i])
+        {
+            row_edge_count[i] = 1;
+        }
         y += block_vertical_margin * row_edge_count[i];
         row_y[i] = y;
         y += row_height[i];

--- a/src/widgets/GraphView.cpp
+++ b/src/widgets/GraphView.cpp
@@ -279,15 +279,15 @@ void GraphView::computeGraph(ut64 entry)
     initVec(row_y, entryb.row_count, 0);
     initVec(col_edge_x, entryb.col_count + 1, 0);
     initVec(row_edge_y, entryb.row_count + 1, 0);
-    int x = block_padding;
+    int x = block_horizontal_margin * 2;
     for(int i = 0; i < entryb.col_count; i++)
     {
         col_edge_x[i] = x;
-        x += block_margin * col_edge_count[i];
+        x += block_horizontal_margin * col_edge_count[i];
         col_x[i] = x;
         x += col_width[i];
     }
-    int y = block_padding;
+    int y = block_vertical_margin * 2;
     for(int i = 0; i < entryb.row_count; i++)
     {
         row_edge_y[i] = y;
@@ -296,26 +296,26 @@ void GraphView::computeGraph(ut64 entry)
         {
             row_edge_count[i] = 1;
         }
-        y += block_margin * row_edge_count[i];
+        y += block_vertical_margin * row_edge_count[i];
         row_y[i] = y;
         y += row_height[i];
     }
     col_edge_x[entryb.col_count] = x;
     row_edge_y[entryb.row_count] = y;
-    width = x + block_padding + (block_margin * col_edge_count[entryb.col_count]);
-    height = y + block_padding + (block_margin * row_edge_count[entryb.row_count]);
+    width = x + (block_horizontal_margin * 2) + (block_horizontal_margin * col_edge_count[entryb.col_count]);
+    height = y + (block_vertical_margin * 2) + (block_vertical_margin * row_edge_count[entryb.row_count]);
 
     //Compute node positions
     for(auto & blockIt : blocks)
     {
         GraphBlock &block = blockIt.second;
         block.x = int(
-                      (col_x[block.col] + col_width[block.col] + 4 * col_edge_count[block.col + 1]) - (block.width / 2));
+                      (col_x[block.col] + col_width[block.col] + ((block_horizontal_margin / 2) * col_edge_count[block.col + 1])) - (block.width / 2));
         if((block.x + block.width) > (
-                    col_x[block.col] + col_width[block.col] + col_width[block.col + 1] + block_margin * col_edge_count[
+                    col_x[block.col] + col_width[block.col] + col_width[block.col + 1] + block_horizontal_margin * col_edge_count[
                         block.col + 1]))
         {
-            block.x = int((col_x[block.col] + col_width[block.col] + col_width[block.col + 1] + block_margin * col_edge_count[
+            block.x = int((col_x[block.col] + col_width[block.col] + col_width[block.col + 1] + block_horizontal_margin * col_edge_count[
                                block.col + 1]) - block.width);
         }
         block.y = row_y[block.row];
@@ -331,7 +331,8 @@ void GraphView::computeGraph(ut64 entry)
             auto start = edge.points[0];
             auto start_col = start.col;
             auto last_index = edge.start_index;
-            auto first_pt = QPoint(col_edge_x[start_col] + (block_margin * last_index) + 4,
+            // This is the start point of the edge.
+            auto first_pt = QPoint(col_edge_x[start_col] + (block_horizontal_margin * last_index) + (block_horizontal_margin / 2),
                                    block.y + block.height);
             auto last_pt = first_pt;
             QPolygonF pts;
@@ -346,9 +347,9 @@ void GraphView::computeGraph(ut64 entry)
                 QPoint new_pt;
                 // block_vertical_margin/2 gives the margin from block to the horizontal lines
                 if(start_col == end_col)
-                    new_pt = QPoint(last_pt.x(), row_edge_y[end_row] + (block_margin * last_index) + (block_margin/2));
+                    new_pt = QPoint(last_pt.x(), row_edge_y[end_row] + (block_vertical_margin * last_index) + (block_vertical_margin/2));
                 else
-                    new_pt = QPoint(col_edge_x[end_col] + (block_margin * last_index) + 4, last_pt.y());
+                    new_pt = QPoint(col_edge_x[end_col] + (block_horizontal_margin * last_index) + (block_horizontal_margin/2), last_pt.y());
                 pts.push_back(new_pt);
                 last_pt = new_pt;
                 start_col = end_col;
@@ -368,11 +369,14 @@ void GraphView::computeGraph(ut64 entry)
                 pts.append(first_pt);
                 edge.arrow_start = pts;
             }
-            pts.clear();
-            pts.append(QPoint(new_pt.x() - 3, new_pt.y() - 6));
-            pts.append(QPoint(new_pt.x() + 3, new_pt.y() - 6));
-            pts.append(new_pt);
-            edge.arrow_end = pts;
+            if(ec.end_arrow)
+            {
+                pts.clear();
+                pts.append(QPoint(new_pt.x() - 3, new_pt.y() - 6));
+                pts.append(QPoint(new_pt.x() + 3, new_pt.y() - 6));
+                pts.append(new_pt);
+                edge.arrow_end = pts;
+            }
         }
     }
 
@@ -813,7 +817,7 @@ bool GraphView::checkPointClicked(QPointF &point, int x, int y, bool above_y)
     if((point.x() - half_target_size < x) &&
             (point.y() - (above_y ? (2 * half_target_size) : 0) < y) &&
             (x < point.x() + half_target_size) &&
-            (y < point.y() + (above_y ? 0 : (2 * half_target_size))))
+            (y < point.y() + (above_y ? 0 : (3 * half_target_size))))
     {
         return true;
     }

--- a/src/widgets/GraphView.cpp
+++ b/src/widgets/GraphView.cpp
@@ -53,6 +53,14 @@ void GraphView::blockClicked(GraphView::GraphBlock &block, QMouseEvent *event, Q
     qWarning() << "Block clicked not overridden!";
 }
 
+void GraphView::blockDoubleClicked(GraphView::GraphBlock &block, QMouseEvent *event, QPoint pos)
+{
+    Q_UNUSED(block);
+    Q_UNUSED(event);
+    Q_UNUSED(pos);
+    qWarning() << "Block double clicked not overridden!";
+}
+
 void GraphView::blockTransitionedTo(GraphView::GraphBlock *to)
 {
     Q_UNUSED(to);
@@ -434,7 +442,6 @@ void GraphView::paintEvent(QPaintEvent* event)
                 p.drawConvexPolygon(edge.arrow_end);
             }
         }
-
     }
 }
 
@@ -874,6 +881,26 @@ void GraphView::mouseMoveEvent(QMouseEvent* event)
         this->scroll_base_y = event->y();
         this->horizontalScrollBar()->setValue(this->horizontalScrollBar()->value() + x_delta);
         this->verticalScrollBar()->setValue(this->verticalScrollBar()->value() + y_delta);
+    }
+}
+
+void GraphView::mouseDoubleClickEvent(QMouseEvent *event)
+{
+    int x = (event->pos().x() / current_scale) + horizontalScrollBar()->value();
+    int y = (event->pos().y() / current_scale) + verticalScrollBar()->value();
+
+    // Check if a block was clicked
+    for(auto & blockIt : blocks)
+    {
+        GraphBlock &block = blockIt.second;
+
+        if((block.x <= x) && (block.y <= y) &&
+                (x <= block.x + block.width) & (y <= block.y + block.height))
+        {
+            QPoint pos = QPoint(x - block.x, y - block.y);
+            blockDoubleClicked(block, event, pos);
+            return;
+        }
     }
 }
 

--- a/src/widgets/GraphView.h
+++ b/src/widgets/GraphView.h
@@ -101,7 +101,10 @@ protected:
     std::unordered_map<ut64, GraphBlock> blocks;
     QColor backgroundColor = QColor(Qt::white);
     // The vertical margin between blocks
-    int block_vertical_margin = 32;
+    int block_margin = 32;
+
+    // Padding inside the block
+    int block_padding = 16;
 
     // Zoom data
     double current_scale = 1.0;

--- a/src/widgets/GraphView.h
+++ b/src/widgets/GraphView.h
@@ -109,6 +109,9 @@ protected:
     // Zoom data
     double current_scale = 1.0;
 
+    int unscrolled_render_offset_x = 0;
+    int unscrolled_render_offset_y = 0;
+
     void addBlock(GraphView::GraphBlock block);
     void setEntry(ut64 e);
     void computeGraph(ut64 entry);

--- a/src/widgets/GraphView.h
+++ b/src/widgets/GraphView.h
@@ -6,6 +6,7 @@
 #include <QWidget>
 #include <QAbstractScrollArea>
 #include <QScrollBar>
+#include <QElapsedTimer>
 
 #include <unordered_map>
 #include <unordered_set>
@@ -112,6 +113,7 @@ protected:
     // Callbacks that should be overridden
     virtual void drawBlock(QPainter & p, GraphView::GraphBlock &block);
     virtual void blockClicked(GraphView::GraphBlock &block, QMouseEvent *event, QPoint pos);
+    virtual void blockDoubleClicked(GraphView::GraphBlock &block, QMouseEvent *event, QPoint pos);
     virtual void blockTransitionedTo(GraphView::GraphBlock *to);
     virtual EdgeConfiguration edgeConfiguration(GraphView::GraphBlock &from, GraphView::GraphBlock *to);
 
@@ -158,6 +160,7 @@ private slots:
     void mousePressEvent(QMouseEvent *event) override;
     void mouseMoveEvent(QMouseEvent *event) override;
     void mouseReleaseEvent(QMouseEvent *event) override;
+    void mouseDoubleClickEvent(QMouseEvent *event) override;
 
 };
 

--- a/src/widgets/GraphView.h
+++ b/src/widgets/GraphView.h
@@ -20,8 +20,8 @@ class GraphView : public QAbstractScrollArea
 
     enum class LayoutType
     {
-        Wide,
         Medium,
+        Wide,
         Narrow,
     };
 public:
@@ -101,7 +101,8 @@ protected:
     std::unordered_map<ut64, GraphBlock> blocks;
     QColor backgroundColor = QColor(Qt::white);
     // The vertical margin between blocks
-    int block_margin = 32;
+    int block_vertical_margin = 32;
+    int block_horizontal_margin = 10;
 
     // Padding inside the block
     int block_padding = 16;


### PR DESCRIPTION
Fix some regressions of the new GraphView:
- DoubleClick jumping re-implemented
- Selection sometimes was off in huge blocks
- Sometimes the first block overlapped with the second one

Known issue:
- Graph does not center on start
- Graph does not center items without a scrollbar