### PR TITLE
Fixed switching between views in same offset

### DIFF
--- a/src/Cutter.cpp
+++ b/src/Cutter.cpp
@@ -166,9 +166,8 @@ QString CutterCore::cmd(const QString &str)
         if (this->cmd("afi.").trimmed().isEmpty() && memoryWidgetPriority == MemoryWidgetType::Graph) {
             memoryWidgetPriority = MemoryWidgetType::Disassembly;
         }
-
-        triggerRaisePrioritizedMemoryWidget();
     }
+    triggerRaisePrioritizedMemoryWidget();
     return o;
 }
 
@@ -215,6 +214,7 @@ bool CutterCore::loadFile(QString path, ut64 baddr, ut64 mapaddr, int perms, int
 
     f = r_core_file_open(core_, path.toUtf8().constData(), perms, mapaddr);
     if (!f) {
+        // @TODO pop warning msg
         eprintf("r_core_file_open failed\n");
         return false;
     }


### PR DESCRIPTION
Previously if you double-click on an item in search you would only change to disasm/graph view if we were in different offsets. Now, it always switches views.

Might fix https://github.com/radareorg/cutter/issues/398