### PR TITLE
RelocsWidget: Change from QTableView to QTreeView

### DIFF
--- a/src/widgets/RelocsWidget.cpp
+++ b/src/widgets/RelocsWidget.cpp
@@ -77,7 +77,7 @@ RelocsWidget::RelocsWidget(MainWindow *main, QAction *action) :
 {
     ui->setupUi(this);
 
-    ui->relocsTableView->setModel(model);
+    ui->relocsTreeView->setModel(model);
 
     setScrollMode();
 
@@ -86,7 +86,7 @@ RelocsWidget::RelocsWidget(MainWindow *main, QAction *action) :
 
 RelocsWidget::~RelocsWidget() {}
 
-void RelocsWidget::on_relocsTableView_doubleClicked(const QModelIndex &index)
+void RelocsWidget::on_relocsTreeView_doubleClicked(const QModelIndex &index)
 {
     Core()->seek(index.data(RelocsModel::AddressRole).toLongLong());
 }
@@ -96,10 +96,10 @@ void RelocsWidget::refreshRelocs()
     model->beginReload();
     relocs = Core()->getAllRelocs();
     model->endReload();
-    ui->relocsTableView->resizeColumnsToContents();
+    qhelpers::adjustColumns(ui->relocsTreeView, 3, 0);
 }
 
 void RelocsWidget::setScrollMode()
 {
-    qhelpers::setVerticalScrollMode(ui->relocsTableView);
+    qhelpers::setVerticalScrollMode(ui->relocsTreeView);
 }

--- a/src/widgets/RelocsWidget.h
+++ b/src/widgets/RelocsWidget.h
@@ -45,7 +45,7 @@ public:
     ~RelocsWidget();
 
 private slots:
-    void on_relocsTableView_doubleClicked(const QModelIndex &index);
+    void on_relocsTreeView_doubleClicked(const QModelIndex &index);
     void refreshRelocs();
 
 private:

--- a/src/widgets/RelocsWidget.ui
+++ b/src/widgets/RelocsWidget.ui
@@ -28,9 +28,9 @@
      <number>0</number>
     </property>
     <item>
-     <widget class="QTableView" name="relocsTableView">
+     <widget class="QTreeView" name="relocsTreeView">
       <property name="styleSheet">
-       <string notr="true">QTableView::item
+       <string notr="true">QTreeView::item
 {
     padding-top: 1px;
     padding-bottom: 1px;
@@ -39,18 +39,12 @@
       <property name="frameShape">
        <enum>QFrame::NoFrame</enum>
       </property>
-      <property name="showGrid">
-       <bool>false</bool>
+      <property name="indentation">
+       <number>8</number>
       </property>
       <property name="sortingEnabled">
        <bool>true</bool>
       </property>
-      <attribute name="horizontalHeaderStretchLastSection">
-       <bool>true</bool>
-      </attribute>
-      <attribute name="verticalHeaderVisible">
-       <bool>false</bool>
-      </attribute>
      </widget>
     </item>
    </layout>


### PR DESCRIPTION
In the previous PR #418 . I've used the QTableView as it seemed fit for 2D data. However that would seem visually inconsistent with the rest of cutter as it uses QTreeView exclusively. This PR fixes that.