### PR TITLE
Cleanup Windows build scripts

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,43 +1,37 @@
-@echo off
+@ECHO off
+SETLOCAL ENABLEDELAYEDEXPANSION
 
-echo Setting path
-if "%OLDPATH%"=="" set OLDPATH=%PATH%
-if "%QT32PATH%"=="" set QT32PATH=C:\Qt\5.9.2\msvc2015
-if "%QT64PATH%"=="" set QT64PATH=C:\Qt\5.9.2\msvc2015_64
-if "%VSVARSALLPATH%"=="" set VSVARSALLPATH=C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat
+IF NOT DEFINED QT32PATH SET QT32PATH=C:\Qt\5.9.2\msvc2015
+IF NOT DEFINED QT64PATH SET QT64PATH=C:\Qt\5.9.2\msvc2015_64
+IF NOT DEFINED VSVARSALLPATH SET VSVARSALLPATH=C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat
 
-if "%1"=="32" (
-    set "PATH=%QT32PATH%\bin;%PATH%"
-    call "%VSVARSALLPATH%" x86
-    set MSBUILDPLATFORM=Win32
-) else if "%1"=="64" (
-    set "PATH=%QT64PATH%\bin;%PATH%"
-    call "%VSVARSALLPATH%" x64
-    set MSBUILDPLATFORM=x64
+if "%1" == "32" (
+    SET "PATH=%QT32PATH%\bin;%PATH%"
+    CALL "%VSVARSALLPATH%" x86
+    SET MSBUILDPLATFORM=Win32
+) else if "%1" == "64" (
+    SET "PATH=%QT64PATH%\bin;%PATH%"
+    CALL "%VSVARSALLPATH%" x64
+    SET MSBUILDPLATFORM=x64
 ) else (
-    echo Usage: build.bat 32/64
-    goto restorepath
+    ECHO Usage: %0 {32^|64}
+    EXIT /B
 )
 
-echo Preparing directory
-rmdir /s /q build%1
-mkdir build%1
-cd build%1
+ECHO Preparing directory
+RMDIR /S /Q build%1
+MKDIR build%1
+CD build%1
 
-echo Building cutter
+ECHO Building cutter
 qmake ..\src\cutter.pro -config release -tp vc
-if not %ERRORLEVEL%==0 exit
+IF !ERRORLEVEL! NEQ 0 EXIT /B
 msbuild /m cutter.vcxproj /p:Configuration=Release;Platform=%MSBUILDPLATFORM%
-if not %ERRORLEVEL%==0 exit
+IF !ERRORLEVEL! NEQ 0 EXIT /B
 
-echo Deploying cutter
-mkdir cutter%1
-move release\cutter.exe cutter%1\cutter.exe
-xcopy /s ..\dist%1 cutter%1\
+ECHO Deploying cutter
+MKDIR cutter%1
+MOVE release\cutter.exe cutter%1\cutter.exe
+XCOPY /S ..\dist%1 cutter%1\
 windeployqt cutter%1\cutter.exe
-cd ..
-
-:restorepath
-echo Restoring path
-set PATH=%OLDPATH%
-set OLDPATH=
+CD ..

--- a/prepare_r2.bat
+++ b/prepare_r2.bat
@@ -1,60 +1,68 @@
-@echo off
+@ECHO OFF
+SETLOCAL ENABLEDELAYEDEXPANSION
 
-if "%OLDPATH%"=="" set OLDPATH=%PATH%
-if "%PYTHON%"=="" set PYTHON=C:\Python36-x64
-if "%NINJA_URL%"=="" set NINJA_URL=https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-win.zip
-if "%VSVARSALLPATH%"=="" set VSVARSALLPATH=C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat
+SET BADARG=1
+FOR %%i IN ("" "32" "64") DO (IF "%1" == %%i SET BADARG=) 
+IF DEFINED BADARG (
+	ECHO Usage: %0 [32^|64]
+	EXIT /B
+)
+SET BITS=%1
 
-set "PYTHONHOME=%PYTHON%"
-set "PATH=%PYTHON%;%PATH%"
+FOR %%i IN (python.exe) DO (IF NOT DEFINED PYTHON SET PYTHON=%%~dp$PATH:i)
+
+IF NOT DEFINED PYTHON SET PYTHON=C:\Program Files\Python36
+IF NOT DEFINED NINJA_URL SET NINJA_URL=https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-win.zip
+IF NOT DEFINED VSVARSALLPATH SET VSVARSALLPATH=C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat
+
+IF NOT EXIST %PYTHON%\python.exe EXIT /B
+
+SET "PYTHONHOME=%PYTHON%"
+SET "PATH=%CD%;%PYTHON%;%PYTHON%\Scripts;%PATH%"
 
 git submodule update --init
 
-echo Downloading meson and ninja
-python -m pip install meson && COPY %PYTHON%\Scripts\meson.py meson.py
-if defined NINJA_URL ( powershell -Command wget %NINJA_URL% -OutFile ninja.zip && unzip -o ninja.zip -d .\ && del ninja.zip )
-
-
-IF NOT "%BITS%"=="32" (
-	set VARSALL=x64
-	set BI=64
-	call :BUILD
-)
-IF NOT "%BITS%"=="64" (
-	set VARSALL=x86
-	set BI=32
-	call :BUILD
+ECHO Downloading meson and ninja
+python -m pip install meson
+IF !ERRORLEVEL! NEQ 0 EXIT /B
+IF NOT EXIST ninja.exe (
+	powershell -Command wget %NINJA_URL% -OutFile ninja.zip && powershell -Command Expand-Archive .\ninja.zip -DestinationPath .\ && DEL ninja.zip
+	IF !ERRORLEVEL! NEQ 0 EXIT /B
 )
 
-GOTO :END
+IF NOT "%BITS%" == "32" (
+	SET VARSALL=x64
+	SET BI=64
+	CALL :BUILD
+	IF !ERRORLEVEL! NEQ 0 EXIT /B
+)
+IF NOT "%BITS%" == "64" (
+	SET VARSALL=x86
+	SET BI=32
+	CALL :BUILD
+	IF !ERRORLEVEL! NEQ 0 EXIT /B
+)
+
+ECHO Copying relevant files in cutter_win32
+IF "%BITS%" == "64" (
+	XCOPY /S /Y dist64\include\libr cutter_win32\radare2\include\libr\
+) ELSE (
+	XCOPY /S /Y dist32\include\libr cutter_win32\radare2\include\libr\
+)
+EXIT /B
 
 :BUILD
-echo Building radare2 (%VARSALL%)
-cd radare2
+ECHO Building radare2 (%VARSALL%)
+CD radare2
 git clean -xfd
-copy ..\ninja.exe .\
-copy ..\meson.py .\
-rmdir /s /q ..\dist%BI%
-call "%VSVARSALLPATH%" %VARSALL%
-%PYTHON%\python.exe sys\meson.py --release --shared --prefix="%CD%"
-if not %ERRORLEVEL%==0 exit
-call sys\meson_install.bat --with-static ..\dist%BI%
-copy /Y build\r_userconf.h ..\dist%BI%\include\libr\
-copy /Y build\r_version.h ..\dist%BI%\include\libr\
-copy /Y build\shlr\liblibr2sdb.a ..\dist%BI%\r_sdb.lib
-cd ..
-copy /Y dist%BI%\*.lib cutter_win32\radare2\lib%BI%\
+RMDIR /s /q ..\dist%BI%
+CALL "%VSVARSALLPATH%" %VARSALL%
+python sys\meson.py --release --shared --prefix="%CD%"
+IF !ERRORLEVEL! NEQ 0 EXIT /B 1
+CALL sys\meson_install.bat --with-static ..\dist%BI%
+COPY /Y build\r_userconf.h ..\dist%BI%\include\libr\
+COPY /Y build\r_version.h ..\dist%BI%\include\libr\
+COPY /Y build\shlr\liblibr2sdb.a ..\dist%BI%\r_sdb.lib
+CD ..
+COPY /Y dist%BI%\*.lib cutter_win32\radare2\lib%BI%\
 EXIT /B 0
-
-:END
-echo Copying relevant files in cutter_win32
-IF "%BITS%"=="64" (
-	xcopy /s /Y dist64\include\libr cutter_win32\radare2\include\libr\
-) ELSE (
-	xcopy /s /Y dist32\include\libr cutter_win32\radare2\include\libr\
-)
-del ninja.exe
-del meson.py
-
-set PATH=%OLDPATH%
-set OLDPATH=


### PR DESCRIPTION
Common:

- Uppercase style

- Using local env variables instead backup/restore

- Enabled delayed expansion for properly error handling 

prepare.bat:

- Added optional argument for building only 32/64 r2 version

- Using Python from PATH

- Changed default PYTHON variable value to default path for Python 3.6 x64

- Using meson and ninja via PATH

- Using PowerShell builtin unzip cmdlet