### PR TITLE
adding Open Shellcode function to the New menu mode

### DIFF
--- a/src/AnalTask.cpp
+++ b/src/AnalTask.cpp
@@ -71,7 +71,7 @@ void AnalTask::runTask()
         return;
     }
 
-    if (!options.shellcode.isNull() && options.shellcode.size() * 0.5 > 0) {
+    if (!options.shellcode.isNull() && options.shellcode.size() / 2 > 0) {
         log(tr("Loading shellcode...\n"));
         Core()->cmd("wx " + options.shellcode);
     }

--- a/src/AnalTask.cpp
+++ b/src/AnalTask.cpp
@@ -71,7 +71,7 @@ void AnalTask::runTask()
         return;
     }
 
-    if (!options.shellcode.isNull()) {
+    if (!options.shellcode.isNull() && options.shellcode.size() * 0.5 > 0) {
         log(tr("Loading shellcode...\n"));
         Core()->cmd("wx " + options.shellcode);
     }

--- a/src/AnalTask.cpp
+++ b/src/AnalTask.cpp
@@ -71,6 +71,11 @@ void AnalTask::runTask()
         return;
     }
 
+    if (!options.shellcode.isNull()) {
+        log(tr("Loading shellcode...\n"));
+        Core()->cmd("wx " + options.shellcode);
+    }
+
     if (options.endian != InitialOptions::Endianness::Auto) {
         Core()->setEndianness(options.endian == InitialOptions::Endianness::Big);
     }

--- a/src/AnalTask.h
+++ b/src/AnalTask.h
@@ -37,6 +37,8 @@ struct InitialOptions
 	int bbsize = 0;
 
 	QList<QString> analCmd;
+
+	QString shellcode;
 };
 
 class AnalTask : public AsyncTask

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -312,7 +312,7 @@ void MainWindow::addExtraWidget(QDockWidget *extraDock)
     restoreExtraDock.restoreWidth(extraDock->widget());
 }
 
-void MainWindow::openNewFile(const QString &fn, int analLevel, QList<QString> advancedOptions)
+void MainWindow::openNewFile(const QString &fn, int analLevel, QList<QString> advancedOptions, const QString &shellcode)
 {
     setFilename(fn);
 
@@ -330,7 +330,7 @@ void MainWindow::openNewFile(const QString &fn, int analLevel, QList<QString> ad
     }
 
     /* Show analysis options dialog */
-    displayAnalysisOptionsDialog(analLevel, advancedOptions, loadScript);
+    displayAnalysisOptionsDialog(analLevel, advancedOptions, loadScript, shellcode);
 }
 
 void MainWindow::openNewFileFailed()
@@ -361,11 +361,12 @@ void MainWindow::closeNewFileDialog()
     newFileDialog = nullptr;
 }
 
-void MainWindow::displayAnalysisOptionsDialog(int analLevel, QList<QString> advancedOptions, const QString &script)
+void MainWindow::displayAnalysisOptionsDialog(int analLevel, QList<QString> advancedOptions, const QString &script, const QString &shellcode)
 {
     OptionsDialog *o = new OptionsDialog(this);
     o->setAttribute(Qt::WA_DeleteOnClose);
     o->setInitialScript(script);
+    o->setShellcode(shellcode);
     o->show();
 
     if (analLevel >= 0) {
@@ -429,12 +430,6 @@ void MainWindow::setFilename(const QString &fn)
     // Add file name to window title
     this->filename = fn;
     this->setWindowTitle(APPNAME" - " + fn);
-}
-
-void MainWindow::setShellcode(const QString &shellcode)
-{
-    this->shellcode = shellcode;
-    this->setWindowTitle("Shellcode");
 }
 
 void MainWindow::closeEvent(QCloseEvent *event)

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -431,6 +431,12 @@ void MainWindow::setFilename(const QString &fn)
     this->setWindowTitle(APPNAME" - " + fn);
 }
 
