### PR TITLE
Docker: Fix running, Add Xauth settings, Add binary loading

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -62,4 +62,4 @@ RUN chown -R r2:r2 /var/sharedFolder
 RUN chown -R r2:r2 /home/r2/
 USER r2
 
-ENTRYPOINT ["/bin/bash", "-c", "/opt/cutter/build/cutter"]
+ENTRYPOINT ["/opt/cutter/build/Cutter"]

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,7 +1,14 @@
 SHELL := /bin/bash
 
+
 # The directory of this file
 DIR := $(shell echo $(shell cd "$(shell  dirname "${BASH_SOURCE[0]}" )" && pwd ))
+
+# To mount a specific binary using BINARY=/absolute/path/to/binary
+ifdef BINARY
+    MOUNTFLAGS += -v $(BINARY):/home/r2/$(shell basename $(BINARY)):ro
+    RUNFLAGS += /home/r2/$(shell basename $(BINARY))
+endif
 
 VERSION ?= latest
 IMAGE_NAME ?= radareorg/cutter
@@ -24,21 +31,31 @@ build-nc: ## Build the container without caching
 	sudo docker build --rm --no-cache -t $(IMAGE_NAME) .
 
 run: ## Run container
+	XSOCK=/tmp/.X11-unix && \
+	XAUTH=$(shell mktemp /tmp/r2cutter_tmp.XXX.xauth) && \
+	xauth nlist $$DISPLAY | sed -e 's/^..../ffff/' | xauth -f $$XAUTH nmerge - && \
+	chmod 644 $$XAUTH && \
 	touch $(DIR)/radare2rc && \
 	mkdir -p $(DIR)/r2-config && \
 	mkdir -p $(DIR)/sharedFolder && \
-	xhost +local:root && \
 	sudo docker run \
-	-it \
-	--name $(CONTAINER_NAME) \
-	--cap-drop=ALL  \
-	--cap-add=SYS_PTRACE \
-	-e DISPLAY=$$DISPLAY \
-	-v /tmp/.X11-unix:/tmp/.X11-unix:ro \
-	-v $(DIR)/sharedFolder:/var/sharedFolder \
-	-v $(DIR)/radare2rc:/home/r2/.radare2rc \
-	-v $(DIR)/r2-config:/home/r2/.config/radare2 \
-	$(IMAGE_NAME):$(VERSION)
+		-it \
+		--name $(CONTAINER_NAME) \
+		--cap-drop=ALL  \
+		--cap-add=SYS_PTRACE \
+		-e DISPLAY=$$DISPLAY \
+		-e XAUTHORITY=$$XAUTH \
+		-v $$XSOCK:$$XSOCK:ro \
+		-v $$XAUTH:$$XAUTH \
+		$(MOUNTFLAGS) \
+		-v $(DIR)/sharedFolder:/var/sharedFolder \
+		-v $(DIR)/radare2rc:/home/r2/.radare2rc \
+		-v $(DIR)/r2-config:/home/r2/.config/radare2 \
+		$(IMAGE_NAME):$(VERSION) $(RUNFLAGS) && \
+	rm $$XAUTH
+
+get: ## Get the latest Cutter image
+	sudo docker pull $(IMAGE_NAME):$(VERSION)
 
 stop: ## Stop a running container
 	sudo docker stop $(CONTAINER_NAME)

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,24 +1,16 @@
 # Docker Configuration for Cutter
 
-These files provide an easy way to deploy *cutter* in a docker container.
+These files provide an easy way to deploy *Cutter* in a Docker container. After additional configuration you may want to apply to the `Makefile`, execute `make run`. By default, the *Cutter* image on [Docker Hub](https://hub.docker.com/r/radareorg/cutter/) will be used along with additional capability, X and mount settings:
 
-You can use the pre-built image like:
-```
-touch $PWD/radare2rc && \
-mkdir -p $PWD/r2-config && \
-mkdir -p $PWD/sharedFolder && \
-xhost +local:root && \
-sudo docker run \
-    -it \
-    --name cutter \
-    --cap-drop=ALL  \
-    --cap-add=SYS_PTRACE \
-    -e DISPLAY=$DISPLAY \
-    -v /tmp/.X11-unix:/tmp/.X11-unix:ro \
-    -v $PWD/sharedFolder:/var/sharedFolder \
-    -v $PWD/radare2rc:/home/r2/.radare2rc \
-    -v $PWD/r2-config:/home/r2/.config/radare2 \
-    radareorg/cutter:latest
-```
+- Xauthority settings which avoid using potentially insecure `xhost` directives. The settings have been adapted from [this post](https://stackoverflow.com/questions/16296753/can-you-run-gui-apps-in-a-docker-container/25280523#25280523).
+- Mount directives to mount a shared folder and radare2 configuration files.
+- Capability dropping to only use `SYS_PTRACE`.
 
-or by using the `Makefile` (after additional configuration to make it fit your needs) by executing `make build` and `make run`.
+## Mounting and Using a Specific Binary
+
+The `Makefile` allows mounting a single binary file as read-only, which will also be used as an input for *Cutter*. To use this feature, execute `make run BINARY=/absolote/path/to/binary`.
+
+## Additional Notes
+
+- The internal container user doesn't use superuser privileges and is called `r2`.
+- To check for more options of the `Makefile`, execute `make`.


### PR DESCRIPTION
Hey there. This PR does these things:

- Fix an error encountered when running the container (Wrong directory name of the cutter executable).
- Add proper Xauth settings when running the container to avoid using something like `xhost +root`.
- Add a feature to directly use a binary as input for cutter using a read-only mount.
- Add `make get` to update the local image.
- Update documentation.

Note: If this gets merged, please also update the readme on docker hub :)