### PR TITLE
Graph improvements

### DIFF
--- a/src/widgets/GraphView.cpp
+++ b/src/widgets/GraphView.cpp
@@ -906,3 +906,13 @@ void GraphView::mouseReleaseEvent(QMouseEvent *event)
         viewport()->releaseMouse();
     }
 }
+
+void GraphView::wheelEvent(QWheelEvent *event)
+{
+    const QPoint delta = -event->angleDelta();
+    int x_delta = delta.x();
+    int y_delta = delta.y();
+    horizontalScrollBar()->setValue(horizontalScrollBar()->value() + x_delta * (1/current_scale));
+    verticalScrollBar()->setValue(verticalScrollBar()->value() + y_delta * (1/current_scale));
+    event->accept();
+}

--- a/src/widgets/GraphView.cpp
+++ b/src/widgets/GraphView.cpp
@@ -411,6 +411,9 @@ void GraphView::paintEvent(QPaintEvent *event)
 {
     Q_UNUSED(event);
     QPainter p(viewport());
+    
+    p.setRenderHint(QPainter::Antialiasing);
+    
     int render_offset_x = -horizontalScrollBar()->value() * current_scale;
     int render_offset_y = -verticalScrollBar()->value() * current_scale;
     int render_width = viewport()->size().width() / current_scale;

--- a/src/widgets/GraphView.cpp
+++ b/src/widgets/GraphView.cpp
@@ -864,8 +864,8 @@ void GraphView::mouseMoveEvent(QMouseEvent *event)
         int y_delta = scroll_base_y - event->y();
         scroll_base_x = event->x();
         scroll_base_y = event->y();
-        horizontalScrollBar()->setValue(horizontalScrollBar()->value() + x_delta);
-        verticalScrollBar()->setValue(verticalScrollBar()->value() + y_delta);
+        horizontalScrollBar()->setValue(horizontalScrollBar()->value() + x_delta * (1/current_scale));
+        verticalScrollBar()->setValue(verticalScrollBar()->value() + y_delta * (1/current_scale));
     }
 }
 

--- a/src/widgets/GraphView.h
+++ b/src/widgets/GraphView.h
@@ -121,6 +121,7 @@ protected:
     virtual void blockHelpEvent(GraphView::GraphBlock &block, QHelpEvent *event, QPoint pos);
     virtual bool helpEvent(QHelpEvent *event);
     virtual void blockTransitionedTo(GraphView::GraphBlock *to);
+    virtual void wheelEvent(QWheelEvent *event) override;
     virtual EdgeConfiguration edgeConfiguration(GraphView::GraphBlock &from, GraphView::GraphBlock *to);
 
     void adjustSize(int new_width, int new_height, QPoint mouse = QPoint(0, 0));


### PR DESCRIPTION
Makes the graph arrows and lines anti-aliased for better viewing on low-resolution screens:
Before
![before_alias](https://user-images.githubusercontent.com/8339834/40273049-e3cb1308-5b6d-11e8-926f-09a6b1c14883.png)
After
![after_alias](https://user-images.githubusercontent.com/8339834/40273051-e7d5083c-5b6d-11e8-983c-ea80c632330a.png)

Makes panning/scrolling scale proportionally with the zoom level, so panning while zoomed out doesn't feel slow:
Before
![before_grab](https://user-images.githubusercontent.com/8339834/40273060-0757d8f6-5b6e-11e8-9802-de926911bcfa.gif)
After
![after_grab](https://user-images.githubusercontent.com/8339834/40273061-0e746d20-5b6e-11e8-9d65-efc0699fd195.gif)
