### PR TITLE
Docker: Fix typo in README.md, travis: fix image name

### DIFF
--- a/docker/.travis.yml
+++ b/docker/.travis.yml
@@ -4,5 +4,4 @@ services:
   - docker
 
 script:
-  - docker build -t radare/cutter .
-  - docker images
+  - docker build -t radareorg/cutter .

--- a/docker/README.md
+++ b/docker/README.md
@@ -8,7 +8,7 @@ These files provide an easy way to deploy *Cutter* in a Docker container. After 
 
 ## Mounting and Using a Specific Binary
 
-The `Makefile` allows mounting a single binary file as read-only, which will also be used as an input for *Cutter*. To use this feature, execute `make run BINARY=/absolote/path/to/binary`.
+The `Makefile` allows mounting a single binary file as read-only, which will also be used as an input for *Cutter*. To use this feature, execute `make run BINARY=/absolute/path/to/binary`.
 
 ## Additional Notes
 


### PR DESCRIPTION
Just a quick fix of a typo and the image name in the `.travis.yml` file.