### PR TITLE
Docker: Set correct image name

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -4,7 +4,7 @@ SHELL := /bin/bash
 DIR := $(shell echo $(shell cd "$(shell  dirname "${BASH_SOURCE[0]}" )" && pwd ))
 
 VERSION ?= latest
-IMAGE_NAME ?= radare/cutter
+IMAGE_NAME ?= radareorg/cutter
 CONTAINER_NAME ?= cutter
 
 # This will output the help for each task
@@ -16,8 +16,6 @@ help: ## This help
 
 .DEFAULT_GOAL := help
 
-
-# DOCKER TASKS
 # Build the container
 build: ## Build the container
 	sudo docker build --rm -t $(IMAGE_NAME) .

--- a/docker/README.md
+++ b/docker/README.md
@@ -18,7 +18,7 @@ sudo docker run \
     -v $PWD/sharedFolder:/var/sharedFolder \
     -v $PWD/radare2rc:/home/r2/.radare2rc \
     -v $PWD/r2-config:/home/r2/.config/radare2 \
-    radare/cutter:latest
+    radareorg/cutter:latest
 ```
 
 or by using the `Makefile` (after additional configuration to make it fit your needs) by executing `make build` and `make run`.


### PR DESCRIPTION
The cutter docker image name is `radareorg/cutter/` (see https://hub.docker.com/r/radareorg/cutter/), so I've edited the docker related files to use that name.