### PR TITLE
Small refactor for the widgets of Cutter

### DIFF
--- a/src/Cutter.pro
+++ b/src/Cutter.pro
@@ -142,7 +142,7 @@ SOURCES += \
     utils/PythonAPI.cpp \
     utils/NestedIPyKernel.cpp \
     dialogs/R2PluginsDialog.cpp \
-    widgets/CutterWidget.cpp \
+    widgets/CutterDockWidget.cpp \
     widgets/GraphWidget.cpp
 
 HEADERS  += \
@@ -211,7 +211,7 @@ HEADERS  += \
     utils/PythonAPI.h \
     utils/NestedIPyKernel.h \
     dialogs/R2PluginsDialog.h \
-    widgets/CutterWidget.h \
+    widgets/CutterDockWidget.h \
     widgets/GraphWidget.h
 
 FORMS    += \

--- a/src/Cutter.pro
+++ b/src/Cutter.pro
@@ -141,7 +141,9 @@ SOURCES += \
     widgets/JupyterWidget.cpp \
     utils/PythonAPI.cpp \
     utils/NestedIPyKernel.cpp \
-    dialogs/R2PluginsDialog.cpp
+    dialogs/R2PluginsDialog.cpp \
+    widgets/CutterWidget.cpp \
+    widgets/GraphWidget.cpp
 
 HEADERS  += \
     Cutter.h \
@@ -208,7 +210,9 @@ HEADERS  += \
     widgets/JupyterWidget.h \
     utils/PythonAPI.h \
     utils/NestedIPyKernel.h \
-    dialogs/R2PluginsDialog.h
+    dialogs/R2PluginsDialog.h \
+    widgets/CutterWidget.h \
+    widgets/GraphWidget.h
 
 FORMS    += \
     dialogs/AboutDialog.ui \

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -91,6 +91,9 @@ public:
     void addDebugOutput(const QString &msg);
     void refreshOmniBar(const QStringList &flags);
 
+    void addToDockWidgetList(QDockWidget *dockWidget);
+    void addDockWidgetAction(QDockWidget *dockWidget, QAction *action);
+
 public slots:
 
     void refreshAll();
@@ -198,14 +201,14 @@ private:
     JupyterWidget      *jupyterDock = nullptr;
 #endif
 
-    void toggleDockWidget(QDockWidget *dock_widget, bool show);
-
     void resetToDefaultLayout();
 
     void restoreDocks();
     void hideAllDocks();
     void showDefaultDocks();
     void updateDockActionsChecked();
+
+    void toggleDockWidget(QDockWidget *dock_widget, bool show);
 
 public:
     QString getFilename() const         { return filename; }

--- a/src/widgets/ClassesWidget.cpp
+++ b/src/widgets/ClassesWidget.cpp
@@ -2,6 +2,7 @@
 #include <QList>
 
 #include "ClassesWidget.h"
+#include "MainWindow.h"
 #include "ui_ClassesWidget.h"
 #include "utils/Helpers.h"
 
