### PR TITLE
Disable align to 0 of HexdumpWidget, highlight current seek (FIX #64)

### DIFF
--- a/src/widgets/HexdumpWidget.cpp
+++ b/src/widgets/HexdumpWidget.cpp
@@ -319,10 +319,10 @@ void HexdumpWidget::refresh(RVA addr)
     ui->hexHexText->ensureCursorVisible();
 
     // Set the backgorund color of the current seek
-    QTextCursor offset_cursor(ui->hexOffsetText->document()->findBlockByLineNumber(curAddrLineOffset));
-    QTextBlockFormat formatTmp = offset_cursor.blockFormat();
+    QTextCursor offsetCursor(ui->hexOffsetText->document()->findBlockByLineNumber(curAddrLineOffset));
+    QTextBlockFormat formatTmp = offsetCursor.blockFormat();
     formatTmp.setBackground(QColor(64, 129, 160));
-    offset_cursor.setBlockFormat(formatTmp);
+    offsetCursor.setBlockFormat(formatTmp);
     
     updateWidths();
 

--- a/src/widgets/HexdumpWidget.cpp
+++ b/src/widgets/HexdumpWidget.cpp
@@ -289,9 +289,6 @@ void HexdumpWidget::refresh(RVA addr)
     if (cols == 0)
         cols = 16;
 
-    // Align addr to cols
-    addr -= addr % cols;
-
     // TODO: Figure out how to calculate a sane value for this
     bufferLines = qhelpers::getMaxFullyDisplayedLines(ui->hexHexText);
 
@@ -321,6 +318,12 @@ void HexdumpWidget::refresh(RVA addr)
     ui->hexHexText->setTextCursor(cursor);
     ui->hexHexText->ensureCursorVisible();
 
+    // Set the backgorund color of the current seek
+    QTextCursor offset_cursor(ui->hexOffsetText->document()->findBlockByLineNumber(curAddrLineOffset));
+    QTextBlockFormat format_tmp = offset_cursor.blockFormat();
+    format_tmp.setBackground(QColor(64, 129, 160));
+    offset_cursor.setBlockFormat(format_tmp);
+    
     updateWidths();
 
     // Update other text areas scroll

--- a/src/widgets/HexdumpWidget.cpp
+++ b/src/widgets/HexdumpWidget.cpp
@@ -320,9 +320,9 @@ void HexdumpWidget::refresh(RVA addr)
 
     // Set the backgorund color of the current seek
     QTextCursor offset_cursor(ui->hexOffsetText->document()->findBlockByLineNumber(curAddrLineOffset));
-    QTextBlockFormat format_tmp = offset_cursor.blockFormat();
-    format_tmp.setBackground(QColor(64, 129, 160));
-    offset_cursor.setBlockFormat(format_tmp);
+    QTextBlockFormat formatTmp = offset_cursor.blockFormat();
+    formatTmp.setBackground(QColor(64, 129, 160));
+    offset_cursor.setBlockFormat(formatTmp);
     
     updateWidths();
 


### PR DESCRIPTION
Fixed and added features described in issue #64 .
Disabled the alginment to `0x???????0` and made the current seek the first column.
Added color to highlight the current seek address.