### PR TITLE
Improve 'About' plugins window

### DIFF
--- a/src/Cutter.cpp
+++ b/src/Cutter.cpp
@@ -950,13 +950,27 @@ QList<RCorePluginDescription> CutterCore::getRCorePluginDescriptions()
     return ret;
 }
 
-QStringList CutterCore::getRAsmPlugins()
+QList<RAsmPluginDescription> CutterCore::getRAsmPluginDescriptions()
 {
-    QStringList ret;
+    CORE_LOCK();
+    RListIter *it;
+    QList<RAsmPluginDescription> ret;
 
-    QJsonArray plugins = cmdj("evj asm.arch").array()[0].toObject()["options"].toArray();
-    for(QJsonValueRef pluginValue : plugins)
-        ret << pluginValue.toString();
+    RAsmPlugin *ap;
+    CutterRListForeach(core_->assembler->plugins, it, RAsmPlugin, ap)
+    {
+        RAsmPluginDescription plugin;
+
+        plugin.name = ap->name;
+        plugin.architecture = ap->arch;
+        plugin.author = ap->author;
+        plugin.version = ap->version;
+        plugin.cpus = ap->cpus;
+        plugin.description = ap->desc;
+        plugin.license = ap->license;
+
+        ret << plugin;
+    }
 
     return ret;
 }

--- a/src/Cutter.h
+++ b/src/Cutter.h
@@ -200,6 +200,17 @@ struct RCorePluginDescription
     QString description;
 };
 
+struct RAsmPluginDescription
+{
+    QString name;
+    QString architecture;
+    QString author;
+    QString version;
+    QString cpus;
+    QString description;
+    QString license;
+};
+
 struct DisassemblyLine
 {
     RVA offset;
@@ -257,6 +268,7 @@ Q_DECLARE_METATYPE(EntrypointDescription)
 Q_DECLARE_METATYPE(RBinPluginDescription)
 Q_DECLARE_METATYPE(RIOPluginDescription)
 Q_DECLARE_METATYPE(RCorePluginDescription)
+Q_DECLARE_METATYPE(RAsmPluginDescription)
 Q_DECLARE_METATYPE(ClassMethodDescription)
 Q_DECLARE_METATYPE(ClassFieldDescription)
 Q_DECLARE_METATYPE(ClassDescription)
@@ -389,7 +401,7 @@ public:
     QList<RBinPluginDescription> getRBinPluginDescriptions(const QString &type = nullptr);
     QList<RIOPluginDescription> getRIOPluginDescriptions();
     QList<RCorePluginDescription> getRCorePluginDescriptions();
-    QStringList getRAsmPlugins();
+    QList<RAsmPluginDescription> getRAsmPluginDescriptions();
 
     QList<FunctionDescription> getAllFunctions();
     QList<ImportDescription> getAllImports();

--- a/src/dialogs/R2PluginsDialog.cpp
+++ b/src/dialogs/R2PluginsDialog.cpp
@@ -41,12 +41,19 @@ R2PluginsDialog::R2PluginsDialog(QWidget *parent) :
     }
     qhelpers::adjustColumns(ui->RCoreTreeWidget, 0);
 
-    for(auto plugin : Core()->getRAsmPlugins())
+    for(auto plugin : Core()->getRAsmPluginDescriptions())
     {
         QTreeWidgetItem* item = new QTreeWidgetItem();
-        item->setText(0, plugin);
+        item->setText(0, plugin.name);
+        item->setText(1, plugin.architecture);
+        item->setText(2, plugin.cpus);
+        item->setText(3, plugin.version);
+        item->setText(4, plugin.description);
+        item->setText(5, plugin.license);
+        item->setText(6, plugin.author);
         ui->RAsmTreeWidget->addTopLevelItem(item);
     }
+    qhelpers::adjustColumns(ui->RAsmTreeWidget, 0);
 }
 
 R2PluginsDialog::~R2PluginsDialog()