@@ -242,8 +243,8 @@ bool ClassesSortFilterProxyModel::lessThan(const QModelIndex &left, const QModel
 
 
 
-ClassesWidget::ClassesWidget(QWidget *parent) :
-    QDockWidget(parent),
+ClassesWidget::ClassesWidget(MainWindow *main, QAction *action) :
+    CutterWidget(main, action),
     ui(new Ui::ClassesWidget)
 {
     ui->setupUi(this);

--- a/src/widgets/ClassesWidget.cpp
+++ b/src/widgets/ClassesWidget.cpp
@@ -244,7 +244,7 @@ bool ClassesSortFilterProxyModel::lessThan(const QModelIndex &left, const QModel
 
 
 ClassesWidget::ClassesWidget(MainWindow *main, QAction *action) :
-    CutterWidget(main, action),
+    CutterDockWidget(main, action),
     ui(new Ui::ClassesWidget)
 {
     ui->setupUi(this);

--- a/src/widgets/ClassesWidget.h
+++ b/src/widgets/ClassesWidget.h
@@ -4,10 +4,10 @@
 #include <memory>
 
 #include "Cutter.h"
+#include "CutterWidget.h"
 
 #include <QAbstractListModel>
 #include <QSortFilterProxyModel>
-#include <QDockWidget>
 
 namespace Ui
 {
@@ -16,6 +16,7 @@ namespace Ui
 
 class QTreeWidget;
 class QTreeWidgetItem;
+class MainWindow;
 
 
 class ClassesModel: public QAbstractItemModel
@@ -65,12 +66,12 @@ protected:
 
 
 
-class ClassesWidget : public QDockWidget
+class ClassesWidget : public CutterWidget
 {
     Q_OBJECT
 
 public:
-    explicit ClassesWidget(QWidget *parent = nullptr);
+    explicit ClassesWidget(MainWindow *main, QAction *action = nullptr);
     ~ClassesWidget();
 
 private slots:

--- a/src/widgets/ClassesWidget.h
+++ b/src/widgets/ClassesWidget.h
@@ -4,7 +4,7 @@
 #include <memory>
 
 #include "Cutter.h"
-#include "CutterWidget.h"
+#include "CutterDockWidget.h"
 
 #include <QAbstractListModel>
 #include <QSortFilterProxyModel>
@@ -66,7 +66,7 @@ protected:
 
 
 
-class ClassesWidget : public CutterWidget
+class ClassesWidget : public CutterDockWidget
 {
     Q_OBJECT
 

--- a/src/widgets/CommentsWidget.cpp
+++ b/src/widgets/CommentsWidget.cpp
@@ -8,7 +8,7 @@
 #include "utils/Helpers.h"
 
 CommentsWidget::CommentsWidget(MainWindow *main, QAction *action) :
-    CutterWidget(main, action),
+    CutterDockWidget(main, action),
     ui(new Ui::CommentsWidget),
     main(main)
 {

--- a/src/widgets/CommentsWidget.cpp
+++ b/src/widgets/CommentsWidget.cpp
@@ -7,8 +7,8 @@
 #include "MainWindow.h"
 #include "utils/Helpers.h"
 
-CommentsWidget::CommentsWidget(MainWindow *main, QWidget *parent) :
-    QDockWidget(parent),
+CommentsWidget::CommentsWidget(MainWindow *main, QAction *action) :
+    CutterWidget(main, action),
     ui(new Ui::CommentsWidget),
     main(main)
 {

--- a/src/widgets/CommentsWidget.h
+++ b/src/widgets/CommentsWidget.h
@@ -3,7 +3,7 @@
 
 #include <memory>
 
-#include <QDockWidget>
+#include "CutterWidget.h"
 
 class MainWindow;
 class QTreeWidgetItem;
@@ -13,12 +13,12 @@ namespace Ui
     class CommentsWidget;
 }
 
-class CommentsWidget : public QDockWidget
+class CommentsWidget : public CutterWidget
 {
     Q_OBJECT
 
 public:
-    explicit CommentsWidget(MainWindow *main, QWidget *parent = 0);
+    explicit CommentsWidget(MainWindow *main, QAction *action = nullptr);
     ~CommentsWidget();
 
 protected:

--- a/src/widgets/CommentsWidget.h
+++ b/src/widgets/CommentsWidget.h
@@ -3,7 +3,7 @@
 
 #include <memory>
 
-#include "CutterWidget.h"
+#include "CutterDockWidget.h"
 
 class MainWindow;
 class QTreeWidgetItem;
@@ -13,7 +13,7 @@ namespace Ui
     class CommentsWidget;
 }
 
-class CommentsWidget : public CutterWidget
+class CommentsWidget : public CutterDockWidget
 {
     Q_OBJECT
 

--- a/src/widgets/ConsoleWidget.cpp
+++ b/src/widgets/ConsoleWidget.cpp
@@ -91,7 +91,7 @@ static bool isForbidden(const QString &input)
 }
 
 ConsoleWidget::ConsoleWidget(MainWindow *main, QAction *action) :
-    CutterWidget(main, action),
+    CutterDockWidget(main, action),
     ui(new Ui::ConsoleWidget),
     debugOutputEnabled(true),
     maxHistoryEntries(100),

--- a/src/widgets/ConsoleWidget.cpp
+++ b/src/widgets/ConsoleWidget.cpp
@@ -90,8 +90,8 @@ static bool isForbidden(const QString &input)
     return false;
 }
 
-ConsoleWidget::ConsoleWidget(QWidget *parent, Qt::WindowFlags flags) :
-    QDockWidget(parent, flags),
+ConsoleWidget::ConsoleWidget(MainWindow *main, QAction *action) :
+    CutterWidget(main, action),
     ui(new Ui::ConsoleWidget),
     debugOutputEnabled(true),
     maxHistoryEntries(100),
@@ -110,9 +110,9 @@ ConsoleWidget::ConsoleWidget(QWidget *parent, Qt::WindowFlags flags) :
     QTextDocument *console_docu = ui->outputTextEdit->document();
     console_docu->setDocumentMargin(10);
 
-    QAction *action = new QAction(tr("Clear Output"), ui->outputTextEdit);
-    connect(action, SIGNAL(triggered(bool)), ui->outputTextEdit, SLOT(clear()));
-    actions.append(action);
+    QAction *actionClear = new QAction(tr("Clear Output"), ui->outputTextEdit);
+    connect(actionClear, SIGNAL(triggered(bool)), ui->outputTextEdit, SLOT(clear()));
+    actions.append(actionClear);
 
     // Completion
     QCompleter *completer = new QCompleter(radareArgs, this);
@@ -142,12 +142,6 @@ ConsoleWidget::ConsoleWidget(QWidget *parent, Qt::WindowFlags flags) :
     historyOnDown->setContext(Qt::WidgetShortcut);
 
     connect(Config(), SIGNAL(fontsUpdated()), this, SLOT(setupFont()));
-}
-
-ConsoleWidget::ConsoleWidget(const QString &title, QWidget *parent, Qt::WindowFlags flags)
-        : ConsoleWidget(parent, flags)
-{
-    setWindowTitle(title);
 }
 
 ConsoleWidget::~ConsoleWidget() {}

--- a/src/widgets/ConsoleWidget.h
+++ b/src/widgets/ConsoleWidget.h
@@ -3,7 +3,7 @@
 
 #include <memory>
 #include "MainWindow.h"
-#include "CutterWidget.h"
+#include "CutterDockWidget.h"
 
 namespace Ui
 {
@@ -11,7 +11,7 @@ namespace Ui
 }
 
 
-class ConsoleWidget : public CutterWidget
+class ConsoleWidget : public CutterDockWidget
 {
     Q_OBJECT
 

--- a/src/widgets/ConsoleWidget.h
+++ b/src/widgets/ConsoleWidget.h
@@ -1,9 +1,9 @@
 #ifndef CONSOLEWIDGET_H
 #define CONSOLEWIDGET_H
 
-#include <QWidget>
 #include <memory>
 #include "MainWindow.h"
+#include "CutterWidget.h"
 
 namespace Ui
 {
@@ -11,13 +11,12 @@ namespace Ui
 }
 
 
-class ConsoleWidget : public QDockWidget
+class ConsoleWidget : public CutterWidget
 {
     Q_OBJECT
 
 public:
-    explicit ConsoleWidget(const QString &title, QWidget *parent = nullptr, Qt::WindowFlags flags = 0);
-    explicit ConsoleWidget(QWidget *parent = nullptr, Qt::WindowFlags flags = 0);
+    explicit ConsoleWidget(MainWindow *main, QAction *action = nullptr);
 
     ~ConsoleWidget();
 

--- a/src/widgets/CutterDockWidget.cpp
+++ b/src/widgets/CutterDockWidget.cpp
@@ -1,20 +1,20 @@
-#include "CutterWidget.h"
+#include "CutterDockWidget.h"
 #include "MainWindow.h"
 
 
-CutterWidget::CutterWidget(MainWindow *main, QAction *action) :
+CutterDockWidget::CutterDockWidget(MainWindow *main, QAction *action) :
     QDockWidget(main),
     action(action)
 {
     main->addToDockWidgetList(this);
     if (action) {
         main->addDockWidgetAction(this, action);
-        connect(action, &QAction::triggered, this, &CutterWidget::toggleDockWidget);
+        connect(action, &QAction::triggered, this, &CutterDockWidget::toggleDockWidget);
     }
 }
 
 
-void CutterWidget::toggleDockWidget(bool show)
+void CutterDockWidget::toggleDockWidget(bool show)
 {
     if (!show)
     {
@@ -27,11 +27,11 @@ void CutterWidget::toggleDockWidget(bool show)
     }
 }
 
-void CutterWidget::closeEvent(QCloseEvent * event) {
+void CutterDockWidget::closeEvent(QCloseEvent * event) {
     if (action) {
         this->action->setChecked(false);
     }
     QDockWidget::closeEvent(event);
 }
 
-CutterWidget::~CutterWidget() {}
+CutterDockWidget::~CutterDockWidget() {}

--- a/src/widgets/CutterDockWidget.h
+++ b/src/widgets/CutterDockWidget.h
@@ -5,14 +5,14 @@
 
 class MainWindow;
 
-class CutterWidget : public QDockWidget
+class CutterDockWidget : public QDockWidget
 {
 
     Q_OBJECT
 
 public:
-    explicit CutterWidget(MainWindow *main, QAction *action = nullptr);
-    ~CutterWidget();
+    explicit CutterDockWidget(MainWindow *main, QAction *action = nullptr);
+    ~CutterDockWidget();
 public slots:
     void toggleDockWidget(bool show);
 

--- a/src/widgets/CutterWidget.cpp
+++ b/src/widgets/CutterWidget.cpp
@@ -1,0 +1,37 @@
+#include "CutterWidget.h"
+#include "MainWindow.h"
+
+
+CutterWidget::CutterWidget(MainWindow *main, QAction *action) :
+    QDockWidget(main),
+    action(action)
+{
+    main->addToDockWidgetList(this);
+    if (action) {
+        main->addDockWidgetAction(this, action);
+        connect(action, &QAction::triggered, this, &CutterWidget::toggleDockWidget);
+    }
+}
+
+
+void CutterWidget::toggleDockWidget(bool show)
+{
+    if (!show)
+    {
+        this->close();
+    }
+    else
+    {
+        this->show();
+        this->raise();
+    }
+}
+
+void CutterWidget::closeEvent(QCloseEvent * event) {
+    if (action) {
+        this->action->setChecked(false);
+    }
+    QDockWidget::closeEvent(event);
+}
+
+CutterWidget::~CutterWidget() {}

--- a/src/widgets/CutterWidget.h
+++ b/src/widgets/CutterWidget.h
@@ -1,0 +1,27 @@
+#ifndef CUTTERWIDGET_H
+#define CUTTERWIDGET_H
+
+#include <QDockWidget>
+
+class MainWindow;
+
+class CutterWidget : public QDockWidget
+{
+
+    Q_OBJECT
+
+public:
+    explicit CutterWidget(MainWindow *main, QAction *action = nullptr);
+    ~CutterWidget();
+public slots:
+    void toggleDockWidget(bool show);
+
+
+private:
+    QAction *action;
+
+protected:
+    void closeEvent(QCloseEvent * event) override;
+};
+
+#endif // CUTTERWIDGET_H

--- a/src/widgets/Dashboard.cpp
+++ b/src/widgets/Dashboard.cpp
@@ -13,7 +13,7 @@
 #include <QLayoutItem>
 
 Dashboard::Dashboard(MainWindow *main, QAction *action) :
-    CutterWidget(main, action),
+    CutterDockWidget(main, action),
     ui(new Ui::Dashboard)
 {
     ui->setupUi(this);

--- a/src/widgets/Dashboard.cpp
+++ b/src/widgets/Dashboard.cpp
@@ -12,11 +12,9 @@
 #include <QFile>
 #include <QLayoutItem>
 
-
-Dashboard::Dashboard(MainWindow *main, QWidget *parent) :
-    QDockWidget(parent),
-    ui(new Ui::Dashboard),
-    main(main)
+Dashboard::Dashboard(MainWindow *main, QAction *action) :
+    CutterWidget(main, action),
+    ui(new Ui::Dashboard)
 {
     ui->setupUi(this);
 

--- a/src/widgets/Dashboard.h
+++ b/src/widgets/Dashboard.h
@@ -2,8 +2,7 @@
 #define DASHBOARD_H
 
 #include <memory>
-
-#include <QDockWidget>
+#include "CutterWidget.h"
 
 class MainWindow;
 
@@ -12,12 +11,12 @@ namespace Ui
     class Dashboard;
 }
 
-class Dashboard : public QDockWidget
+class Dashboard : public CutterWidget
 {
     Q_OBJECT
 
 public:
-    explicit Dashboard(MainWindow *main, QWidget *parent = 0);
+    explicit Dashboard(MainWindow *main, QAction *action = nullptr);
     ~Dashboard();
 
 private slots:
@@ -25,7 +24,6 @@ private slots:
 
 private:
     std::unique_ptr<Ui::Dashboard>   ui;
-    MainWindow      *main;
 };
 
 #endif // DASHBOARD_H

--- a/src/widgets/Dashboard.h
+++ b/src/widgets/Dashboard.h
@@ -2,7 +2,7 @@
 #define DASHBOARD_H
 
 #include <memory>
-#include "CutterWidget.h"
+#include "CutterDockWidget.h"
 
 class MainWindow;
 
@@ -11,7 +11,7 @@ namespace Ui
     class Dashboard;
 }
 
-class Dashboard : public CutterWidget
+class Dashboard : public CutterDockWidget
 {
     Q_OBJECT
 

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -38,7 +38,7 @@ static DisassemblyTextBlockUserData *getUserData(const QTextBlock &block)
 
 
 DisassemblyWidget::DisassemblyWidget(MainWindow *main, QAction *action)
-    :   CutterWidget(main, action)
+    :   CutterDockWidget(main, action)
     ,   mCtxMenu(new DisassemblyContextMenu(this))
     ,   mDisasScrollArea(new DisassemblyScrollArea(this))
     ,   mDisasTextEdit(new DisassemblyTextEdit(this))

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -37,8 +37,8 @@ static DisassemblyTextBlockUserData *getUserData(const QTextBlock &block)
 }
 
 
-DisassemblyWidget::DisassemblyWidget(QWidget *parent)
-    :   QDockWidget(parent)
+DisassemblyWidget::DisassemblyWidget(MainWindow *main, QAction *action)
+    :   CutterWidget(main, action)
     ,   mCtxMenu(new DisassemblyContextMenu(this))
     ,   mDisasScrollArea(new DisassemblyScrollArea(this))
     ,   mDisasTextEdit(new DisassemblyTextEdit(this))

--- a/src/widgets/DisassemblyWidget.h
+++ b/src/widgets/DisassemblyWidget.h
@@ -2,7 +2,7 @@
 #define DISASSEMBLYWIDGET_H
 
 #include "Cutter.h"
-#include <QDockWidget>
+#include "CutterWidget.h"
 #include <QTextEdit>
 #include <QPlainTextEdit>
 #include <QShortcut>
@@ -12,11 +12,11 @@ class DisassemblyTextEdit;
 class DisassemblyScrollArea;
 class DisassemblyContextMenu;
 
-class DisassemblyWidget : public QDockWidget
+class DisassemblyWidget : public CutterWidget
 {
     Q_OBJECT
 public:
-    explicit DisassemblyWidget(QWidget *parent = nullptr);
+    explicit DisassemblyWidget(MainWindow *main, QAction *action = nullptr);
     QWidget* getTextWidget();
 
 public slots:

--- a/src/widgets/DisassemblyWidget.h
+++ b/src/widgets/DisassemblyWidget.h
@@ -2,7 +2,7 @@
 #define DISASSEMBLYWIDGET_H
 
 #include "Cutter.h"
-#include "CutterWidget.h"
+#include "CutterDockWidget.h"
 #include <QTextEdit>
 #include <QPlainTextEdit>
 #include <QShortcut>
@@ -12,7 +12,7 @@ class DisassemblyTextEdit;
 class DisassemblyScrollArea;
 class DisassemblyContextMenu;
 
-class DisassemblyWidget : public CutterWidget
+class DisassemblyWidget : public CutterDockWidget
 {
     Q_OBJECT
 public:

--- a/src/widgets/EntrypointWidget.cpp
+++ b/src/widgets/EntrypointWidget.cpp
@@ -12,10 +12,9 @@
  * Entrypoint Widget
  */
 
-EntrypointWidget::EntrypointWidget(MainWindow *main, QWidget *parent) :
-    QDockWidget(parent),
-    ui(new Ui::EntrypointWidget),
-    main(main)
+EntrypointWidget::EntrypointWidget(MainWindow *main, QAction *action) :
+    CutterWidget(main, action),
+    ui(new Ui::EntrypointWidget)
 {
     ui->setupUi(this);
 

--- a/src/widgets/EntrypointWidget.cpp
+++ b/src/widgets/EntrypointWidget.cpp
@@ -13,7 +13,7 @@
  */
 
 EntrypointWidget::EntrypointWidget(MainWindow *main, QAction *action) :
-    CutterWidget(main, action),
+    CutterDockWidget(main, action),
     ui(new Ui::EntrypointWidget)
 {
     ui->setupUi(this);

--- a/src/widgets/EntrypointWidget.h
+++ b/src/widgets/EntrypointWidget.h
@@ -5,7 +5,7 @@
 #include <QStyledItemDelegate>
 #include <QTreeWidgetItem>
 
-#include "CutterWidget.h"
+#include "CutterDockWidget.h"
 
 class MainWindow;
 class QTreeWidget;
@@ -15,7 +15,7 @@ namespace Ui
     class EntrypointWidget;
 }
 
-class EntrypointWidget : public CutterWidget
+class EntrypointWidget : public CutterDockWidget
 {
     Q_OBJECT
 

--- a/src/widgets/EntrypointWidget.h
+++ b/src/widgets/EntrypointWidget.h
@@ -2,10 +2,10 @@
 #define ENTRYPOINTWIDGET_H
 
 #include <memory>
-
-#include <QDockWidget>
 #include <QStyledItemDelegate>
 #include <QTreeWidgetItem>
+
+#include "CutterWidget.h"
 
 class MainWindow;
 class QTreeWidget;
@@ -15,12 +15,12 @@ namespace Ui
     class EntrypointWidget;
 }
 
-class EntrypointWidget : public QDockWidget
+class EntrypointWidget : public CutterWidget
 {
     Q_OBJECT
 
 public:
-    explicit EntrypointWidget(MainWindow *main, QWidget *parent = 0);
+    explicit EntrypointWidget(MainWindow *main, QAction *action = nullptr);
     ~EntrypointWidget();
 
 private slots:
@@ -30,7 +30,6 @@ private slots:
 
 private:
     std::unique_ptr<Ui::EntrypointWidget> ui;
-    MainWindow      *main;
 
     void setScrollMode();
 };

--- a/src/widgets/ExportsWidget.cpp
+++ b/src/widgets/ExportsWidget.cpp
@@ -129,15 +129,11 @@ bool ExportsSortFilterProxyModel::lessThan(const QModelIndex &left, const QModel
 
 
 
-ExportsWidget::ExportsWidget(MainWindow *main, QWidget *parent) :
-    QDockWidget(parent),
-    ui(new Ui::ExportsWidget),
-    main(main)
+ExportsWidget::ExportsWidget(MainWindow *main, QAction *action) :
+    CutterWidget(main, action),
+    ui(new Ui::ExportsWidget)
 {
     ui->setupUi(this);
-
-    // Radare core found in:
-    this->main = main;
 
     exports_model = new ExportsModel(&exports, this);
     exports_proxy_model = new ExportsSortFilterProxyModel(exports_model, this);

--- a/src/widgets/ExportsWidget.cpp
+++ b/src/widgets/ExportsWidget.cpp
@@ -130,7 +130,7 @@ bool ExportsSortFilterProxyModel::lessThan(const QModelIndex &left, const QModel
 
 
 ExportsWidget::ExportsWidget(MainWindow *main, QAction *action) :
-    CutterWidget(main, action),
+    CutterDockWidget(main, action),
     ui(new Ui::ExportsWidget)
 {
     ui->setupUi(this);

--- a/src/widgets/ExportsWidget.h
+++ b/src/widgets/ExportsWidget.h
@@ -4,7 +4,7 @@
 #include <memory>
 
 #include "Cutter.h"
-#include "CutterWidget.h"
+#include "CutterDockWidget.h"
 
 #include <QAbstractListModel>
 #include <QSortFilterProxyModel>
@@ -61,7 +61,7 @@ protected:
 
 
 
-class ExportsWidget : public CutterWidget
+class ExportsWidget : public CutterDockWidget
 {
     Q_OBJECT
 

--- a/src/widgets/ExportsWidget.h
+++ b/src/widgets/ExportsWidget.h
@@ -4,10 +4,10 @@
 #include <memory>
 
 #include "Cutter.h"
+#include "CutterWidget.h"
 
 #include <QAbstractListModel>
 #include <QSortFilterProxyModel>
-#include <QDockWidget>
 
 class MainWindow;
 class QTreeWidget;
@@ -61,12 +61,12 @@ protected:
 
 
 
-class ExportsWidget : public QDockWidget
+class ExportsWidget : public CutterWidget
 {
     Q_OBJECT
 
 public:
-    explicit ExportsWidget(MainWindow *main, QWidget *parent = 0);
+    explicit ExportsWidget(MainWindow *main, QAction *action = nullptr);
     ~ExportsWidget();
 
 private slots:
@@ -76,7 +76,6 @@ private slots:
 
 private:
     std::unique_ptr<Ui::ExportsWidget> ui;
-    MainWindow      *main;
 
     ExportsModel *exports_model;
     ExportsSortFilterProxyModel *exports_proxy_model;

--- a/src/widgets/FlagsWidget.cpp
+++ b/src/widgets/FlagsWidget.cpp
@@ -127,7 +127,7 @@ bool FlagsSortFilterProxyModel::lessThan(const QModelIndex &left, const QModelIn
 
 
 FlagsWidget::FlagsWidget(MainWindow *main, QAction *action) :
-    CutterWidget(main, action),
+    CutterDockWidget(main, action),
     ui(new Ui::FlagsWidget),
     main(main)
 {

--- a/src/widgets/FlagsWidget.cpp
+++ b/src/widgets/FlagsWidget.cpp
@@ -1,4 +1,3 @@
-#include <QDockWidget>
 #include <QTreeWidget>
 #include <QComboBox>
 #include <QMenu>
@@ -127,8 +126,8 @@ bool FlagsSortFilterProxyModel::lessThan(const QModelIndex &left, const QModelIn
 }
 
 
-FlagsWidget::FlagsWidget(MainWindow *main, QWidget *parent) :
-    QDockWidget(parent),
+FlagsWidget::FlagsWidget(MainWindow *main, QAction *action) :
+    CutterWidget(main, action),
     ui(new Ui::FlagsWidget),
     main(main)
 {

--- a/src/widgets/FlagsWidget.h
+++ b/src/widgets/FlagsWidget.h
@@ -7,7 +7,7 @@
 #include <QSortFilterProxyModel>
 
 #include "Cutter.h"
-#include "CutterWidget.h"
+#include "CutterDockWidget.h"
 
 class MainWindow;
 class QTreeWidgetItem;
@@ -57,7 +57,7 @@ namespace Ui
     class FlagsWidget;
 }
 
-class FlagsWidget : public CutterWidget
+class FlagsWidget : public CutterDockWidget
 {
     Q_OBJECT
 

--- a/src/widgets/FlagsWidget.h
+++ b/src/widgets/FlagsWidget.h
@@ -5,9 +5,9 @@
 
 #include <QAbstractItemModel>
 #include <QSortFilterProxyModel>
-#include <QDockWidget>
 
 #include "Cutter.h"
+#include "CutterWidget.h"
 
 class MainWindow;
 class QTreeWidgetItem;
@@ -57,12 +57,12 @@ namespace Ui
     class FlagsWidget;
 }
 
-class FlagsWidget : public QDockWidget
+class FlagsWidget : public CutterWidget
 {
     Q_OBJECT
 
 public:
-    explicit FlagsWidget(MainWindow *main, QWidget *parent = 0);
+    explicit FlagsWidget(MainWindow *main, QAction *action = nullptr);
     ~FlagsWidget();
 
 private slots:

--- a/src/widgets/FunctionsWidget.cpp
+++ b/src/widgets/FunctionsWidget.cpp
@@ -348,7 +348,7 @@ bool FunctionSortFilterProxyModel::lessThan(const QModelIndex &left, const QMode
 }
 
 FunctionsWidget::FunctionsWidget(MainWindow *main, QAction *action) :
-    CutterWidget(main, action),
+    CutterDockWidget(main, action),
     ui(new Ui::FunctionsWidget)
 {
     ui->setupUi(this);

--- a/src/widgets/FunctionsWidget.cpp
+++ b/src/widgets/FunctionsWidget.cpp
@@ -347,10 +347,9 @@ bool FunctionSortFilterProxyModel::lessThan(const QModelIndex &left, const QMode
     }
 }
 
-FunctionsWidget::FunctionsWidget(MainWindow *main, QWidget *parent) :
-    QDockWidget(parent),
-    ui(new Ui::FunctionsWidget),
-    main(main)
+FunctionsWidget::FunctionsWidget(MainWindow *main, QAction *action) :
+    CutterWidget(main, action),
+    ui(new Ui::FunctionsWidget)
 {
     ui->setupUi(this);
 

--- a/src/widgets/FunctionsWidget.h
+++ b/src/widgets/FunctionsWidget.h
@@ -5,9 +5,9 @@
 
 #include <QSortFilterProxyModel>
 #include <QTreeView>
-#include <QDockWidget>
 
 #include "Cutter.h"
+#include "CutterWidget.h"
 
 class MainWindow;
 class QTreeWidgetItem;
@@ -86,12 +86,12 @@ protected:
 
 
 
-class FunctionsWidget : public QDockWidget
+class FunctionsWidget : public CutterWidget
 {
     Q_OBJECT
 
 public:
-    explicit FunctionsWidget(MainWindow *main, QWidget *parent = 0);
+    explicit FunctionsWidget(MainWindow *main, QAction *action = nullptr);
     ~FunctionsWidget();
 
 private slots:

--- a/src/widgets/FunctionsWidget.h
+++ b/src/widgets/FunctionsWidget.h
@@ -7,7 +7,7 @@
 #include <QTreeView>
 
 #include "Cutter.h"
-#include "CutterWidget.h"
+#include "CutterDockWidget.h"
 
 class MainWindow;
 class QTreeWidgetItem;
@@ -86,7 +86,7 @@ protected:
 
 
 
-class FunctionsWidget : public CutterWidget
+class FunctionsWidget : public CutterDockWidget
 {
     Q_OBJECT
 

--- a/src/widgets/GraphWidget.cpp
+++ b/src/widgets/GraphWidget.cpp
@@ -3,7 +3,7 @@
 #include "DisassemblerGraphView.h"
 
 GraphWidget::GraphWidget(MainWindow *main, QAction *action) :
-    CutterWidget(main, action)
+    CutterDockWidget(main, action)
 {
     this->setObjectName("Graph");
     this->setAllowedAreas(Qt::AllDockWidgetAreas);

--- a/src/widgets/GraphWidget.cpp
+++ b/src/widgets/GraphWidget.cpp
@@ -1,0 +1,34 @@
+#include "MainWindow.h"
+#include "GraphWidget.h"
+#include "DisassemblerGraphView.h"
+
+GraphWidget::GraphWidget(MainWindow *main, QAction *action) :
+    CutterWidget(main, action)
+{
+    this->setObjectName("Graph");
+    this->setAllowedAreas(Qt::AllDockWidgetAreas);
+    this->graphView = new DisassemblerGraphView(this);
+    this->setWidget(graphView);
+
+    connect(this, &QDockWidget::visibilityChanged, this, [](bool visibility)
+    {
+        if (visibility)
+        {
+            Core()->setMemoryWidgetPriority(CutterCore::MemoryWidgetType::Graph);
+        }
+    });
+
+    connect(Core(), &CutterCore::raisePrioritizedMemoryWidget, this, [ = ](CutterCore::MemoryWidgetType type)
+    {
+        if (type == CutterCore::MemoryWidgetType::Graph)
+        {
+            this->raise();
+            this->graphView->setFocus();
+        }
+    });
+
+
+
+}
+
+GraphWidget::~GraphWidget() {}

--- a/src/widgets/GraphWidget.h
+++ b/src/widgets/GraphWidget.h
@@ -1,0 +1,22 @@
+#ifndef GRAPHWIDGET_H
+#define GRAPHWIDGET_H
+
+#include "CutterWidget.h"
+
+class MainWindow;
+class DisassemblerGraphView;
+
+class GraphWidget : public CutterWidget
+{
+    Q_OBJECT
+
+public:
+    explicit GraphWidget(MainWindow *main, QAction *action = nullptr);
+    ~GraphWidget();
+
+private:
+    DisassemblerGraphView *graphView;
+
+};
+
+#endif // GRAPHWIDGET_H

--- a/src/widgets/GraphWidget.h
+++ b/src/widgets/GraphWidget.h
@@ -1,12 +1,12 @@
 #ifndef GRAPHWIDGET_H
 #define GRAPHWIDGET_H
 
-#include "CutterWidget.h"
+#include "CutterDockWidget.h"
 
 class MainWindow;
 class DisassemblerGraphView;
 
-class GraphWidget : public CutterWidget
+class GraphWidget : public CutterDockWidget
 {
     Q_OBJECT
 

--- a/src/widgets/HexdumpWidget.cpp
+++ b/src/widgets/HexdumpWidget.cpp
@@ -14,7 +14,7 @@
 #include <QScrollBar>
 
 HexdumpWidget::HexdumpWidget(MainWindow *main, QAction *action) :
-        CutterWidget(main, action),
+        CutterDockWidget(main, action),
         ui(new Ui::HexdumpWidget)
 {
     ui->setupUi(this);

--- a/src/widgets/HexdumpWidget.cpp
+++ b/src/widgets/HexdumpWidget.cpp
@@ -13,8 +13,8 @@
 #include <QClipboard>
 #include <QScrollBar>
 
-HexdumpWidget::HexdumpWidget(QWidget *parent, Qt::WindowFlags flags) :
-        QDockWidget(parent, flags),
+HexdumpWidget::HexdumpWidget(MainWindow *main, QAction *action) :
+        CutterWidget(main, action),
         ui(new Ui::HexdumpWidget)
 {
     ui->setupUi(this);
@@ -83,12 +83,6 @@ HexdumpWidget::HexdumpWidget(QWidget *parent, Qt::WindowFlags flags) :
     format = Format::Hex;
     initParsing();
     selectHexPreview();
-}
-
-HexdumpWidget::HexdumpWidget(const QString &title, QWidget *parent, Qt::WindowFlags flags)
-        : HexdumpWidget(parent, flags)
-{
-    setWindowTitle(title);
 }
 
 void HexdumpWidget::setupScrollSync()

--- a/src/widgets/HexdumpWidget.h
+++ b/src/widgets/HexdumpWidget.h
@@ -3,13 +3,13 @@
 
 #include <QDebug>
 #include <QTextEdit>
-#include <QDockWidget>
 #include <QMouseEvent>
 
 #include <array>
 #include <memory>
 
 #include "Cutter.h"
+#include "CutterWidget.h"
 #include "utils/Highlighter.h"
 #include "utils/HexAsciiHighlighter.h"
 #include "utils/HexHighlighter.h"
@@ -19,14 +19,13 @@
 
 #include "ui_HexdumpWidget.h"
 
-class HexdumpWidget : public QDockWidget
+class HexdumpWidget : public CutterWidget
 {
     Q_OBJECT
 
 
 public:
-    explicit HexdumpWidget(const QString &title, QWidget *parent = nullptr, Qt::WindowFlags flags = 0);
-    explicit HexdumpWidget(QWidget *parent = nullptr, Qt::WindowFlags flags = 0);
+    explicit HexdumpWidget(MainWindow *main, QAction *action = nullptr);
     ~HexdumpWidget();
 
     Highlighter        *highlighter;

--- a/src/widgets/HexdumpWidget.h
+++ b/src/widgets/HexdumpWidget.h
@@ -9,7 +9,7 @@
 #include <memory>
 
 #include "Cutter.h"
-#include "CutterWidget.h"
+#include "CutterDockWidget.h"
 #include "utils/Highlighter.h"
 #include "utils/HexAsciiHighlighter.h"
 #include "utils/HexHighlighter.h"
@@ -19,7 +19,7 @@
 
 #include "ui_HexdumpWidget.h"
 
-class HexdumpWidget : public CutterWidget
+class HexdumpWidget : public CutterDockWidget
 {
     Q_OBJECT
 

--- a/src/widgets/ImportsWidget.cpp
+++ b/src/widgets/ImportsWidget.cpp
@@ -33,7 +33,7 @@ void CMyDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, c
  */
 
 ImportsWidget::ImportsWidget(MainWindow *main, QAction *action) :
-    CutterWidget(main, action),
+    CutterDockWidget(main, action),
     ui(new Ui::ImportsWidget)
 {
     ui->setupUi(this);

--- a/src/widgets/ImportsWidget.cpp
+++ b/src/widgets/ImportsWidget.cpp
@@ -32,10 +32,9 @@ void CMyDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, c
  * Imports Widget
  */
 
-ImportsWidget::ImportsWidget(MainWindow *main, QWidget *parent) :
-    QDockWidget(parent),
-    ui(new Ui::ImportsWidget),
-    main(main)
+ImportsWidget::ImportsWidget(MainWindow *main, QAction *action) :
+    CutterWidget(main, action),
+    ui(new Ui::ImportsWidget)
 {
     ui->setupUi(this);
 

--- a/src/widgets/ImportsWidget.h
+++ b/src/widgets/ImportsWidget.h
@@ -3,9 +3,10 @@
 
 #include <memory>
 
-#include <QDockWidget>
 #include <QStyledItemDelegate>
 #include <QTreeWidgetItem>
+
+#include "CutterWidget.h"
 
 class MainWindow;
 class QTreeWidget;
@@ -15,12 +16,12 @@ namespace Ui
     class ImportsWidget;
 }
 
-class ImportsWidget : public QDockWidget
+class ImportsWidget : public CutterWidget
 {
     Q_OBJECT
 
 public:
-    explicit ImportsWidget(MainWindow *main, QWidget *parent = 0);
+    explicit ImportsWidget(MainWindow *main, QAction *action);
     ~ImportsWidget();
 
 private slots:
@@ -30,7 +31,6 @@ private slots:
 
 private:
     std::unique_ptr<Ui::ImportsWidget> ui;
-    MainWindow      *main;
 
     void highlightUnsafe();
     void setScrollMode();

--- a/src/widgets/ImportsWidget.h
+++ b/src/widgets/ImportsWidget.h
@@ -6,7 +6,7 @@
 #include <QStyledItemDelegate>
 #include <QTreeWidgetItem>
 
-#include "CutterWidget.h"
+#include "CutterDockWidget.h"
 
 class MainWindow;
 class QTreeWidget;
@@ -16,7 +16,7 @@ namespace Ui
     class ImportsWidget;
 }
 
-class ImportsWidget : public CutterWidget
+class ImportsWidget : public CutterDockWidget
 {
     Q_OBJECT
 

--- a/src/widgets/JupyterWidget.cpp
+++ b/src/widgets/JupyterWidget.cpp
@@ -14,8 +14,8 @@
 #include <QWebEngineSettings>
 #endif
 
-JupyterWidget::JupyterWidget(QWidget *parent, Qt::WindowFlags flags) :
-    QDockWidget(parent, flags),
+JupyterWidget::JupyterWidget(MainWindow *main, QAction *action) :
+    CutterWidget(main, action),
     ui(new Ui::JupyterWidget)
 {
     ui->setupUi(this);

--- a/src/widgets/JupyterWidget.cpp
+++ b/src/widgets/JupyterWidget.cpp
@@ -15,7 +15,7 @@
 #endif
 
 JupyterWidget::JupyterWidget(MainWindow *main, QAction *action) :
-    CutterWidget(main, action),
+    CutterDockWidget(main, action),
     ui(new Ui::JupyterWidget)
 {
     ui->setupUi(this);

--- a/src/widgets/JupyterWidget.h
+++ b/src/widgets/JupyterWidget.h
@@ -8,7 +8,7 @@
 
 #include <QAbstractButton>
 
-#include "CutterWidget.h"
+#include "CutterDockWidget.h"
 #include "utils/JupyterConnection.h"
 
 namespace Ui
@@ -20,7 +20,7 @@ class JupyterWebView;
 class QTabWidget;
 class MainWindow;
 
-class JupyterWidget : public CutterWidget
+class JupyterWidget : public CutterDockWidget
 {
 Q_OBJECT
 

--- a/src/widgets/JupyterWidget.h
+++ b/src/widgets/JupyterWidget.h
@@ -6,9 +6,9 @@
 
 #include <memory>
 
-#include <QDockWidget>
 #include <QAbstractButton>
 
+#include "CutterWidget.h"
 #include "utils/JupyterConnection.h"
 
 namespace Ui
@@ -17,15 +17,15 @@ namespace Ui
 }
 
 class JupyterWebView;
-
 class QTabWidget;
+class MainWindow;
 
-class JupyterWidget : public QDockWidget
+class JupyterWidget : public CutterWidget
 {
 Q_OBJECT
 
 public:
-    JupyterWidget(QWidget *parent = nullptr, Qt::WindowFlags flags = Qt::WindowFlags());
+    JupyterWidget(MainWindow *main, QAction *action = nullptr);
     ~JupyterWidget();
 
 #ifdef CUTTER_ENABLE_QTWEBENGINE

--- a/src/widgets/PseudocodeWidget.cpp
+++ b/src/widgets/PseudocodeWidget.cpp
@@ -8,8 +8,8 @@
 #include "utils/SyntaxHighlighter.h"
 #include "utils/TempConfig.h"
 
-PseudocodeWidget::PseudocodeWidget(QWidget *parent, Qt::WindowFlags flags) :
-        QDockWidget(parent, flags),
+PseudocodeWidget::PseudocodeWidget(MainWindow *main, QAction *action) :
+        CutterWidget(main, action),
         ui(new Ui::PseudocodeWidget)
 {
     ui->setupUi(this);
@@ -45,12 +45,6 @@ PseudocodeWidget::PseudocodeWidget(QWidget *parent, Qt::WindowFlags flags) :
     });
 
     refresh(RVA_INVALID);
-}
-
-PseudocodeWidget::PseudocodeWidget(const QString &title, QWidget *parent, Qt::WindowFlags flags)
-        : PseudocodeWidget(parent, flags)
-{
-    setWindowTitle(title);
 }
 
 PseudocodeWidget::~PseudocodeWidget() {}

--- a/src/widgets/PseudocodeWidget.cpp
+++ b/src/widgets/PseudocodeWidget.cpp
@@ -9,7 +9,7 @@
 #include "utils/TempConfig.h"
 
 PseudocodeWidget::PseudocodeWidget(MainWindow *main, QAction *action) :
-        CutterWidget(main, action),
+        CutterDockWidget(main, action),
         ui(new Ui::PseudocodeWidget)
 {
     ui->setupUi(this);

--- a/src/widgets/PseudocodeWidget.h
+++ b/src/widgets/PseudocodeWidget.h
@@ -4,7 +4,7 @@
 #include <memory>
 
 #include "Cutter.h"
-#include "CutterWidget.h"
+#include "CutterDockWidget.h"
 
 namespace Ui
 {
@@ -14,7 +14,7 @@ namespace Ui
 class QTextEdit;
 class SyntaxHighlighter;
 
-class PseudocodeWidget : public CutterWidget
+class PseudocodeWidget : public CutterDockWidget
 {
 Q_OBJECT
 

--- a/src/widgets/PseudocodeWidget.h
+++ b/src/widgets/PseudocodeWidget.h
@@ -1,10 +1,10 @@
 #ifndef PSEUDOCODEWIDGET_H
 #define PSEUDOCODEWIDGET_H
 
-#include <QDockWidget>
 #include <memory>
 
 #include "Cutter.h"
+#include "CutterWidget.h"
 
 namespace Ui
 {
@@ -14,13 +14,12 @@ namespace Ui
 class QTextEdit;
 class SyntaxHighlighter;
 
-class PseudocodeWidget : public QDockWidget
+class PseudocodeWidget : public CutterWidget
 {
 Q_OBJECT
 
 public:
-    explicit PseudocodeWidget(const QString &title, QWidget *parent = nullptr, Qt::WindowFlags flags = 0);
-    explicit PseudocodeWidget(QWidget *parent = nullptr, Qt::WindowFlags flags = 0);
+    explicit PseudocodeWidget(MainWindow *main, QAction *action = nullptr);
     ~PseudocodeWidget();
 
 private slots:

--- a/src/widgets/RelocsWidget.cpp
+++ b/src/widgets/RelocsWidget.cpp
@@ -5,7 +5,7 @@
 #include "utils/Helpers.h"
 
 RelocsWidget::RelocsWidget(MainWindow *main, QAction *action) :
-    CutterWidget(main, action),
+    CutterDockWidget(main, action),
     ui(new Ui::RelocsWidget)
 {
     ui->setupUi(this);

--- a/src/widgets/RelocsWidget.cpp
+++ b/src/widgets/RelocsWidget.cpp
@@ -4,15 +4,11 @@
 #include "MainWindow.h"
 #include "utils/Helpers.h"
 
-RelocsWidget::RelocsWidget(MainWindow *main, QWidget *parent) :
-    QDockWidget(parent),
-    ui(new Ui::RelocsWidget),
-    main(main)
+RelocsWidget::RelocsWidget(MainWindow *main, QAction *action) :
+    CutterWidget(main, action),
+    ui(new Ui::RelocsWidget)
 {
     ui->setupUi(this);
-
-    // Radare core found in:
-    this->main = main;
 
     setScrollMode();
 

--- a/src/widgets/RelocsWidget.h
+++ b/src/widgets/RelocsWidget.h
@@ -3,7 +3,7 @@
 
 #include <memory>
 
-#include <QDockWidget>
+#include "CutterWidget.h"
 
 class MainWindow;
 class QTreeWidgetItem;
@@ -13,12 +13,12 @@ namespace Ui
     class RelocsWidget;
 }
 
-class RelocsWidget : public QDockWidget
+class RelocsWidget : public CutterWidget
 {
     Q_OBJECT
 
 public:
-    explicit RelocsWidget(MainWindow *main, QWidget *parent = 0);
+    explicit RelocsWidget(MainWindow *main, QAction *action = nullptr);
     ~RelocsWidget();
 
 private slots:
@@ -28,7 +28,6 @@ private slots:
 
 private:
     std::unique_ptr<Ui::RelocsWidget> ui;
-    MainWindow      *main;
 
     void setScrollMode();
 };

--- a/src/widgets/RelocsWidget.h
+++ b/src/widgets/RelocsWidget.h
@@ -3,7 +3,7 @@
 
 #include <memory>
 
-#include "CutterWidget.h"
+#include "CutterDockWidget.h"
 
 class MainWindow;
 class QTreeWidgetItem;
@@ -13,7 +13,7 @@ namespace Ui
     class RelocsWidget;
 }
 
-class RelocsWidget : public CutterWidget
+class RelocsWidget : public CutterDockWidget
 {
     Q_OBJECT
 

--- a/src/widgets/ResourcesWidget.cpp
+++ b/src/widgets/ResourcesWidget.cpp
@@ -88,7 +88,7 @@ void ResourcesModel::endReload()
 }
 
 ResourcesWidget::ResourcesWidget(MainWindow *main, QAction *action) :
-    CutterWidget(main, action)
+    CutterDockWidget(main, action)
 {
     setObjectName("ResourcesWidget");
 

--- a/src/widgets/ResourcesWidget.cpp
+++ b/src/widgets/ResourcesWidget.cpp
@@ -1,5 +1,6 @@
 #include "utils/Helpers.h"
 #include "ResourcesWidget.h"
+#include "MainWindow.h"
 #include <QVBoxLayout>
 
 ResourcesModel::ResourcesModel(QList<ResourcesDescription> *resources, QObject *parent)
@@ -86,8 +87,8 @@ void ResourcesModel::endReload()
     endResetModel();
 }
 
-ResourcesWidget::ResourcesWidget(QWidget *parent)
-    : QDockWidget(parent)
+ResourcesWidget::ResourcesWidget(MainWindow *main, QAction *action) :
+    CutterWidget(main, action)
 {
     setObjectName("ResourcesWidget");
 

--- a/src/widgets/ResourcesWidget.h
+++ b/src/widgets/ResourcesWidget.h
@@ -2,7 +2,7 @@
 #define RESOURCESWIDGET_H
 
 #include "Cutter.h"
-#include "CutterWidget.h"
+#include "CutterDockWidget.h"
 
 #include <QAbstractListModel>
 #include <QTreeView>
@@ -30,7 +30,7 @@ public:
     void endReload();
 };
 
-class ResourcesWidget : public CutterWidget
+class ResourcesWidget : public CutterDockWidget
 {
     Q_OBJECT
 

--- a/src/widgets/ResourcesWidget.h
+++ b/src/widgets/ResourcesWidget.h
@@ -2,10 +2,12 @@
 #define RESOURCESWIDGET_H
 
 #include "Cutter.h"
+#include "CutterWidget.h"
 
-#include <QDockWidget>
 #include <QAbstractListModel>
 #include <QTreeView>
+
+class MainWindow;
 
 class ResourcesModel : public QAbstractListModel
 {
@@ -28,7 +30,7 @@ public:
     void endReload();
 };
 
-class ResourcesWidget : public QDockWidget
+class ResourcesWidget : public CutterWidget
 {
     Q_OBJECT
 
@@ -38,7 +40,7 @@ private:
     QList<ResourcesDescription> resources;
 
 public:
-    ResourcesWidget(QWidget *parent = nullptr);
+    explicit ResourcesWidget(MainWindow *main, QAction *action = nullptr);
 
 private slots:
     void refreshResources();

--- a/src/widgets/SdbDock.cpp
+++ b/src/widgets/SdbDock.cpp
@@ -8,7 +8,7 @@
 
 
 SdbDock::SdbDock(MainWindow *main, QAction *action) :
-    CutterWidget(main, action),
+    CutterDockWidget(main, action),
     ui(new Ui::SdbDock)
 {
     ui->setupUi(this);

--- a/src/widgets/SdbDock.cpp
+++ b/src/widgets/SdbDock.cpp
@@ -7,8 +7,8 @@
 #include <QTreeWidget>
 
 
-SdbDock::SdbDock(QWidget *parent) :
-    QDockWidget(parent),
+SdbDock::SdbDock(MainWindow *main, QAction *action) :
+    CutterWidget(main, action),
     ui(new Ui::SdbDock)
 {
     ui->setupUi(this);

--- a/src/widgets/SdbDock.h
+++ b/src/widgets/SdbDock.h
@@ -3,7 +3,7 @@
 
 #include <memory>
 
-#include <QDockWidget>
+#include "CutterWidget.h"
 
 class MainWindow;
 class QTreeWidgetItem;
@@ -13,12 +13,12 @@ namespace Ui
     class SdbDock;
 }
 
-class SdbDock : public QDockWidget
+class SdbDock : public CutterWidget
 {
     Q_OBJECT
 
 public:
-    explicit SdbDock(QWidget *parent = 0);
+    explicit SdbDock(MainWindow *main, QAction *action = nullptr);
     ~SdbDock();
 
 private slots:

--- a/src/widgets/SdbDock.h
+++ b/src/widgets/SdbDock.h
@@ -3,7 +3,7 @@
 
 #include <memory>
 
-#include "CutterWidget.h"
+#include "CutterDockWidget.h"
 
 class MainWindow;
 class QTreeWidgetItem;
@@ -13,7 +13,7 @@ namespace Ui
     class SdbDock;
 }
 
-class SdbDock : public CutterWidget
+class SdbDock : public CutterDockWidget
 {
     Q_OBJECT
 

--- a/src/widgets/SearchWidget.cpp
+++ b/src/widgets/SearchWidget.cpp
@@ -122,10 +122,9 @@ bool SearchSortFilterProxyModel::lessThan(const QModelIndex &left, const QModelI
 }
 
 
-SearchWidget::SearchWidget(MainWindow *main, QWidget *parent) :
-    QDockWidget(parent),
-    ui(new Ui::SearchWidget),
-    main(main)
+SearchWidget::SearchWidget(MainWindow *main, QAction *action) :
+    CutterWidget(main, action),
+    ui(new Ui::SearchWidget)
 {
     ui->setupUi(this);
 

--- a/src/widgets/SearchWidget.cpp
+++ b/src/widgets/SearchWidget.cpp
@@ -123,7 +123,7 @@ bool SearchSortFilterProxyModel::lessThan(const QModelIndex &left, const QModelI
 
 
 SearchWidget::SearchWidget(MainWindow *main, QAction *action) :
-    CutterWidget(main, action),
+    CutterDockWidget(main, action),
     ui(new Ui::SearchWidget)
 {
     ui->setupUi(this);

--- a/src/widgets/SearchWidget.h
+++ b/src/widgets/SearchWidget.h
@@ -5,9 +5,9 @@
 
 #include <QAbstractItemModel>
 #include <QSortFilterProxyModel>
-#include <QDockWidget>
 
 #include "Cutter.h"
+#include "CutterWidget.h"
 
 class MainWindow;
 class QTreeWidgetItem;
@@ -57,12 +57,12 @@ namespace Ui
     class SearchWidget;
 }
 
-class SearchWidget : public QDockWidget
+class SearchWidget : public CutterWidget
 {
     Q_OBJECT
 
 public:
-    explicit SearchWidget(MainWindow *main, QWidget *parent = 0);
+    explicit SearchWidget(MainWindow *main, QAction *action = nullptr);
     ~SearchWidget();
 
 private slots:
@@ -73,7 +73,6 @@ private slots:
 
 private:
     std::unique_ptr<Ui::SearchWidget> ui;
-    MainWindow      *main;
 
     SearchModel *search_model;
     SearchSortFilterProxyModel *search_proxy_model;

--- a/src/widgets/SearchWidget.h
+++ b/src/widgets/SearchWidget.h
@@ -7,7 +7,7 @@
 #include <QSortFilterProxyModel>
 
 #include "Cutter.h"
-#include "CutterWidget.h"
+#include "CutterDockWidget.h"
 
 class MainWindow;
 class QTreeWidgetItem;
@@ -57,7 +57,7 @@ namespace Ui
     class SearchWidget;
 }
 
-class SearchWidget : public CutterWidget
+class SearchWidget : public CutterDockWidget
 {
     Q_OBJECT
 

--- a/src/widgets/SectionsDock.cpp
+++ b/src/widgets/SectionsDock.cpp
@@ -8,14 +8,12 @@
 #include <QResizeEvent>
 
 
-SectionsDock::SectionsDock(MainWindow *main, QWidget *parent) :
-    QDockWidget(parent),
-    ui(new Ui::SectionsDock)
+SectionsDock::SectionsDock(MainWindow *main, QAction *action) :
+    CutterWidget(main, action),
+    ui(new Ui::SectionsDock),
+    main(main)
 {
     ui->setupUi(this);
-
-    // Radare core found in:
-    this->main = main;
 
     this->sectionsWidget = new SectionsWidget(this->main);
     this->setWidget(this->sectionsWidget);

--- a/src/widgets/SectionsDock.cpp
+++ b/src/widgets/SectionsDock.cpp
@@ -9,7 +9,7 @@
 
 
 SectionsDock::SectionsDock(MainWindow *main, QAction *action) :
-    CutterWidget(main, action),
+    CutterDockWidget(main, action),
     ui(new Ui::SectionsDock),
     main(main)
 {

--- a/src/widgets/SectionsDock.h
+++ b/src/widgets/SectionsDock.h
@@ -3,7 +3,7 @@
 
 #include <memory>
 
-#include <QDockWidget>
+#include "CutterWidget.h"
 
 class MainWindow;
 class SectionsWidget;
@@ -13,12 +13,12 @@ namespace Ui
     class SectionsDock;
 }
 
-class SectionsDock : public QDockWidget
+class SectionsDock : public CutterWidget
 {
     Q_OBJECT
 
 public:
-    explicit SectionsDock(MainWindow *main, QWidget *parent = 0);
+    explicit SectionsDock(MainWindow *main, QAction *action = nullptr);
     ~SectionsDock();
 
 protected:

--- a/src/widgets/SectionsDock.h
+++ b/src/widgets/SectionsDock.h
@@ -3,7 +3,7 @@
 
 #include <memory>
 
-#include "CutterWidget.h"
+#include "CutterDockWidget.h"
 
 class MainWindow;
 class SectionsWidget;
@@ -13,7 +13,7 @@ namespace Ui
     class SectionsDock;
 }
 
-class SectionsDock : public CutterWidget
+class SectionsDock : public CutterDockWidget
 {
     Q_OBJECT
 

--- a/src/widgets/SidebarWidget.cpp
+++ b/src/widgets/SidebarWidget.cpp
@@ -17,7 +17,7 @@
 
 
 SidebarWidget::SidebarWidget(MainWindow *main, QAction *action) :
-        CutterWidget(main, action),
+        CutterDockWidget(main, action),
         ui(new Ui::SidebarWidget)
 {
     ui->setupUi(this);

--- a/src/widgets/SidebarWidget.cpp
+++ b/src/widgets/SidebarWidget.cpp
@@ -16,8 +16,8 @@
 #include <QSettings>
 
 
-SidebarWidget::SidebarWidget(QWidget *parent, Qt::WindowFlags flags) :
-        QDockWidget(parent, flags),
+SidebarWidget::SidebarWidget(MainWindow *main, QAction *action) :
+        CutterWidget(main, action),
         ui(new Ui::SidebarWidget)
 {
     ui->setupUi(this);
@@ -34,13 +34,6 @@ SidebarWidget::SidebarWidget(QWidget *parent, Qt::WindowFlags flags) :
 
     connect(Core(), SIGNAL(refreshAll()), this, SLOT(refresh()));
 }
-
-SidebarWidget::SidebarWidget(const QString &title, QWidget *parent, Qt::WindowFlags flags)
-    : SidebarWidget(parent, flags)
-{
-    setWindowTitle(title);
-}
-
 
 SidebarWidget::~SidebarWidget()
 {

--- a/src/widgets/SidebarWidget.h
+++ b/src/widgets/SidebarWidget.h
@@ -13,7 +13,7 @@
 #include <memory>
 
 #include "Cutter.h"
-#include "CutterWidget.h"
+#include "CutterDockWidget.h"
 #include "utils/Highlighter.h"
 #include "utils/HexAsciiHighlighter.h"
 #include "utils/HexHighlighter.h"
@@ -25,7 +25,7 @@ namespace Ui
     class SidebarWidget;
 }
 
-class SidebarWidget : public CutterWidget
+class SidebarWidget : public CutterDockWidget
 {
 Q_OBJECT
 

--- a/src/widgets/SidebarWidget.h
+++ b/src/widgets/SidebarWidget.h
@@ -5,14 +5,15 @@
 
 #include <QDebug>
 #include <QTextEdit>
-#include <QDockWidget>
 #include <QTreeWidget>
 #include <QTabWidget>
 #include <QUrl>
 #include <QPlainTextEdit>
 #include <QMouseEvent>
 #include <memory>
+
 #include "Cutter.h"
+#include "CutterWidget.h"
 #include "utils/Highlighter.h"
 #include "utils/HexAsciiHighlighter.h"
 #include "utils/HexHighlighter.h"
@@ -24,13 +25,12 @@ namespace Ui
     class SidebarWidget;
 }
 
-class SidebarWidget : public QDockWidget
+class SidebarWidget : public CutterWidget
 {
 Q_OBJECT
 
 public:
-    explicit SidebarWidget(const QString &title, QWidget *parent = nullptr, Qt::WindowFlags flags = 0);
-    explicit SidebarWidget(QWidget *parent = nullptr, Qt::WindowFlags flags = 0);
+    explicit SidebarWidget(MainWindow *main, QAction *action = nullptr);
     ~SidebarWidget();
 
 private:

--- a/src/widgets/StringsWidget.cpp
+++ b/src/widgets/StringsWidget.cpp
@@ -132,8 +132,8 @@ bool StringsSortFilterProxyModel::lessThan(const QModelIndex &left, const QModel
 }
 
 
-StringsWidget::StringsWidget(QWidget *parent) :
-    QDockWidget(parent),
+StringsWidget::StringsWidget(MainWindow *main, QAction *action) :
+    CutterWidget(main, action),
     ui(new Ui::StringsWidget)
 {
     ui->setupUi(this);

--- a/src/widgets/StringsWidget.cpp
+++ b/src/widgets/StringsWidget.cpp
@@ -133,7 +133,7 @@ bool StringsSortFilterProxyModel::lessThan(const QModelIndex &left, const QModel
 
 
 StringsWidget::StringsWidget(MainWindow *main, QAction *action) :
-    CutterWidget(main, action),
+    CutterDockWidget(main, action),
     ui(new Ui::StringsWidget)
 {
     ui->setupUi(this);

--- a/src/widgets/StringsWidget.h
+++ b/src/widgets/StringsWidget.h
@@ -4,10 +4,10 @@
 #include <memory>
 
 #include "Cutter.h"
+#include "CutterWidget.h"
 
 #include <QAbstractListModel>
 #include <QSortFilterProxyModel>
-#include <QDockWidget>
 
 class MainWindow;
 class QTreeWidgetItem;
@@ -55,12 +55,12 @@ protected:
 };
 
 
-class StringsWidget : public QDockWidget
+class StringsWidget : public CutterWidget
 {
     Q_OBJECT
 
 public:
-    explicit StringsWidget(QWidget *parent = nullptr);
+    explicit StringsWidget(MainWindow *main, QAction *action = nullptr);
     ~StringsWidget();
 
 private slots:

--- a/src/widgets/StringsWidget.h
+++ b/src/widgets/StringsWidget.h
@@ -4,7 +4,7 @@
 #include <memory>
 
 #include "Cutter.h"
-#include "CutterWidget.h"
+#include "CutterDockWidget.h"
 
 #include <QAbstractListModel>
 #include <QSortFilterProxyModel>
@@ -55,7 +55,7 @@ protected:
 };
 
 
-class StringsWidget : public CutterWidget
+class StringsWidget : public CutterDockWidget
 {
     Q_OBJECT
 

--- a/src/widgets/SymbolsWidget.cpp
+++ b/src/widgets/SymbolsWidget.cpp
@@ -8,7 +8,7 @@
 
 
 SymbolsWidget::SymbolsWidget(MainWindow *main, QAction *action) :
-    CutterWidget(main, action),
+    CutterDockWidget(main, action),
     ui(new Ui::SymbolsWidget)
 {
     ui->setupUi(this);

--- a/src/widgets/SymbolsWidget.cpp
+++ b/src/widgets/SymbolsWidget.cpp
@@ -7,8 +7,8 @@
 #include <QTreeWidget>
 
 
-SymbolsWidget::SymbolsWidget(QWidget *parent) :
-    QDockWidget(parent),
+SymbolsWidget::SymbolsWidget(MainWindow *main, QAction *action) :
+    CutterWidget(main, action),
     ui(new Ui::SymbolsWidget)
 {
     ui->setupUi(this);

--- a/src/widgets/SymbolsWidget.h
+++ b/src/widgets/SymbolsWidget.h
@@ -3,7 +3,7 @@
 
 #include <memory>
 
-#include <QDockWidget>
+#include "CutterWidget.h"
 
 class MainWindow;
 class QTreeWidgetItem;
@@ -13,12 +13,12 @@ namespace Ui
     class SymbolsWidget;
 }
 
-class SymbolsWidget : public QDockWidget
+class SymbolsWidget : public CutterWidget
 {
     Q_OBJECT
 
 public:
-    explicit SymbolsWidget(QWidget *parent = 0);
+    explicit SymbolsWidget(MainWindow *main, QAction *action = nullptr);
     ~SymbolsWidget();
 
 private slots:

--- a/src/widgets/SymbolsWidget.h
+++ b/src/widgets/SymbolsWidget.h
@@ -3,7 +3,7 @@
 
 #include <memory>
 
-#include "CutterWidget.h"
+#include "CutterDockWidget.h"
 
 class MainWindow;
 class QTreeWidgetItem;
@@ -13,7 +13,7 @@ namespace Ui
     class SymbolsWidget;
 }
 
-class SymbolsWidget : public CutterWidget
+class SymbolsWidget : public CutterDockWidget
 {
     Q_OBJECT
 

--- a/src/widgets/TypesWidget.cpp
+++ b/src/widgets/TypesWidget.cpp
@@ -113,15 +113,11 @@ bool TypesSortFilterProxyModel::lessThan(const QModelIndex &left, const QModelIn
 
 
 
-TypesWidget::TypesWidget(MainWindow *main, QWidget *parent) :
-    QDockWidget(parent),
-    ui(new Ui::TypesWidget),
-    main(main)
+TypesWidget::TypesWidget(MainWindow *main, QAction *action) :
+    CutterWidget(main, action),
+    ui(new Ui::TypesWidget)
 {
     ui->setupUi(this);
-
-    // Radare core found in:
-    this->main = main;
 
     types_model = new TypesModel(&types, this);
     types_proxy_model = new TypesSortFilterProxyModel(types_model, this);

--- a/src/widgets/TypesWidget.cpp
+++ b/src/widgets/TypesWidget.cpp
@@ -114,7 +114,7 @@ bool TypesSortFilterProxyModel::lessThan(const QModelIndex &left, const QModelIn
 
 
 TypesWidget::TypesWidget(MainWindow *main, QAction *action) :
-    CutterWidget(main, action),
+    CutterDockWidget(main, action),
     ui(new Ui::TypesWidget)
 {
     ui->setupUi(this);

--- a/src/widgets/TypesWidget.h
+++ b/src/widgets/TypesWidget.h
@@ -4,10 +4,10 @@
 #include <memory>
 
 #include "Cutter.h"
+#include "CutterWidget.h"
 
 #include <QAbstractListModel>
 #include <QSortFilterProxyModel>
-#include <QDockWidget>
 
 class MainWindow;
 class QTreeWidget;
@@ -61,12 +61,12 @@ protected:
 
 
 
-class TypesWidget : public QDockWidget
+class TypesWidget : public CutterWidget
 {
     Q_OBJECT
 
 public:
-    explicit TypesWidget(MainWindow *main, QWidget *parent = 0);
+    explicit TypesWidget(MainWindow *main, QAction *action = nullptr);
     ~TypesWidget();
 
 private slots:
@@ -76,7 +76,6 @@ private slots:
 
 private:
     std::unique_ptr<Ui::TypesWidget> ui;
-    MainWindow      *main;
 
     TypesModel *types_model;
     TypesSortFilterProxyModel *types_proxy_model;

--- a/src/widgets/TypesWidget.h
+++ b/src/widgets/TypesWidget.h
@@ -4,7 +4,7 @@
 #include <memory>
 
 #include "Cutter.h"
-#include "CutterWidget.h"
+#include "CutterDockWidget.h"
 
 #include <QAbstractListModel>
 #include <QSortFilterProxyModel>
@@ -61,7 +61,7 @@ protected:
 
 
 
-class TypesWidget : public CutterWidget
+class TypesWidget : public CutterDockWidget
 {
     Q_OBJECT
 

--- a/src/widgets/VTablesWidget.cpp
+++ b/src/widgets/VTablesWidget.cpp
@@ -144,7 +144,7 @@ bool VTableSortFilterProxyModel::filterAcceptsRow(int source_row, const QModelIn
 
 
 VTablesWidget::VTablesWidget(MainWindow *main, QAction *action) :
-    CutterWidget(main, action),
+    CutterDockWidget(main, action),
     ui(new Ui::VTablesWidget)
 {
     ui->setupUi(this);

--- a/src/widgets/VTablesWidget.cpp
+++ b/src/widgets/VTablesWidget.cpp
@@ -1,6 +1,7 @@
 #include <QShortcut>
 #include <QModelIndex>
 
+#include "MainWindow.h"
 #include "VTablesWidget.h"
 #include "ui_VTablesWidget.h"
 
@@ -142,8 +143,8 @@ bool VTableSortFilterProxyModel::filterAcceptsRow(int source_row, const QModelIn
 }
 
 
-VTablesWidget::VTablesWidget(QWidget *parent) :
-    QDockWidget(parent),
+VTablesWidget::VTablesWidget(MainWindow *main, QAction *action) :
+    CutterWidget(main, action),
     ui(new Ui::VTablesWidget)
 {
     ui->setupUi(this);

--- a/src/widgets/VTablesWidget.h
+++ b/src/widgets/VTablesWidget.h
@@ -5,14 +5,16 @@
 
 #include <QTreeView>
 #include <QSortFilterProxyModel>
-#include <QDockWidget>
 
 #include "Cutter.h"
+#include "CutterWidget.h"
 
 namespace Ui
 {
     class VTablesWidget;
 }
+
+class MainWindow;
 
 class VTableModel : public QAbstractItemModel
 {
@@ -49,12 +51,12 @@ protected:
     bool filterAcceptsRow(int source_row, const QModelIndex &source_parent) const;
 };
 
-class VTablesWidget : public QDockWidget
+class VTablesWidget : public CutterWidget
 {
     Q_OBJECT
 
 public:
-    explicit VTablesWidget(QWidget *parent = 0);
+    explicit VTablesWidget(MainWindow *main, QAction *action = nullptr);
     ~VTablesWidget();
 
 private slots:

--- a/src/widgets/VTablesWidget.h
+++ b/src/widgets/VTablesWidget.h
@@ -7,7 +7,7 @@
 #include <QSortFilterProxyModel>
 
 #include "Cutter.h"
-#include "CutterWidget.h"
+#include "CutterDockWidget.h"
 
 namespace Ui
 {
@@ -51,7 +51,7 @@ protected:
     bool filterAcceptsRow(int source_row, const QModelIndex &source_parent) const;
 };
 
-class VTablesWidget : public CutterWidget
+class VTablesWidget : public CutterDockWidget
 {
     Q_OBJECT
 


### PR DESCRIPTION
This proposal of refactor includes the following :

### Creation of a new class
Creation of a new class, named CutterWidget, that inherits from QDockWidget and
is used to represent all of the widgets of the main window.
The goal of this class is to regroup all the behaviour shared by the widgets of
Cutter.

For example : in the constructor, instructions corresponding of those
present in the macro `ADD_DOCK` (in MainWindow.cpp) are executed.
This was made because I think that the macro `ADD_DOCK` which is used
to construct the widgets does not take advantage of the object structure.

### Ensure that every widget has a parent
Some widgets were created using the constructor QDockWidget, but using
`nullptr` (default) as argument, thus they haven't got any parent.

The constructor of a CutterWidget takes as argument the MainWindow and an
action (optional) and calls the constructor of QDockWidget with the main
window as argument. This is valid under the assumption that it is mandatory
for every widget to have the main window as a parent.

### Constructors removal
The constructors of some widgets are not used anywhere and does not seem not
fullfill any current usecase. They were removed.

### Unchecking action when closing a widget
When closing a widget by clicking the *close* button, the corresponding element is
unchecked in the list of widgets available.