### PR TITLE
appveyor: Add python3 to PATH before building

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,12 +35,13 @@ environment:
       BACKEND: ninja
 
 install:
+  - cmd: set "PATH=%PYTHON%;%PATH%"
   # Artifacts
   - cmd: if defined MESON ( set "ARTIFACT_NAME=Cutter%BITS%_static" ) else ( set "ARTIFACT_NAME=Cutter%BITS%" )
   - cmd: if defined MESON ( set "ARTIFACT=dist%BITS%" ) else ( set "ARTIFACT=build%BITS%\cutter%BITS%" )
   # Meson specific
   - cmd: if defined MESON ( if "%ARCH%" == "x64" ( set "PATH=%QT64PATH%\bin;%PATH%" ) else ( set "PATH=%QT32PATH%\bin;%PATH%" ) )
-  - cmd: if defined MESON ( %PYTHON%\python.exe -m pip install meson )
+  - cmd: if defined MESON ( python -m pip install meson )
   - cmd: if defined MESON ( if "%BACKEND%" == "ninja" ( powershell -Command wget %NINJA_URL% -OutFile ninja.zip && unzip ninja.zip ) )
 
 before_build:
@@ -50,7 +51,7 @@ before_build:
 # Build config
 build_script:
   - cmd: if defined QMAKE ( build.bat %BITS% )
-  - cmd: if defined MESON ( call "%VSVARSALLPATH%" %ARCH% && %PYTHON%\python.exe meson.py --dist=%ARTIFACT% --backend=%BACKEND% )
+  - cmd: if defined MESON ( call "%VSVARSALLPATH%" %ARCH% && python meson.py --dist=%ARTIFACT% --backend=%BACKEND% )
 
 # Tests
 test: off


### PR DESCRIPTION
Issue: broken r2 version info for Appveyor meson build.
Reason: "python" is resolved as python2 that hasn't os.readlink() function.