### PR TITLE
build.sh: check for existence of qmake, don't call it with wrong opts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -21,8 +21,8 @@ if [ $? = 0 ]; then
 fi
 
 # Check if qmake is available
-qmake --help >/dev/null 2>&1
-if [ $? != 0 ]; then
+qmakepath=$(which qmake)
+if [ -z "$qmakepath" ]; then
 	echo "You need qmake to build Cutter."
 	echo "Please make sure qmake is in your PATH environment variable."
 	exit 1


### PR DESCRIPTION
This fixes #387.

Formerly, `qmake --help` was called, and the return value was checked
for being 0, but `--help` is not a valid option in any of my qmakes.

`-help` would be correct, but even with that, qmake returns a non-zero
value.

So, simply replaced that with a check for the existence of the qmake
executable.