### PR TITLE
update seek on startup

### DIFF
--- a/src/Cutter.cpp
+++ b/src/Cutter.cpp
@@ -490,6 +490,11 @@ void CutterCore::seekNext()
     triggerRaisePrioritizedMemoryWidget();
 }
 
+void CutterCore::updateSeek()
+{
+    emit seekChanged(core_->offset);
+}
+
 RVA CutterCore::prevOpAddr(RVA startAddr, int count)
 {
     CORE_LOCK();

--- a/src/Cutter.h
+++ b/src/Cutter.h
@@ -440,6 +440,7 @@ public:
     void seek(ut64 offset);
     void seekPrev();
     void seekNext();
+    void updateSeek();
     RVA getOffset();
     RVA prevOpAddr(RVA startAddr, int count);
     RVA nextOpAddr(RVA startAddr, int count);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -392,6 +392,7 @@ void MainWindow::finalizeOpen()
     // Override any incorrect setting saved in the project
     core->setSettings();
 
+    core->updateSeek();
     core->message(tr(" > Populating UI"));
     refreshAll();
 


### PR DESCRIPTION
If you run Cutter, and don't click anywhere (aka you don't seek anywhere) before trying to rename the current function (usually entry0) you try to rename the wrong flag. If you right click it you will see a random flag different than entry0. This is because on startup emit seekChanged is never called.

Before:
![screenshot from 2018-09-06 16-41-47](https://user-images.githubusercontent.com/11303847/45169511-ab123080-b1f5-11e8-8221-b109e9265f4d.png)

After:
![screenshot from 2018-09-06 16-45-54](https://user-images.githubusercontent.com/11303847/45169522-b1a0a800-b1f5-11e8-869b-0d4a37c35cf0.png)
