### PR TITLE
 Add information about register used in a function #381 

### DIFF
--- a/src/Cutter.cpp
+++ b/src/Cutter.cpp
@@ -651,22 +651,9 @@ QString CutterCore::getOffsetInfo(QString addr)
     return cmd("ao @ " + addr);
 }
 
-QStringList CutterCore::getRegistersInfo()
+QJsonDocument CutterCore::getRegistersInfo()
 {
-    CORE_LOCK();
-    QStringList ret;
-
-    QJsonObject jsonRoot = cmdj("aeafj").object();
-    foreach (QString key, jsonRoot.keys()) {
-        QString temp;
-        temp.append(key + ":");
-        foreach (QJsonValue value, jsonRoot[key].toArray()) {
-            temp.append(" " + value.toString());
-        }
-        ret.append(temp);
-    }
-
-    return ret;
+    return cmdj("aeafj");
 }
 
 RVA CutterCore::getOffsetJump(RVA addr)

--- a/src/Cutter.cpp
+++ b/src/Cutter.cpp
@@ -651,9 +651,22 @@ QString CutterCore::getOffsetInfo(QString addr)
     return cmd("ao @ " + addr);
 }
 
-QString CutterCore::getRegistersInfo()
+QStringList CutterCore::getRegistersInfo()
 {
-    return cmd("aeaf");
+    CORE_LOCK();
+    QStringList ret;
+
+    QJsonObject jsonRoot = cmdj("aeafj").object();
+    foreach (QString key, jsonRoot.keys()) {
+        QString temp;
+        temp.append(key + ":");
+        foreach (QJsonValue value, jsonRoot[key].toArray()) {
+            temp.append(" " + value.toString());
+        }
+        ret.append(temp);
+    }
+
+    return ret;
 }
 
 RVA CutterCore::getOffsetJump(RVA addr)

--- a/src/Cutter.cpp
+++ b/src/Cutter.cpp
@@ -651,6 +651,11 @@ QString CutterCore::getOffsetInfo(QString addr)
     return cmd("ao @ " + addr);
 }
 
+QString CutterCore::getRegistersInfo()
+{
+    return cmd("aeaf");
+}
+
 RVA CutterCore::getOffsetJump(RVA addr)
 {
     bool ok;

--- a/src/Cutter.h
+++ b/src/Cutter.h
@@ -385,7 +385,7 @@ public:
     ulong get_baddr();
     QList<QList<QString>> get_exec_sections();
     QString getOffsetInfo(QString addr);
-    QStringList getRegistersInfo();
+    QJsonDocument getRegistersInfo();
     RVA getOffsetJump(RVA addr);
     QString getDecompiledCode(RVA addr);
     QString getDecompiledCode(QString addr);

--- a/src/Cutter.h
+++ b/src/Cutter.h
@@ -385,7 +385,7 @@ public:
     ulong get_baddr();
     QList<QList<QString>> get_exec_sections();
     QString getOffsetInfo(QString addr);
-    QString getRegistersInfo();
+    QStringList getRegistersInfo();
     RVA getOffsetJump(RVA addr);
     QString getDecompiledCode(RVA addr);
     QString getDecompiledCode(QString addr);

--- a/src/Cutter.h
+++ b/src/Cutter.h
@@ -385,6 +385,7 @@ public:
     ulong get_baddr();
     QList<QList<QString>> get_exec_sections();
     QString getOffsetInfo(QString addr);
+    QString getRegistersInfo();
     RVA getOffsetJump(RVA addr);
     QString getDecompiledCode(RVA addr);
     QString getDecompiledCode(QString addr);

--- a/src/widgets/SidebarWidget.cpp
+++ b/src/widgets/SidebarWidget.cpp
@@ -232,13 +232,13 @@ void SidebarWidget::fillRegistersInfo()
 
     ui->regInfoTreeWidget->clear();
 
-    QString raw = Core()->getRegistersInfo();
-    QList<QString> lines = raw.split("\n", QString::SkipEmptyParts);
-    foreach (QString line, lines) {
+    QStringList list = Core()->getRegistersInfo();
+    foreach (QString line, list) {
         QList<QString> eles = line.split(":", QString::SkipEmptyParts);
         QTreeWidgetItem *tempItem = new QTreeWidgetItem();
         tempItem->setText(0, eles.at(0).toUpper());
-        tempItem->setText(1, eles.at(1));
+        if (eles.count() > 1)
+            tempItem->setText(1, eles.at(1));
         ui->regInfoTreeWidget->addTopLevelItem(tempItem);
     }
 

--- a/src/widgets/SidebarWidget.cpp
+++ b/src/widgets/SidebarWidget.cpp
@@ -14,7 +14,8 @@
 #include <QFont>
 #include <QUrl>
 #include <QSettings>
-
+#include <QJsonObject>
+#include <QJsonArray>
 
 SidebarWidget::SidebarWidget(MainWindow *main, QAction *action) :
     CutterDockWidget(main, action),
@@ -232,13 +233,15 @@ void SidebarWidget::fillRegistersInfo()
 
     ui->regInfoTreeWidget->clear();
 
-    QStringList list = Core()->getRegistersInfo();
-    foreach (QString line, list) {
-        QList<QString> eles = line.split(":", QString::SkipEmptyParts);
+    QJsonObject jsonRoot = Core()->getRegistersInfo().object();
+    foreach (QString key, jsonRoot.keys()) {
         QTreeWidgetItem *tempItem = new QTreeWidgetItem();
-        tempItem->setText(0, eles.at(0).toUpper());
-        if (eles.count() > 1)
-            tempItem->setText(1, eles.at(1));
+        QString tempString;
+        tempItem->setText(0, key.toUpper());
+        foreach (QJsonValue value, jsonRoot[key].toArray()) {
+            tempString.append(value.toString() + " ");
+        }
+        tempItem->setText(1, tempString);
         ui->regInfoTreeWidget->addTopLevelItem(tempItem);
     }
 

--- a/src/widgets/SidebarWidget.cpp
+++ b/src/widgets/SidebarWidget.cpp
@@ -52,6 +52,7 @@ void SidebarWidget::refresh(RVA addr)
     updateRefs(addr);
     setFcnName(addr);
     fillOffsetInfo(RAddressString(addr));
+    fillRegistersInfo();
 }
 
 void SidebarWidget::on_xrefFromTreeWidget_itemDoubleClicked(QTreeWidgetItem *item, int /*column*/)
@@ -107,6 +108,17 @@ void SidebarWidget::on_xrefToToolButton_clicked()
     } else {
         ui->xrefToTreeWidget->show();
         ui->xrefToToolButton->setArrowType(Qt::DownArrow);
+    }
+}
+
+void SidebarWidget::on_regInfoToolButton_clicked()
+{
+    if (ui->regInfoToolButton->isChecked()) {
+        ui->regInfoTreeWidget->hide();
+        ui->regInfoToolButton->setArrowType(Qt::RightArrow);
+    } else {
+        ui->regInfoTreeWidget->show();
+        ui->regInfoToolButton->setArrowType(Qt::DownArrow);
     }
 }
 