+void MainWindow::setShellcode(const QString &shellcode)
+{
+    this->shellcode = shellcode;
+    this->setWindowTitle("Shellcode");
+}
+
 void MainWindow::closeEvent(QCloseEvent *event)
 {
     QMessageBox::StandardButton ret = QMessageBox::question(this, APPNAME,

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -68,10 +68,10 @@ public:
     ~MainWindow();
 
     void openNewFile(const QString &fn, int analLevel = -1,
-                     QList<QString> advancedOptions = QList<QString>());
+                     QList<QString> advancedOptions = QList<QString>(), const QString &shellcode = QString());
     void displayNewFileDialog();
     void closeNewFileDialog();
-    void displayAnalysisOptionsDialog(int analLevel, QList<QString> advancedOptions, const QString &script);
+    void displayAnalysisOptionsDialog(int analLevel, QList<QString> advancedOptions, const QString &script, const QString &shellcode = QString());
     void openProject(const QString &project_name);
 
     void initUI();
@@ -94,7 +94,6 @@ public:
     void readDebugSettings();
     void saveDebugSettings();
     void setFilename(const QString &fn);
-    void setShellcode(const QString &shellcode);
     void addOutput(const QString &msg);
     void addDebugOutput(const QString &msg);
     void refreshOmniBar(const QStringList &flags);
@@ -184,7 +183,6 @@ private:
     ut64 hexdumpTopOffset;
     ut64 hexdumpBottomOffset;
     QString filename;
-    QString shellcode;
     std::unique_ptr<Ui::MainWindow> ui;
     Highlighter *highlighter;
     AsciiHighlighter *hex_highlighter;
@@ -253,10 +251,6 @@ public:
     QString getFilename() const
     {
         return filename;
-    }
-    QString getShellcode() const
-    {
-        return shellcode;
     }
 };
 

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -94,6 +94,7 @@ public:
     void readDebugSettings();
     void saveDebugSettings();
     void setFilename(const QString &fn);
+    void setShellcode(const QString &shellcode);
     void addOutput(const QString &msg);
     void addDebugOutput(const QString &msg);
     void refreshOmniBar(const QStringList &flags);
@@ -183,6 +184,7 @@ private:
     ut64 hexdumpTopOffset;
     ut64 hexdumpBottomOffset;
     QString filename;
+    QString shellcode;
     std::unique_ptr<Ui::MainWindow> ui;
     Highlighter *highlighter;
     AsciiHighlighter *hex_highlighter;
@@ -251,6 +253,10 @@ public:
     QString getFilename() const
     {
         return filename;
+    }
+    QString getShellcode() const
+    {
+        return shellcode;
     }
 };
 

