### PR TITLE
Fix references to pkg-config in lib_radare2.pri for Unix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ cache: ccache
 branches:
   only:
   - master
-  - pkgconfig-fix
   - /^v\d.*$/
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache: ccache
 branches:
   only:
   - master
+  - pkgconfig-fix
   - /^v\d.*$/
 
 matrix:

--- a/src/lib_radare2.pri
+++ b/src/lib_radare2.pri
@@ -46,9 +46,16 @@ win32 {
         # caution: may not work for cross compilations
         PKG_CONFIG_PATH=$$PKG_CONFIG_PATH:$$R2_USER_PKGCONFIG
     } else {
-        exists($$PREFIX/lib/pkgconfig/r_core.pc) {
-            PKG_CONFIG_PATH=$$PKG_CONFIG_PATH:$$PREFIX/lib/pkgconfig
-        } else {
+        unix {
+            exists($$PREFIX/lib/pkgconfig/r_core.pc) {
+                PKG_CONFIG_PATH=$$PKG_CONFIG_PATH:$$PREFIX/lib/pkgconfig
+            } else {
+                LIBS += -L$$PREFIX/lib
+                INCLUDEPATH += $$PREFIX/include/libr
+                USE_PKGCONFIG = 0
+           }
+        }
+        macx {
             LIBS += -L$$PREFIX/lib
             INCLUDEPATH += $$PREFIX/include/libr
             USE_PKGCONFIG = 0

--- a/src/lib_radare2.pri
+++ b/src/lib_radare2.pri
@@ -44,10 +44,10 @@ win32 {
     R2_USER_PKGCONFIG = $$(HOME)/bin/prefix/radare2/lib/pkgconfig
     exists($$R2_USER_PKGCONFIG) {
         # caution: may not work for cross compilations
-        QMAKE_PKG_CONFIG = PKG_CONFIG_PATH=$$R2_USER_PKGCONFIG pkg-config
+        PKG_CONFIG_PATH=$$PKG_CONFIG_PATH:$$R2_USER_PKGCONFIG
     } else {
         exists($$PREFIX/lib/pkgconfig/r_core.pc) {
-            QMAKE_PKG_CONFIG = PKG_CONFIG_PATH=$$PREFIX/lib/pkgconfig pkg-config
+            PKG_CONFIG_PATH=$$PKG_CONFIG_PATH:$$PREFIX/lib/pkgconfig
         } else {
             LIBS += -L$$PREFIX/lib
             INCLUDEPATH += $$PREFIX/include/libr

--- a/src/lib_radare2.pri
+++ b/src/lib_radare2.pri
@@ -35,16 +35,22 @@ win32 {
         -lr_crypto \
         -lr_shlr
 } else {
+    macx {
+        PREFIX=/usr/local
+    } else {
+        PREFIX=/usr
+    }
     USE_PKGCONFIG = 1
     R2_USER_PKGCONFIG = $$(HOME)/bin/prefix/radare2/lib/pkgconfig
     exists($$R2_USER_PKGCONFIG) {
         # caution: may not work for cross compilations
         QMAKE_PKG_CONFIG = PKG_CONFIG_PATH=$$R2_USER_PKGCONFIG pkg-config
     } else {
-        exists(/usr/local/lib/pkgconfig/r_core.pc) {
-            QMAKE_PKG_CONFIG = PKG_CONFIG_PATH=/usr/local/lib/pkgconfig pkg-config
-            LIBS += -L/usr/local/lib
-            INCLUDEPATH += /usr/local/include/libr
+        exists($$PREFIX/lib/pkgconfig/r_core.pc) {
+            QMAKE_PKG_CONFIG = PKG_CONFIG_PATH=$$PREFIX/lib/pkgconfig pkg-config
+        } else {
+            LIBS += -L$$PREFIX/lib
+            INCLUDEPATH += $$PREFIX/include/libr
             USE_PKGCONFIG = 0
         }
     }


### PR DESCRIPTION
In Unix systems (not macOSX) radare2 is installed under /usr and pkg-config files are put under /usr/lib/pkgconfig. For macOSX instead the /usr/local should be used, although I cannot test it because I do not have a mac system.

[https://github.com/radare/radare2/blob/master/sys/build.sh](url)
From line 15

Also, I think the logic should be correct now: if r_core.pc is found, use pkg-config, otherwise set LIB and INCLUDEPATH manually and set USE_PKGCONFIG to 0.