@@ -210,4 +222,26 @@ void SidebarWidget::setScrollMode()
 {
     qhelpers::setVerticalScrollMode(ui->xrefFromTreeWidget);
     qhelpers::setVerticalScrollMode(ui->xrefToTreeWidget);
+}
+
+void SidebarWidget::fillRegistersInfo()
+{
+    TempConfig tempConfig;
+    tempConfig.set("scr.html", false)
+    .set("scr.color", COLOR_MODE_DISABLED);
+
+    ui->regInfoTreeWidget->clear();
+
+    QString raw = Core()->getRegistersInfo();
+    QList<QString> lines = raw.split("\n", QString::SkipEmptyParts);
+    foreach (QString line, lines) {
+        QList<QString> eles = line.split(":", QString::SkipEmptyParts);
+        QTreeWidgetItem *tempItem = new QTreeWidgetItem();
+        tempItem->setText(0, eles.at(0).toUpper());
+        tempItem->setText(1, eles.at(1));
+        ui->regInfoTreeWidget->addTopLevelItem(tempItem);
+    }
+
+    // Adjust columns to content
+    qhelpers::adjustColumns(ui->regInfoTreeWidget, 0);
 }

--- a/src/widgets/SidebarWidget.h
+++ b/src/widgets/SidebarWidget.h
@@ -39,6 +39,7 @@ private:
     void updateRefs(RVA addr);
     void fillRefs(QList<XrefDescription> refs, QList<XrefDescription> xrefs);
     void fillOffsetInfo(QString off);
+    void fillRegistersInfo();
 
     void setScrollMode();
 
@@ -54,6 +55,7 @@ private slots:
     void on_opcodeDescToolButton_clicked();
     void on_xrefFromToolButton_clicked();
     void on_xrefToToolButton_clicked();
+    void on_regInfoToolButton_clicked();
 };
 
 #endif // SIDEBARWIDGET_H

--- a/src/widgets/SidebarWidget.ui
+++ b/src/widgets/SidebarWidget.ui
@@ -318,6 +318,92 @@
            </widget>
           </item>
           <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_17">
+            <property name="spacing">
+             <number>5</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QToolButton" name="regInfoToolButton">
+              <property name="text">
+               <string/>
+              </property>
+              <property name="iconSize">
+               <size>
+                <width>8</width>
+                <height>8</height>
+               </size>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+              <property name="autoRaise">
+               <bool>true</bool>
+              </property>
+              <property name="arrowType">
+               <enum>Qt::DownArrow</enum>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="label_4">
+              <property name="font">
+               <font>
+                <weight>75</weight>
+                <bold>true</bold>
+               </font>
+              </property>
+              <property name="mouseTracking">
+               <bool>true</bool>
+              </property>
+              <property name="text">
+               <string>Function registers info:</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QTreeWidget" name="regInfoTreeWidget">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>100</height>
+             </size>
+            </property>
+            <property name="frameShape">
+             <enum>QFrame::NoFrame</enum>
+            </property>
+            <property name="horizontalScrollBarPolicy">
+             <enum>Qt::ScrollBarAlwaysOff</enum>
+            </property>
+            <property name="indentation">
+             <number>10</number>
+            </property>
+            <property name="headerHidden">
+             <bool>true</bool>
+            </property>
+            <column>
+             <property name="text">
+              <string>Info</string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string>Value</string>
+             </property>
+            </column>
+           </widget>
+          </item>
+          <item>
            <layout class="QHBoxLayout" name="horizontalLayout_16">
             <property name="spacing">
              <number>5</number>
@@ -514,6 +600,12 @@ QToolTip {
             </column>
            </widget>
           </item>
+
+
+
+
+
+
           <item>
            <spacer name="verticalSpacer_4">
             <property name="orientation">

--- a/src/widgets/SidebarWidget.ui
+++ b/src/widgets/SidebarWidget.ui
@@ -600,12 +600,6 @@ QToolTip {
             </column>
            </widget>
           </item>
-
-
-
-
-
-
           <item>
            <spacer name="verticalSpacer_4">
             <property name="orientation">


### PR DESCRIPTION
Added information about registers in the sidebar using ```aeaf```.
![cutter1](https://user-images.githubusercontent.com/15955935/38783768-c83ee986-40fe-11e8-813f-e0598c277b9b.png)
