### PR TITLE
Sort numbers correctly and align right

### DIFF
--- a/src/widgets/FunctionsWidget.cpp
+++ b/src/widgets/FunctionsWidget.cpp
@@ -134,7 +134,7 @@ QVariant FunctionModel::data(const QModelIndex &index, int role) const
             case NameColumn:
                 return function.name;
             case SizeColumn:
-                return RSizeString(function.size);
+                return function.size;
             case OffsetColumn:
                 return RAddressString(function.offset);
             default:
@@ -152,6 +152,11 @@ QVariant FunctionModel::data(const QModelIndex &index, int role) const
         if (currentIndex == function_index)
             return highlightFont;
         return defaultFont;
+
+    case Qt::TextAlignmentRole:
+        if (index.column() == 1)
+            return static_cast<int>(Qt::AlignRight | Qt::AlignVCenter);
+        return static_cast<int>(Qt::AlignLeft | Qt::AlignVCenter);
 
     case Qt::ToolTipRole:
     {

--- a/src/widgets/SectionsWidget.cpp
+++ b/src/widgets/SectionsWidget.cpp
@@ -88,7 +88,8 @@ void SectionsWidget::fillSections(int row, const SectionDescription &section)
 
     QTreeWidgetItem *tempItem = new QTreeWidgetItem();
     tempItem->setText(0, section.name);
-    tempItem->setText(1, RSizeString(section.size));
+    tempItem->setData(1, Qt::DisplayRole, section.size);
+    tempItem->setTextAlignment(1, Qt::AlignRight | Qt::AlignVCenter);
     tempItem->setText(2, RAddressString(section.vaddr));
     tempItem->setText(3, RAddressString(section.vaddr + section.vsize));
     tempItem->setData(0, Qt::DecorationRole, colors[row % colors.size()]);


### PR DESCRIPTION
The size columns in FunctionsWidget and SectionsWidget display numbers left aligned, which makes comparison hard. Also, when sorting by these columns, the ASCII values are compared instead of the numeric values. This commit addresses both issues.