### PR TITLE
Add appstream XML file

### DIFF
--- a/src/Cutter.appdata.xml
+++ b/src/Cutter.appdata.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id>Cutter.desktop</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0</project_license>
+  <name>Cutter</name>
+  <summary>A Qt and C++ GUI for radare2 reverse engineering framework</summary>
+  <description>
+    <p>
+      Cutter is Qt and C++ GUI for radare2, originally named Iaito. It is not aimed at existing radare2 users, but focuses on those whose aren’t fluent yet with the command line, likely because of the steep learning curve.
+    </p>
+  </description>
+  <screenshots>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/radareorg/cutter/master/docs/screenshot.png</image>
+      <caption>Main UI</caption>
+    </screenshot>
+    <screenshot>
+      <image>http://beta.rada.re/en/latest/_images/cutter.png</image>
+      <caption>Light Theme</caption>
+    </screenshot>
+    <screenshot>
+      <image>http://beta.rada.re/en/latest/_images/cutter_dark.jpg</image>
+      <caption>Dark Theme</caption>
+    </screenshot>
+  </screenshots>
+  <url type="homepage">http://beta.rada.re/en/latest/cutter.html</url>
+  <releases>
+    <release version="1.4" date="2018-04-24" />
+    <release version="1.3" date="2018-03-09" />
+    <release version="1.2" date="2018-01-30" />
+    <release version="1.1" date="2017-12-25" />
+    <release version="1.0" date="2017-12-03" />
+  </releases>
+</component>

--- a/src/Cutter.pro
+++ b/src/Cutter.pro
@@ -315,13 +315,18 @@ unix {
 
     desktop_file = Cutter.desktop
 
-    # built-in no need for files atm
-    target.path = $$PREFIX/bin
-
     share_applications.path = $$PREFIX/share/applications
     share_applications.files = $$desktop_file
 
-    INSTALLS += target share_applications share_pixmaps
+    appstream_file = Cutter.appdata.xml
+
+    share_appdata.path = $$PREFIX/share/appdata
+    share_appdata.files = $$appstream_file
+
+    # built-in no need for files atm
+    target.path = $$PREFIX/bin
+
+    INSTALLS += target share_appdata share_applications share_pixmaps
 
     # Triggered for example by 'qmake APPIMAGE=1'
     !isEmpty(APPIMAGE){


### PR DESCRIPTION
I am in the process of packaging Cutter for flathub: https://github.com/flathub/flathub/pull/422
I created an appstream file in the process. This pull request is for the case that this file might be useful to you.

(Note that I hadn't seen the inside of a qmake file before writing this patch, so you might want to have a second look at that…)