### PR TITLE
Fix copy assignement operator to be deleted

### DIFF
--- a/src/dialogs/preferences/PreferenceCategory.h
+++ b/src/dialogs/preferences/PreferenceCategory.h
@@ -19,8 +19,8 @@ public:
     void addItem(QTreeWidgetItem &tree, QStackedWidget &panel);
 
 private:
-    const QString name;
-    const QIcon icon;
+    QString name;
+    QIcon icon;
     QWidget *widget;
     QList<PreferenceCategory> children;
 };


### PR DESCRIPTION
Having `const` members in the PreferenceCategory class makes g++ to delete the copy assignement.