### PR TITLE
Fixed x-refs to Address

### DIFF
--- a/src/Cutter.cpp
+++ b/src/Cutter.cpp
@@ -1418,7 +1418,7 @@ QList<XrefDescription> CutterCore::getXRefs(RVA addr, bool to, bool whole_functi
             continue;
 
         xref.from = xrefObject["from"].toVariant().toULongLong();
-        xref.from_str = Core()->cmd("fd " + xrefObject["from"].toString()).trimmed();
+        xref.from_str = Core()->cmd("fd " + QString::number(xrefObject["from"].toInt())).trimmed();
 
         if (!whole_function && !to && xref.from != addr)
             continue;


### PR DESCRIPTION
`fd` received an empty string which caused it to show the wrong offset.

Fixed from this:
![image](https://user-images.githubusercontent.com/20182642/39996082-105f2dc2-5787-11e8-96c3-080db9834963.png)



To this:
![image](https://user-images.githubusercontent.com/20182642/39996008-d5ad7d6e-5786-11e8-8dc0-7b3da905a6e7.png)

Note the "Address" column
