### PR TITLE
Docker: Add UID/GID mapping, Refactoring

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,20 +4,21 @@ LABEL maintainer "pschmied <ps1337@mailbox.org>"
 # Dependencies
 RUN apt-get update && \
     apt-get -y install \
-    curl \
-    libqt5svg5-dev \
-    make \
-    qtbase5-dev \
-    qtwebengine5-dev \
-    unzip \
-    wget \
-    cmake \
-    g++ \
-    gcc \
-    git-core \
-    python3 \
-    python3-dev \
-    pkg-config
+        cmake \
+        curl \
+        g++ \
+        gcc \
+        git-core \
+        gosu \
+        libqt5svg5-dev \
+        make \
+        pkg-config \
+        python3 \
+        python3-dev \
+        qtbase5-dev \
+        qtwebengine5-dev \
+        unzip \
+        wget
 
 # Get latest cutter release
 WORKDIR /opt
@@ -40,26 +41,26 @@ RUN rm -rf radare2 && \
     wget -O radare2.zip -i - && \
     unzip radare2.zip && \
     rm radare2.zip && \
-    mv radare-radare2* radare2
-
-RUN cd radare2 && ./sys/install.sh
+    mv radare-radare2* radare2 && \
+    cd radare2 && ./sys/install.sh
 
 # Build cutter
 RUN mkdir build
 WORKDIR /opt/cutter/build
-RUN cmake ../src
-RUN make
+RUN cmake ../src && \
+    make
 
 # Add r2 user
 RUN useradd r2
 
+# Prepare files to mount configurations later on
+RUN mkdir /var/sharedFolder && \
+    mkdir -p /home/r2/.config/radare2 && \
+    touch /home/r2/.radare2rc
+
+RUN chown -R r2:r2 /var/sharedFolder && \
+    chown -R r2:r2 /home/r2/
+
 WORKDIR /home/r2
-RUN mkdir /var/sharedFolder
-RUN mkdir -p /home/r2/.config/radare2
-RUN touch /home/r2/.radare2rc
-
-RUN chown -R r2:r2 /var/sharedFolder
-RUN chown -R r2:r2 /home/r2/
 USER r2
-
 ENTRYPOINT ["/opt/cutter/build/Cutter"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -62,5 +62,5 @@ RUN chown -R r2:r2 /var/sharedFolder && \
     chown -R r2:r2 /home/r2/
 
 WORKDIR /home/r2
-USER r2
-ENTRYPOINT ["/opt/cutter/build/Cutter"]
+ADD entrypoint.sh /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,8 +1,11 @@
 SHELL := /bin/bash
 
-
 # The directory of this file
 DIR := $(shell echo $(shell cd "$(shell  dirname "${BASH_SOURCE[0]}" )" && pwd ))
+
+# The local users UID/GID
+LUID := $(shell id -u)
+LGID := $(shell id -g)
 
 # To mount a specific binary using BINARY=/absolute/path/to/binary
 ifdef BINARY
@@ -41,10 +44,11 @@ run: ## Run container
 	sudo docker run \
 		-it \
 		--name $(CONTAINER_NAME) \
-		--cap-drop=ALL  \
 		--cap-add=SYS_PTRACE \
 		-e DISPLAY=$$DISPLAY \
 		-e XAUTHORITY=$$XAUTH \
+		-e LOCAL_USER_ID=$(LUID) \
+		-e LOCAL_GROUP_ID=$(LGID) \
 		-v $$XSOCK:$$XSOCK:ro \
 		-v $$XAUTH:$$XAUTH \
 		$(MOUNTFLAGS) \

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,10 +1,10 @@
 # Docker Configuration for Cutter
 
-These files provide an easy way to deploy *Cutter* in a Docker container. After additional configuration you may want to apply to the `Makefile`, execute `make run`. By default, the *Cutter* image on [Docker Hub](https://hub.docker.com/r/radareorg/cutter/) will be used along with additional capability, X and mount settings:
+These files provide an easy way to deploy *Cutter* in a Docker container. After additional configuration you may want to apply to the `Makefile`, execute `make run`. By default, the *Cutter* image on [Docker Hub](https://hub.docker.com/r/radareorg/cutter/) will be used along with additional UID, capability, X and mount settings:
 
 - Xauthority settings which avoid using potentially insecure `xhost` directives. The settings have been adapted from [this post](https://stackoverflow.com/questions/16296753/can-you-run-gui-apps-in-a-docker-container/25280523#25280523).
 - Mount directives to mount a shared folder and radare2 configuration files.
-- Capability dropping to only use `SYS_PTRACE`.
+- The UID and GID of the user executing `make run` will also be used for the internal container user to avoid permission problems when sharing files.
 
 ## Mounting and Using a Specific Binary
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+USERNAME="r2"
+
+echo "Cutter: Starting with UID:GID $LOCAL_USER_ID:$LOCAL_GROUP_ID"
+usermod -u $LOCAL_USER_ID $USERNAME
+usermod -g $LOCAL_GROUP_ID $USERNAME
+export HOME=/home/$USERNAME
+
+exec gosu $USERNAME "/opt/cutter/build/Cutter" $@


### PR DESCRIPTION
Hey there. This PR does these things:

- Reduce the docker image layer count by merging commands.
- When using `make run`, the local users UID/GID will be also be used for the internal container user to avoid problems when sharing files.
- Add documentation for the point above.