### PR TITLE
Add forward/back functionality to mouse buttons

### DIFF
--- a/src/CutterApplication.cpp
+++ b/src/CutterApplication.cpp
@@ -83,6 +83,7 @@ CutterApplication::CutterApplication(int &argc, char **argv) : QApplication(argc
     }
 
     mainWindow = new MainWindow();
+    installEventFilter(mainWindow);
 
     if (args.empty()) {
         if (analLevelSpecified) {

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -746,6 +746,19 @@ void MainWindow::mousePressEvent(QMouseEvent *event)
     }
 }
 
+bool MainWindow::eventFilter(QObject *, QEvent *event)
+{
+    if (event->type() == QEvent::MouseButtonPress) {
+        QMouseEvent *mouseEvent = static_cast<QMouseEvent*>(event);
+        if (mouseEvent->button() == Qt::ForwardButton || mouseEvent->button() == Qt::BackButton) {
+            mousePressEvent(mouseEvent);
+            return true;
+        }
+    }
+
+    return false;
+}
+
 void MainWindow::addToDockWidgetList(QDockWidget *dockWidget)
 {
     this->dockWidgets.push_back(dockWidget);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -732,6 +732,20 @@ void MainWindow::projectSaved(const QString &name)
     addOutput(tr("Project saved: ") + name);
 }
 
+void MainWindow::mousePressEvent(QMouseEvent *event)
+{
+    switch (event->button()) {
+    case Qt::BackButton:
+        Core()->seekPrev();
+        break;
+    case Qt::ForwardButton:
+        Core()->seekNext();
+        break;
+    default:
+        break;
+    }
+}
+
 void MainWindow::addToDockWidgetList(QDockWidget *dockWidget)
 {
     this->dockWidgets.push_back(dockWidget);

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -155,6 +155,7 @@ private slots:
     void projectSaved(const QString &name);
 
     void mousePressEvent(QMouseEvent *event) override;
+    bool eventFilter(QObject *object, QEvent *event);
 
 private:
     CutterCore *core;

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -154,6 +154,8 @@ private slots:
 
     void projectSaved(const QString &name);
 
+    void mousePressEvent(QMouseEvent *event) override;
+
 private:
     CutterCore *core;
 


### PR DESCRIPTION
Really simple quality-of-life feature: this binds the two side buttons on the mouse to seek forward and backward, like in a web browser.