### PR TITLE
Fix disassembly colors

### DIFF
--- a/src/utils/Configuration.cpp
+++ b/src/utils/Configuration.cpp
@@ -265,7 +265,7 @@ void Configuration::setColorTheme(QString theme)
     QJsonObject colorsObject = colors.object();
     QJsonObject::iterator it;
     for (it = colorsObject.begin(); it != colorsObject.end(); it++) {
-        if (!it.key().contains("graph"))
+        if (it.key().contains("gui"))
             continue;
         QJsonArray rgb = it.value().toArray();
         s.setValue("colors." + it.key(), QColor(rgb[0].toInt(), rgb[1].toInt(), rgb[2].toInt()));

--- a/src/utils/RichTextPainter.cpp
+++ b/src/utils/RichTextPainter.cpp
@@ -1,6 +1,7 @@
 /* x64dbg RichTextPainter */
 #include "RichTextPainter.h"
 #include "CachedFontMetrics.h"
+#include "utils/Configuration.h"
 #include <QPainter>
 #include <QTextBlock>
 #include <QTextFragment>
@@ -21,6 +22,8 @@ void RichTextPainter::paintRichText(QPainter *painter, int x, int y, int w, int 
             break;
         switch (curRichText.flags) {
         case FlagNone: //defaults
+            pen.setColor(ConfigColor("btext").name());
+            painter->setPen(pen);
             break;
         case FlagColor: //color only
             pen.setColor(curRichText.textColor);


### PR DESCRIPTION
With changes to radare (https://github.com/radare/radare2/pull/11078) it makes cutter display all disassembly colors. It also fixes problem with cutter trying to use colors that are not fetched from radare.

![screenshot_20180814_055210](https://user-images.githubusercontent.com/1407751/44071035-37d1f6a8-9f87-11e8-9fab-caca7f17afa2.png)

(There is also visible problem with spacing after var names which is caused by the fact that "fontMetrics->width(..)" is not returning real width (it works with mono fonts). It wasn't visible before this fix because whole line was drawn at once)