--- a/src/dialogs/NewFileDialog.cpp
+++ b/src/dialogs/NewFileDialog.cpp
@@ -131,13 +131,13 @@ void NewFileDialog::on_shellcodeButton_clicked()
 {
     QString shellcode = ui->shellcodeText->toPlainText();
     QString extractedCode = "";
-    QRegExp rx("([0-9A-Fa-f]{2})");
-    int pos = 0;
-    while ((pos = rx.indexIn(shellcode, pos)) != -1) {
-        extractedCode.append(rx.cap(1));
-        pos += rx.matchedLength();
+    static const QRegularExpression rx("([0-9a-f]{2})", QRegularExpression::CaseInsensitiveOption);
+    QRegularExpressionMatchIterator i = rx.globalMatch(shellcode);
+    while (i.hasNext()) {
+        QRegularExpressionMatch match = i.next();
+        extractedCode.append(match.captured(1));
     }
-    int size = extractedCode.size() * 0.5;
+    int size = extractedCode.size() / 2;
     if (size > 0) {
         loadShellcode(extractedCode, size);
     }
@@ -378,7 +378,6 @@ void NewFileDialog::loadShellcode(const QString &shellcode, const int size)
 {
     MainWindow *main = new MainWindow();
     QString ioFile = QString("malloc://%1").arg(size);
-    main->setWindowTitle("Shellcode");
     main->openNewFile(ioFile, -1, QList<QString>(), shellcode);
     close();
 }

--- a/src/dialogs/NewFileDialog.cpp
+++ b/src/dialogs/NewFileDialog.cpp
@@ -127,6 +127,11 @@ void NewFileDialog::on_loadProjectButton_clicked()
     loadProject(item->data(Qt::UserRole).toString());
 }
 
+void NewFileDialog::on_shellcodeButton_clicked()
+{
+    loadShellcode(ui->shellcodeText->toPlainText());
+}
+
 void NewFileDialog::on_recentsListWidget_itemClicked(QListWidgetItem *item)
 {
     QVariant data = item->data(Qt::UserRole);
@@ -355,6 +360,23 @@ void NewFileDialog::loadProject(const QString &project)
     MainWindow *main = new MainWindow();
     main->openProject(project);
 
+    close();
+}
+
+void NewFileDialog::loadShellcode(const QString &shellcode)
+{
+    QString extractedCode = "";
+    for (int i = 0; i < shellcode.size(); i++) {
+        QChar c = shellcode[i];
+        if (c != QChar('\\') && c != QChar('x') && c != QChar('"') && c != QChar('\n')) {
+            extractedCode.append(c);
+        }
+    }
+    MainWindow *main = new MainWindow();
+    int shellcodeSize = extractedCode.size() * 0.5;
+    QString ioFile = QString("malloc://%1").arg(shellcodeSize);
+    main->setShellcode(extractedCode);
+    main->openNewFile(ioFile);
     close();
 }
 

--- a/src/dialogs/NewFileDialog.cpp
+++ b/src/dialogs/NewFileDialog.cpp
@@ -129,7 +129,18 @@ void NewFileDialog::on_loadProjectButton_clicked()
 
 void NewFileDialog::on_shellcodeButton_clicked()
 {
-    loadShellcode(ui->shellcodeText->toPlainText());
+    QString shellcode = ui->shellcodeText->toPlainText();
+    QString extractedCode = "";
+    QRegExp rx("([0-9A-Fa-f]{2})");
+    int pos = 0;
+    while ((pos = rx.indexIn(shellcode, pos)) != -1) {
+        extractedCode.append(rx.cap(1));
+        pos += rx.matchedLength();
+    }
+    int size = extractedCode.size() * 0.5;
+    if (size > 0) {
+        loadShellcode(extractedCode, size);
+    }
 }
 
 void NewFileDialog::on_recentsListWidget_itemClicked(QListWidgetItem *item)
@@ -363,20 +374,12 @@ void NewFileDialog::loadProject(const QString &project)
     close();
 }
 
-void NewFileDialog::loadShellcode(const QString &shellcode)
+void NewFileDialog::loadShellcode(const QString &shellcode, const int size)
 {
-    QString extractedCode = "";
-    for (int i = 0; i < shellcode.size(); i++) {
-        QChar c = shellcode[i];
-        if (c != QChar('\\') && c != QChar('x') && c != QChar('"') && c != QChar('\n')) {
-            extractedCode.append(c);
-        }
-    }
     MainWindow *main = new MainWindow();
-    int shellcodeSize = extractedCode.size() * 0.5;
-    QString ioFile = QString("malloc://%1").arg(shellcodeSize);
-    main->setShellcode(extractedCode);
-    main->openNewFile(ioFile);
+    QString ioFile = QString("malloc://%1").arg(size);
+    main->setWindowTitle("Shellcode");
+    main->openNewFile(ioFile, -1, QList<QString>(), shellcode);
     close();
 }
 

--- a/src/dialogs/NewFileDialog.h
+++ b/src/dialogs/NewFileDialog.h
@@ -59,7 +59,7 @@ private:
 
     void loadFile(const QString &filename);
     void loadProject(const QString &project);
