### PR TITLE
Added multithreaded compilation on Windows

### DIFF
--- a/src/Cutter.pro
+++ b/src/Cutter.pro
@@ -46,8 +46,8 @@ win32 {
     QMAKE_CXXFLAGS_RELEASE += -Zi   # Compiler
     QMAKE_LFLAGS_RELEASE += /DEBUG  # Linker
 	
-	# Multithreaded compilation
-	QMAKE_CXXFLAGS += -MP
+    # Multithreaded compilation
+    QMAKE_CXXFLAGS += -MP
 }
 
 macx {

--- a/src/Cutter.pro
+++ b/src/Cutter.pro
@@ -45,6 +45,9 @@ win32 {
     # Generate debug symbols in release mode
     QMAKE_CXXFLAGS_RELEASE += -Zi   # Compiler
     QMAKE_LFLAGS_RELEASE += /DEBUG  # Linker
+	
+	# Multithreaded compilation
+	QMAKE_CXXFLAGS += -MP
 }
 
 macx {


### PR DESCRIPTION
Simple change.

I've omitted the _RELEASE part of CXXFLAGS so it works on debug mode too, if you use that.