--- a/src/dialogs/R2PluginsDialog.ui
+++ b/src/dialogs/R2PluginsDialog.ui
@@ -5,146 +5,178 @@
   <property name="windowTitle">
    <string>radare2 plugin information</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="1" column="1">
-    <widget class="QTreeWidget" name="RCoreTreeWidget">
-     <column>
-      <property name="text">
-       <string>Name</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Description</string>
-      </property>
-     </column>
+  <layout class="QVBoxLayout" name="verticalLayout_6">
+   <item>
+    <widget class="QTabWidget" name="tabWidget">
+     <widget class="QWidget" name="RBinTab">
+      <attribute name="title">
+       <string>RBin</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <widget class="QLabel" name="RBinLabel">
+         <property name="text">
+          <string>RBin plugins</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QTreeWidget" name="RBinTreeWidget">
+         <property name="sortingEnabled">
+          <bool>true</bool>
+         </property>
+         <column>
+          <property name="text">
+           <string>Name</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Description</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>License</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Type</string>
+          </property>
+         </column>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="RIOTab">
+      <attribute name="title">
+       <string>RIO</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <widget class="QLabel" name="RIOLabel">
+         <property name="text">
+          <string>RIO plugins</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QTreeWidget" name="RIOTreeWidget">
+         <column>
+          <property name="text">
+           <string>Name</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Description</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>License</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Permissions</string>
+          </property>
+         </column>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="RCoreTab">
+      <attribute name="title">
+       <string>RCore</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_4">
+       <item>
+        <widget class="QLabel" name="RCoreLabel">
+         <property name="text">
+          <string>RCore plugins</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QTreeWidget" name="RCoreTreeWidget">
+         <column>
+          <property name="text">
+           <string>Name</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Description</string>
+          </property>
+         </column>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="RAsmTab">
+      <attribute name="title">
+       <string>RAsm</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_5">
+       <item>
+        <widget class="QLabel" name="RAsmLabel">
+         <property name="text">
+          <string>RAsm plugins</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QTreeWidget" name="RAsmTreeWidget">
+         <column>
+          <property name="text">
+           <string>Name</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Architecture</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>CPU's</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Version</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Description</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>License</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Author</string>
+          </property>
+         </column>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
-   <item row="4" column="0" colspan="2">
+   <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
       <set>QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="RIOLabel">
-     <property name="text">
-      <string>RIO plugins</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QLabel" name="RAsmLabel">
-     <property name="text">
-      <string>RAsm plugins</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <widget class="QTreeWidget" name="RAsmTreeWidget">
-     <column>
-      <property name="text">
-       <string>Name</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Architecture</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>CPU's</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Version</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Description</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>License</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Author</string>
-      </property>
-     </column>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QTreeWidget" name="RBinTreeWidget">
-     <property name="sortingEnabled">
-      <bool>true</bool>
-     </property>
-     <column>
-      <property name="text">
-       <string>Name</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Description</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>License</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Type</string>
-      </property>
-     </column>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QTreeWidget" name="RIOTreeWidget">
-     <column>
-      <property name="text">
-       <string>Name</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Description</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>License</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Permissions</string>
-      </property>
-     </column>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QLabel" name="RCoreLabel">
-     <property name="text">
-      <string>RCore plugins</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="RBinLabel">
-     <property name="text">
-      <string>RBin plugins</string>
      </property>
     </widget>
    </item>

--- a/src/dialogs/R2PluginsDialog.ui
+++ b/src/dialogs/R2PluginsDialog.ui
@@ -51,6 +51,36 @@
        <string>Name</string>
       </property>
      </column>
+     <column>
+      <property name="text">
+       <string>Architecture</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>CPU's</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Version</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Description</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>License</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Author</string>
+      </property>
+     </column>
     </widget>
    </item>
    <item row="1" column="0">


### PR DESCRIPTION
Fixes #377 .

It appears Cutter already can list RAsm plugins, but via the library and not JSON. I've used this method instead.

Also organized the plugins window into tabs to remove clutter.