### PR TITLE
build.sh: when asking for user confirmation, accept y, Y, default

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -33,7 +33,7 @@ if [ $BUILDR2 -eq 1 ]; then
 	answer="Y"
 	echo -n "A (new?) version of radare2 will be installed. Do you agree? [Y/n] "
 	read answer
-	if [ "$answer" = "Y" ]; then
+	if [ -z "$answer" -o "$answer" = "Y" -o "$answer" = "y" ]; then
 		git submodule init && git submodule update
 		cd radare2 || exit 1
 		./sys/install.sh


### PR DESCRIPTION
Old behaviour was only to accept "Y". The prompt suggested, however,
that "y" was the default behaviour, so accepting "return" as
confirmation of that choice is the sane behaviour with least user
experience disruption.