### PR TITLE
change version to 1.1

### DIFF
--- a/src/cutter.h
+++ b/src/cutter.h
@@ -30,7 +30,7 @@
 #define __question(x) (QMessageBox::Yes==QMessageBox::question (this, "Alert", QString(x), QMessageBox::Yes| QMessageBox::No))
 
 #define APPNAME "Cutter"
-#define CUTTER_VERSION "1.0"
+#define CUTTER_VERSION "1.1"
 
 #define Core() (CutterCore::getInstance())
 


### PR DESCRIPTION
You [released](https://github.com/radareorg/cutter/releases/tag/v1.1)  cutter version 1.1 today (on 12/25/17) but the _about_ window shows v1.0 (see photo)
<img width="251" alt="capture d ecran 27" src="https://user-images.githubusercontent.com/8758978/34341720-c924b834-e99d-11e7-9704-5746d1a70b3e.png">

I updated `CUTTER_VERSION` macro to 1.1.