### PR TITLE
Fixed sorting in Strings widget

### DIFF
--- a/src/widgets/StringsWidget.cpp
+++ b/src/widgets/StringsWidget.cpp
@@ -116,9 +116,14 @@ bool StringsSortFilterProxyModel::lessThan(const QModelIndex &left, const QModel
         case StringsModel::OFFSET:
             if (left_str.vaddr != right_str.vaddr)
                 return left_str.vaddr < right_str.vaddr;
-            // fallthrough
-        case StringsModel::STRING:
+        case StringsModel::STRING: // sort by string
             return left_str.string < right_str.string;
+        case StringsModel::TYPE: // sort by type
+            return left_str.type < right_str.type;
+        case StringsModel::SIZE: // sort by size
+            return left_str.size < right_str.size;
+        case StringsModel::LENGTH: // sort by length
+            return left_str.length < right_str.length;
         default:
             break;
     }


### PR DESCRIPTION
Sorting by string, type, size or length now works when selecting the corresponding column.