### PR TITLE
SectionsWidget - remove unnecessary dot checking

### DIFF
--- a/src/widgets/SectionsWidget.cpp
+++ b/src/widgets/SectionsWidget.cpp
@@ -30,9 +30,6 @@ void SectionsWidget::refreshSections()
     int row = 0;
     for (auto section : CutterCore::getInstance()->getAllSections())
     {
-        if (!section.name.contains("."))
-            continue;
-
         fillSections(row++, section);
     }
 


### PR DESCRIPTION
Some executable's section name don't have dot (such as UPX packed file)