-    void loadShellcode(const QString &shellcode);
+    void loadShellcode(const QString &shellcode, const int size);
 
     static const int MaxRecentFiles = 5;
 };

--- a/src/dialogs/NewFileDialog.h
+++ b/src/dialogs/NewFileDialog.h
@@ -23,6 +23,7 @@ private slots:
 
     void on_selectProjectsDirButton_clicked();
     void on_loadProjectButton_clicked();
+    void on_shellcodeButton_clicked();
 
     void on_aboutButton_clicked();
 
@@ -58,6 +59,7 @@ private:
 
     void loadFile(const QString &filename);
     void loadProject(const QString &project);
+    void loadShellcode(const QString &shellcode);
 
     static const int MaxRecentFiles = 5;
 };

--- a/src/dialogs/NewfileDialog.ui
+++ b/src/dialogs/NewfileDialog.ui
@@ -314,6 +314,65 @@
            </layout>
           </widget>
 
+          <widget class="QWidget" name="shellcodeTab">
+           <attribute name="title">
+            <string>Open Shellcode</string>
+           </attribute>
+           <layout class="QVBoxLayout" name="shellcodeLayout">
+
+            <item>
+             <widget class="QLabel" name="shellcodeLabel">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>&lt;b&gt;Paste Shellcode&lt;b&gt;</string>
+              </property>
+             </widget>
+            </item>
+
+            <item>
+             <widget class="QPlainTextEdit" name="shellcodeText">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                <horstretch>1</horstretch>
+                <verstretch>1</verstretch>
+               </sizepolicy>
+              </property>
+             </widget>
+            </item>
+
+            <item>
+             <layout class="QHBoxLayout" name="shellcodeLayout_1">
+              <item>
+               <spacer name="shellcodeSpacer">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="spacerSize" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item>
+               <widget class="QPushButton" name="shellcodeButton">
+                <property name="text">
+                 <string>Open</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+
+           </layout>
+          </widget>>
+
           <widget class="QWidget" name="projectsTab">
            <attribute name="title">
             <string>Projects</string>
@@ -458,65 +517,6 @@
             </item>
            </layout>
           </widget>
-
-          <widget class="QWidget" name="shellcodeTab">
-           <attribute name="title">
-            <string>Open Shellcode</string>
-           </attribute>
-           <layout class="QVBoxLayout" name="shellcodeLayout">
-
-            <item>
-             <widget class="QLabel" name="shellcodeLabel">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>&lt;b&gt;Paste Shellcode&lt;b&gt;</string>
-              </property>
-             </widget>
-            </item>
-
-            <item>
-             <widget class="QTextEdit" name="shellcodeText">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                <horstretch>1</horstretch>
-                <verstretch>1</verstretch>
-               </sizepolicy>
-              </property>
-             </widget>
-            </item>
-
-            <item>
-             <layout class="QHBoxLayout" name="horizontalLayout_2">
-              <item>
-               <spacer name="horizontalSpacer_3">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-              <item>
-               <widget class="QPushButton" name="shellcodeButton">
-                <property name="text">
-                 <string>Open</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-
-           </layout>
-          </widget>>
 
          </widget>
         </item>

--- a/src/dialogs/NewfileDialog.ui
+++ b/src/dialogs/NewfileDialog.ui
@@ -138,6 +138,7 @@
           <property name="currentIndex">
            <number>0</number>
           </property>
+
           <widget class="QWidget" name="filesTab">
            <attribute name="title">
             <string>Open File</string>
@@ -312,6 +313,7 @@
             </item>
            </layout>
           </widget>
+
           <widget class="QWidget" name="projectsTab">
            <attribute name="title">
             <string>Projects</string>
@@ -456,6 +458,66 @@
             </item>
            </layout>
           </widget>
