### PR TITLE
 Make calls more readble and user-friendly

### DIFF
--- a/src/Cutter.cpp
+++ b/src/Cutter.cpp
@@ -1559,7 +1559,7 @@ QList<DisassemblyLine> CutterCore::disassembleLines(RVA offset, int lines)
 
         DisassemblyLine line;
         line.offset = object["offset"].toVariant().toULongLong();
-        line.text = object["text"].toString();
+        line.text = object["text"].toString().replace(QRegularExpression("dword[&nbsp;]+\\[sym\\.imp\\..+_(.+)\\]"), "\\1");
 
         r << line;
     }

--- a/src/Cutter.cpp
+++ b/src/Cutter.cpp
@@ -1559,7 +1559,10 @@ QList<DisassemblyLine> CutterCore::disassembleLines(RVA offset, int lines)
 
         DisassemblyLine line;
         line.offset = object["offset"].toVariant().toULongLong();
-        line.text = object["text"].toString().replace(QRegularExpression("dword[&nbsp;]+\\[sym\\.imp\\..+_(.+)\\]"), "\\1");
+
+        // If the'rs a call to an API function, clean how it looks like and remove "dword [sym.imp...]" from the line.
+        line.text = object["text"].toString().replace(
+                                QRegularExpression("(dword[&nbsp;]*)*\\[sym\\.imp\\..+_(.+)\\]", QRegularExpression::CaseInsensitiveOption), "\\2");
 
         r << line;
     }

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -223,7 +223,9 @@ void DisassemblerGraphView::loadCurrentGraph()
             i.size -= 1;
 
             QString disas;
-            disas = op["text"].toString().replace(QRegularExpression("dword[&nbsp;]+\\[sym\\.imp\\..+_(.+)\\]"), "\\1");
+             // If the'rs a call to an API function, clean how it looks like and remove "dword [sym.imp...]" from the line.
+            disas = op["text"].toString().replace(
+                            QRegularExpression("(dword[&nbsp;]*)*\\[sym\\.imp\\..+_(.+)\\]", QRegularExpression::CaseInsensitiveOption), "\\2");
 
             QTextDocument textDoc;
             textDoc.setHtml(disas);

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -5,6 +5,7 @@
 #include <QJsonArray>
 #include <QMouseEvent>
 #include <QPropertyAnimation>
+#include <QRegularExpression>
 #include <QShortcut>
 #include <QToolTip>
 #include <QTextDocument>
@@ -222,7 +223,7 @@ void DisassemblerGraphView::loadCurrentGraph()
             i.size -= 1;
 
             QString disas;
-            disas = op["text"].toString();
+            disas = op["text"].toString().replace(QRegularExpression("dword[&nbsp;]+\\[sym\\.imp\\..+_(.+)\\]"), "\\1");
 
             QTextDocument textDoc;
             textDoc.setHtml(disas);


### PR DESCRIPTION
These changes aim to make the disassembly more readable. I know this is quite an ugly solution, but  it'll be enough untill we develop a more permanent fix to radare2's `agJ` and `pdj`.

I used Regex to make something like this:
```
call dword [sym.imp.KERNEL32.dll_GetModuleFileNameW]
```
To look Like this:
```
call GetModuleFileNameW
```

## Screenshots
**Before:**

![image](https://user-images.githubusercontent.com/20182642/41018484-afd433d8-6962-11e8-8cea-9df9d7289d2f.png)

![image](https://user-images.githubusercontent.com/20182642/41018502-c2102bf6-6962-11e8-96f1-d23236a2455f.png)

-----

**After:**

![image](https://user-images.githubusercontent.com/20182642/41018206-468ab664-6961-11e8-92fd-699360f1da03.png)


![image](https://user-images.githubusercontent.com/20182642/41018162-15a1b476-6961-11e8-8f10-4b57c57be6a6.png)