+
+          <widget class="QWidget" name="shellcodeTab">
+           <attribute name="title">
+            <string>Open Shellcode</string>
+           </attribute>
+           <layout class="QVBoxLayout" name="shellcodeLayout">
+
+            <item>
+             <widget class="QLabel" name="shellcodeLabel">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>&lt;b&gt;Paste Shellcode&lt;b&gt;</string>
+              </property>
+             </widget>
+            </item>
+
+            <item>
+             <widget class="QTextEdit" name="shellcodeLine">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                <horstretch>1</horstretch>
+                <verstretch>1</verstretch>
+               </sizepolicy>
+              </property>
+             </widget>
+            </item>
+
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_2">
+              <item>
+               <spacer name="horizontalSpacer_3">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item>
+               <widget class="QPushButton" name="shellcodeButton">
+                <property name="text">
+                 <string>Open</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+
+           </layout>
+          </widget>>
+
          </widget>
         </item>
        </layout>

--- a/src/dialogs/NewfileDialog.ui
+++ b/src/dialogs/NewfileDialog.ui
@@ -480,7 +480,7 @@
             </item>
 
             <item>
-             <widget class="QTextEdit" name="shellcodeLine">
+             <widget class="QTextEdit" name="shellcodeText">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
                 <horstretch>1</horstretch>

--- a/src/dialogs/OptionsDialog.cpp
+++ b/src/dialogs/OptionsDialog.cpp
@@ -199,6 +199,7 @@ void OptionsDialog::setupAndStartAnalysis(int level, QList<QString> advanced)
     InitialOptions options;
 
     options.filename = main->getFilename();
+    options.shellcode = main->getShellcode();
 
     // Where the bin header is located in the file (-B)
     if (ui->entry_loadOffset->text().length() > 0) {

--- a/src/dialogs/OptionsDialog.cpp
+++ b/src/dialogs/OptionsDialog.cpp
@@ -91,6 +91,11 @@ void OptionsDialog::setInitialScript(const QString &script)
     }
 }
 
+void OptionsDialog::setShellcode(const QString &shellcode)
+{
+    this->shellcode = shellcode;
+}
+
 QString OptionsDialog::getSelectedArch()
 {
     QVariant archValue = ui->archComboBox->currentData();
@@ -199,7 +204,7 @@ void OptionsDialog::setupAndStartAnalysis(int level, QList<QString> advanced)
     InitialOptions options;
 
     options.filename = main->getFilename();
-    options.shellcode = main->getShellcode();
+    options.shellcode = this->shellcode;
 
     // Where the bin header is located in the file (-B)
     if (ui->entry_loadOffset->text().length() > 0) {

--- a/src/dialogs/OptionsDialog.h
+++ b/src/dialogs/OptionsDialog.h
@@ -47,11 +47,13 @@ private:
     int defaultAnalLevel;
 
     QString analysisDescription(int level);
+    QString shellcode;
 
     void updateCPUComboBox();
 
 public:
     void setInitialScript(const QString &script);
+    void setShellcode(const QString &shellcode);
 
     QString getSelectedArch();
     QString getSelectedCPU();

--- a/src/dialogs/R2PluginsDialog.ui
+++ b/src/dialogs/R2PluginsDialog.ui
@@ -13,7 +13,7 @@
   <property name="windowTitle">
    <string>radare2 plugin information</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_6">
+  <layout class="QVBoxLayout" name="verticalLayout_1">
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">


### PR DESCRIPTION
so basically i implemented "paste shellcode and run" functionality. just added the new tab to "New" so you will find it there immediately after open Cutter.

Just in case I'm adding the screenshot so check it out please.
![pasteshellcode](https://user-images.githubusercontent.com/29271244/43856800-852f48f8-9b84-11e8-9a36-fd231b4467b8.png)
![shellcodeanal](https://user-images.githubusercontent.com/29271244/43856832-95e6331e-9b84-11e8-8bfc-42faad169fcb.png)

the ticket is this
https://github.com/radareorg/cutter/issues/547