### PR TITLE
Early color scheme feature

### DIFF
--- a/src/Cutter.pro
+++ b/src/Cutter.pro
@@ -17,7 +17,7 @@ ICON = img/cutter.icns
 # Icon/resources for Windows
 win32: RC_ICONS = img/cutter.ico
 
-QT += core gui widgets svg
+QT += core gui widgets svg network
 QT_CONFIG -= no-pkg-config
 CONFIG += c++11
 

--- a/src/Cutter.pro
+++ b/src/Cutter.pro
@@ -192,7 +192,8 @@ SOURCES += \
     dialogs/BreakpointsDialog.cpp \
     dialogs/AttachProcDialog.cpp \
     widgets/RegisterRefsWidget.cpp \
-    dialogs/SetToDataDialog.cpp
+    dialogs/SetToDataDialog.cpp \
+    widgets/ColorSchemePrefWidget.cpp
 
 HEADERS  += \
     Cutter.h \
@@ -287,7 +288,8 @@ HEADERS  += \
     dialogs/AttachProcDialog.h \
     widgets/RegisterRefsWidget.h \
     dialogs/SetToDataDialog.h \
-    utils/InitialOptions.h
+    utils/InitialOptions.h \
+    widgets/ColorSchemePrefWidget.h
 
 FORMS    += \
     dialogs/AboutDialog.ui \
@@ -341,7 +343,8 @@ FORMS    += \
     dialogs/BreakpointsDialog.ui \
     dialogs/AttachProcDialog.ui \
     widgets/RegisterRefsWidget.ui \
-    dialogs/SetToDataDialog.ui
+    dialogs/SetToDataDialog.ui \
+    widgets/ColorSchemePrefWidget.ui
 
 RESOURCES += \
     resources.qrc \

--- a/src/dialogs/AboutDialog.cpp
+++ b/src/dialogs/AboutDialog.cpp
@@ -25,7 +25,7 @@ AboutDialog::AboutDialog(QWidget *parent) :
 
     ui->label->setText(tr("<h1>Cutter</h1>"
                           "Version " CUTTER_VERSION_FULL "<br/>"
-                                                         "Using r2-" R2_GITTAP
+                          "Using r2-" R2_GITTAP
                           "<p><b>Optional Features:</b><br/>"
                           "Jupyter: %1<br/>"
                           "QtWebEngine: %2</p>"
@@ -35,18 +35,18 @@ AboutDialog::AboutDialog(QWidget *parent) :
                           "xarkes, thestr4ng3r, ballessay<br/>"
                           "Based on work by Hugo Teso &lt;hugo.teso@gmail.org&gt; (originally Iaito).")
                        .arg(
-                       #ifdef CUTTER_ENABLE_JUPYTER
+#ifdef CUTTER_ENABLE_JUPYTER
                            "ON"
-                       #else
+#else
                            "OFF"
-                       #endif
+#endif
                            ,
-                       #ifdef CUTTER_ENABLE_QTWEBENGINE
+#ifdef CUTTER_ENABLE_QTWEBENGINE
                            "ON"
-                       #else
+#else
                            "OFF"
-                       #endif
-                           ));
+#endif
+                       ));
 }
 
 AboutDialog::~AboutDialog() {}
@@ -79,7 +79,7 @@ void AboutDialog::on_checkForUpdatesButton_clicked()
     request.setUrl(url);
 
     QProgressDialog waitDialog;
-    QProgressBar* bar = new QProgressBar(&waitDialog);
+    QProgressBar *bar = new QProgressBar(&waitDialog);
     bar->setMaximum(0);
 
     waitDialog.setBar(bar);
@@ -112,7 +112,7 @@ void AboutDialog::on_checkForUpdatesButton_clicked()
     delete reply;
 }
 
-void AboutDialog::serveVersionCheckReply(QNetworkReply* reply)
+void AboutDialog::serveVersionCheckReply(QNetworkReply *reply)
 {
     QString currVersion = "";
     QMessageBox mb;
@@ -122,8 +122,8 @@ void AboutDialog::serveVersionCheckReply(QNetworkReply* reply)
         mb.setWindowTitle(QObject::tr("Error!"));
         mb.setText(reply->errorString());
     } else {
-        for(const auto& it : reply->readAll().split(',')) {
-            if(it.left(10) == QString("\"tag_name\"")) {
+        for (const auto &it : reply->readAll().split(',')) {
+            if (it.left(10) == QString("\"tag_name\"")) {
                 currVersion = it;
                 break;
             }

--- a/src/dialogs/AboutDialog.cpp
+++ b/src/dialogs/AboutDialog.cpp
@@ -5,14 +5,13 @@
 #include "r_version.h"
 #include "utils/Configuration.h"
 
-#include <QtNetwork/QNetworkRequest>
-#include <QtNetwork/QNetworkAccessManager>
 #include <QUrl>
-#include <QDebug>
-#include <QJsonObject>
 #include <QTimer>
+#include <QJsonObject>
 #include <QProgressBar>
 #include <QProgressDialog>
+#include <QtNetwork/QNetworkRequest>
+#include <QtNetwork/QNetworkAccessManager>
 
 #include "CutterConfig.h"
 
@@ -98,8 +97,7 @@ void AboutDialog::on_checkForUpdatesButton_clicked()
     QNetworkReply *reply = nm.get(request);
     timeoutTimer.start();
 
-    connect(&timeoutTimer, &QTimer::timeout, [&waitDialog]() {
-        waitDialog.cancel();
+    connect(&timeoutTimer, &QTimer::timeout, []() {
         QMessageBox mb;
         mb.setIcon(QMessageBox::Critical);
         mb.setStandardButtons(QMessageBox::Ok);

--- a/src/dialogs/AboutDialog.cpp
+++ b/src/dialogs/AboutDialog.cpp
@@ -5,6 +5,15 @@
 #include "r_version.h"
 #include "utils/Configuration.h"
 
+#include <QtNetwork/QNetworkReply>
+#include <QtNetwork/QNetworkRequest>
+#include <QtNetwork/QNetworkAccessManager>
+#include <QUrl>
+#include <QDebug>
+#include <QTimer>
+#include <QProgressBar>
+#include <QProgressDialog>
+
 #include "CutterConfig.h"
 
 AboutDialog::AboutDialog(QWidget *parent) :
@@ -61,4 +70,67 @@ void AboutDialog::on_showPluginsButton_clicked()
 {
     R2PluginsDialog dialog(this);
     dialog.exec();
+}
+
+void AboutDialog::on_checkForUpdatesButton_clicked()
+{
+    QString currVersion = "";
+    QUrl url("https://github.com/radareorg/cutter/releases/latest");
+    QNetworkRequest request;
+    request.setUrl(url);
+
+    QProgressDialog waitDialog;
+    QProgressBar* bar = new QProgressBar(&waitDialog);
+    bar->setMaximum(0);
+
+    waitDialog.setBar(bar);
+    waitDialog.setLabel(new QLabel("Checking for updates...", &waitDialog));
+
+    QNetworkAccessManager nm;
+
+    connect(&nm, &QNetworkAccessManager::finished,
+    [&currVersion, &waitDialog](QNetworkReply * reply) {
+        waitDialog.cancel();
+        QMessageBox mb;
+        if (reply->error()) {
+            mb.setIcon(QMessageBox::Critical);
+            mb.setStandardButtons(QMessageBox::Ok);
+            mb.setWindowTitle(QObject::tr("Error!"));
+            mb.setText(reply->errorString());
+        } else {
+            currVersion = reply->readAll();
+            currVersion.remove(0, currVersion.indexOf("/tag/") + 6);
+            currVersion = currVersion.left(currVersion.indexOf('>') - 1);
+            if (currVersion == CUTTER_VERSION_FULL) {
+                mb.setIcon(QMessageBox::Information);
+                mb.setStandardButtons(QMessageBox::Ok);
+                mb.setWindowTitle(QObject::tr("Version control"));
+                mb.setText(QObject::tr("You have latest version and no need to update!"));
+            } else {
+                mb.setIcon(QMessageBox::Information);
+                mb.setStandardButtons(QMessageBox::Ok);
+                mb.setWindowTitle(QObject::tr("Version control"));
+                mb.setText(tr("<b>Current version</b>: " CUTTER_VERSION_FULL "<br/>"
+                              "<b>Latest version</b>: %1<br/><br/>"
+                              "For update, please check the link: <a href=\"%2\">%2</a>")
+                           .arg(currVersion, "https://github.com/radareorg/cutter/releases"));
+            }
+        }
+        mb.exec();
+    });
+
+    QTimer::singleShot(15000, this, [&currVersion, &waitDialog]() {
+        if (currVersion.isEmpty()) {
+            waitDialog.cancel();
+            QMessageBox mb;
+            mb.setIcon(QMessageBox::Critical);
+            mb.setStandardButtons(QMessageBox::Ok);
+            mb.setWindowTitle(QObject::tr("Timeout error!"));
+            mb.setText(tr("Please check your internet connection and try again."));
+            mb.exec();
+        }
+    });
+
+    nm.get(request);
+    waitDialog.exec();
 }

--- a/src/dialogs/AboutDialog.cpp
+++ b/src/dialogs/AboutDialog.cpp
@@ -9,6 +9,7 @@
 #include <QtNetwork/QNetworkAccessManager>
 #include <QUrl>
 #include <QDebug>
+#include <QJsonObject>
 #include <QTimer>
 #include <QProgressBar>
 #include <QProgressDialog>
@@ -73,7 +74,6 @@ void AboutDialog::on_showPluginsButton_clicked()
 
 void AboutDialog::on_checkForUpdatesButton_clicked()
 {
-    QString currVersion = "";
     QUrl url("https://api.github.com/repos/radareorg/cutter/releases/latest");
     QNetworkRequest request;
     request.setUrl(url);
@@ -103,7 +103,7 @@ void AboutDialog::on_checkForUpdatesButton_clicked()
         QMessageBox mb;
         mb.setIcon(QMessageBox::Critical);
         mb.setStandardButtons(QMessageBox::Ok);
-        mb.setWindowTitle(QObject::tr("Timeout error!"));
+        mb.setWindowTitle(tr("Timeout error!"));
         mb.setText(tr("Please check your internet connection and try again."));
         mb.exec();
     });
@@ -119,22 +119,16 @@ void AboutDialog::serveVersionCheckReply(QNetworkReply *reply)
     mb.setStandardButtons(QMessageBox::Ok);
     if (reply->error()) {
         mb.setIcon(QMessageBox::Critical);
-        mb.setWindowTitle(QObject::tr("Error!"));
+        mb.setWindowTitle(tr("Error!"));
         mb.setText(reply->errorString());
     } else {
-        for (const auto &it : reply->readAll().split(',')) {
-            if (it.left(10) == QString("\"tag_name\"")) {
-                currVersion = it;
-                break;
-            }
-        }
-        currVersion = currVersion.right(currVersion.length() - currVersion.lastIndexOf('v') - 1);
-        currVersion.remove('\"');
+        currVersion = QJsonDocument::fromJson(reply->readAll()).object().value("tag_name").toString();
+        currVersion.remove('v');
 
-        mb.setWindowTitle(QObject::tr("Version control"));
+        mb.setWindowTitle(tr("Version control"));
         mb.setIcon(QMessageBox::Information);
         if (currVersion == CUTTER_VERSION_FULL) {
-            mb.setText(QObject::tr("You have latest version and no need to update!"));
+            mb.setText(tr("You have latest version and no need to update!"));
         } else {
             mb.setText(tr("<b>Current version</b>: " CUTTER_VERSION_FULL "<br/>"
                           "<b>Latest version</b>: %1<br/><br/>"

--- a/src/dialogs/AboutDialog.cpp
+++ b/src/dialogs/AboutDialog.cpp
@@ -59,7 +59,7 @@ void AboutDialog::on_buttonBox_rejected()
 void AboutDialog::on_showVersionButton_clicked()
 {
     QMessageBox popup(this);
-    popup.setWindowTitle("radare2 version information");
+    popup.setWindowTitle(tr("radare2 version information"));
     auto versionInformation = Core()->getVersionInformation();
     popup.setText(versionInformation);
     popup.exec();
@@ -82,7 +82,7 @@ void AboutDialog::on_checkForUpdatesButton_clicked()
     bar->setMaximum(0);
 
     waitDialog.setBar(bar);
-    waitDialog.setLabel(new QLabel("Checking for updates...", &waitDialog));
+    waitDialog.setLabel(new QLabel(tr("Checking for updates..."), &waitDialog));
 
     QNetworkAccessManager nm;
 

--- a/src/dialogs/AboutDialog.h
+++ b/src/dialogs/AboutDialog.h
@@ -20,6 +20,7 @@ private slots:
     void on_buttonBox_rejected();
     void on_showVersionButton_clicked();
     void on_showPluginsButton_clicked();
+    void on_checkForUpdatesButton_clicked();
 
 private:
     std::unique_ptr<Ui::AboutDialog> ui;

--- a/src/dialogs/AboutDialog.h
+++ b/src/dialogs/AboutDialog.h
@@ -3,6 +3,7 @@
 
 #include <QDialog>
 #include <memory>
+#include <QtNetwork/QNetworkReply>
 
 namespace Ui {
 class AboutDialog;
@@ -21,6 +22,7 @@ private slots:
     void on_showVersionButton_clicked();
     void on_showPluginsButton_clicked();
     void on_checkForUpdatesButton_clicked();
+    void serveVersionCheckReply(QNetworkReply *reply);
 
 private:
     std::unique_ptr<Ui::AboutDialog> ui;

--- a/src/dialogs/AboutDialog.ui
+++ b/src/dialogs/AboutDialog.ui
@@ -63,6 +63,19 @@
          </property>
         </widget>
        </item>
+       <item>
+        <widget class="QPushButton" name="checkForUpdatesButton">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Check for updates</string>
+         </property>
+        </widget>
+       </item>
       </layout>
      </item>
     </layout>

--- a/src/dialogs/preferences/GeneralOptionsWidget.ui
+++ b/src/dialogs/preferences/GeneralOptionsWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>442</width>
-    <height>225</height>
+    <height>268</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -102,6 +102,9 @@
      </item>
     </layout>
    </item>
+   <item>
+    <widget class="ColorSchemePrefWidget" name="colorSchemePrefWidget" native="true"/>
+   </item>
   </layout>
   <action name="actionSaveAsDefault">
    <property name="text">
@@ -109,6 +112,14 @@
    </property>
   </action>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ColorSchemePrefWidget</class>
+   <extends>QWidget</extends>
+   <header>widgets/ColorSchemePrefWidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/themes/schemes/ColorScheme.json
+++ b/src/themes/schemes/ColorScheme.json
@@ -1,0 +1,42 @@
+{
+    "bin": {
+        "background": "#2f343f",
+        "text": "#4fb100"
+    },
+    "invalid": {
+        "background": "#2f343f",
+        "text": "#ff0004"
+    },
+    "jne": {
+        "background": "#2f343f",
+        "text": "#ff007f"
+    },
+    "kek": {
+        "background": "#aaff00",
+        "text": "#0004ff"
+    },
+    "lol": {
+        "background": "#2f343f",
+        "text": "#ffffff"
+    },
+    "mov": {
+        "background": "#aaff00",
+        "text": "#000000"
+    },
+    "movs": {
+        "background": "#aaff00",
+        "text": "#000000"
+    },
+    "op": {
+        "background": "#ffaaff",
+        "text": "#ff0004"
+    },
+    "pop": {
+        "background": "#ffaaff",
+        "text": "#ff0004"
+    },
+    "push": {
+        "background": "#2f343f",
+        "text": "#00a243"
+    }
+}

--- a/src/widgets/ColorSchemePrefWidget.cpp
+++ b/src/widgets/ColorSchemePrefWidget.cpp
@@ -1,0 +1,223 @@
+#include "ColorSchemePrefWidget.h"
+#include "ui_ColorSchemePrefWidget.h"
+
+#include <QMouseEvent>
+#include <QJsonDocument>
+#include <QPainter>
+#include <QApplication>
+#include <QColorDialog>
+#include <QDebug>
+#include <QFile>
+
+void ColorOptionDelegate::paint(QPainter *painter,
+                                const QStyleOptionViewItem &option,
+                                const QModelIndex &index) const
+{
+    painter->setPen(QPen(Qt::OpaqueMode));
+    painter->setBrush(QBrush(index.model()->data(index,
+                                                 Qt::UserRole).value<ColorOption>().backgroundColor));
+    painter->drawRect(option.rect);
+
+    QPalette pal;
+    pal.setColor(QPalette::Text, index.model()->data(index,
+                                                     Qt::UserRole).value<ColorOption>().textColor);
+    QStyleOptionViewItem op = option;
+
+    op.palette = pal;
+    op.displayAlignment = Qt::AlignCenter;
+
+    if (option.state & QStyle::State_Selected) {
+        QLinearGradient lgrd = QLinearGradient(option.rect.topLeft(), option.rect.bottomRight());
+        QColor highlighted = QApplication::palette().highlight().color(),
+               highlightedOpague = highlighted;
+        highlightedOpague.setAlpha(0);
+
+        lgrd.setColorAt(0.00, highlighted);
+        lgrd.setColorAt(0.25, highlightedOpague);
+        lgrd.setColorAt(0.75, highlightedOpague);
+        lgrd.setColorAt(1.00, highlighted);
+        painter->setBrush(lgrd);
+        painter->drawRect(option.rect);
+        op.state &= ~ QStyle::State_Selected;
+    }
+
+    op.state &= ~ QStyle::State_Editing;
+    pal = option.palette;
+    pal.setColor(QPalette::Text, index.model()->data(index,
+                                                     Qt::UserRole).value<ColorOption>().textColor);
+    pal.setColor(QPalette::Background, index.model()->data(index,
+                                                           Qt::UserRole).value<ColorOption>().backgroundColor);
+    op.palette = pal;
+    QStyledItemDelegate::paint(painter, op, index);
+}
+
+ColorViewButton::ColorViewButton(QWidget *parent) : QFrame (parent)
+{
+    setLineWidth(3);
+    setFrameShape(QFrame::Panel);
+    setFrameShadow(QFrame::Raised);
+    setColor(palette().background().color());
+    setMaximumWidth(100);
+}
+
+void ColorViewButton::setColor(const QColor &c)
+{
+    QPalette pal = palette();
+    pal.setColor(QPalette::Background, c);
+    setAutoFillBackground(true);
+    setPalette(pal);
+    repaint();
+}
+
+void ColorViewButton::mouseReleaseEvent(QMouseEvent *event)
+{
+    if (event->button() != Qt::LeftButton)
+        return;
+
+    QColorDialog d;
+    d.setCurrentColor(palette().background().color());
+    d.exec();
+    emit newColor(d.selectedColor());
+}
+
+PreferencesListView::PreferencesListView(QWidget *parent) :
+    QListView (parent)
+{
+    QFile f(path);
+    f.open(QFile::ReadOnly);
+
+    setModel(new ColorSettingsModel(QJsonDocument::fromJson(f.readAll()).object(), this));
+    setItemDelegate(new ColorOptionDelegate(this));
+
+    f.close();
+}
+
+void PreferencesListView::currentChanged(const QModelIndex &current,
+                                         const QModelIndex &previous)
+{
+    emit indexChanged(current);
+    QListView::currentChanged(current, previous);
+}
+
+ColorSchemePrefWidget::ColorSchemePrefWidget(QWidget *parent) : QWidget (parent),
+    ui (new Ui::ColorSchemePrefWidget)
+{
+    ui->setupUi(this);
+    connect(ui->colorViewBack, &ColorViewButton::newColor, this, &ColorSchemePrefWidget::newColor);
+    connect(ui->colorViewFore, &ColorViewButton::newColor, this, &ColorSchemePrefWidget::newColor);
+    connect(ui->preferencesListView, &PreferencesListView::indexChanged, this,
+            &ColorSchemePrefWidget::indexChanged);
+}
+
+ColorSchemePrefWidget::~ColorSchemePrefWidget()
+{
+    apply();
+    delete ui;
+}
+
+void ColorSchemePrefWidget::apply()
+{
+    ColorSettingsModel *model = static_cast<ColorSettingsModel *>(ui->preferencesListView->model());
+    QJsonObject mainObj, prefObj;
+    for (int i = 0; i < model->rowCount(); i++) {
+        prefObj.insert("background", QJsonValue::fromVariant(QVariant::fromValue(model->data(model->index(i), Qt::UserRole).value<ColorOption>().backgroundColor)));
+        prefObj.insert("text", QJsonValue::fromVariant(QVariant::fromValue(model->data(model->index(i), Qt::UserRole).value<ColorOption>().textColor)));
+        mainObj.insert(model->data(model->index(i)).toString(), prefObj);
+    }
+    QFile f(path);
+    f.open(QFile::WriteOnly | QFile::Truncate);
+    f.write(QJsonDocument(mainObj).toJson());
+    f.close();
+}
+
+void ColorSchemePrefWidget::on_setDefBack_clicked()
+{
+    if (ui->preferencesListView->currentIndex().row() == -1)
+        return;
+    ColorSettingsModel *model = static_cast<ColorSettingsModel *>(ui->preferencesListView->model());
+    QString currOption = model->data(ui->preferencesListView->currentIndex()).toString();
+    ColorOption currData;
+    for (int i = 0; i < model->rowCount(); i++) {
+        currData = model->data(model->index(i, Qt::UserRole)).value<ColorOption>();
+        if (currData.optionName == defaultBackgroundOptionName) {
+            model->setColor(currOption, "background", currData.backgroundColor);
+        }
+    }
+}
+
+void ColorSchemePrefWidget::on_setDefFore_clicked()
+{
+    if (ui->preferencesListView->currentIndex().row() == -1)
+        return;
+    ColorSettingsModel *model = static_cast<ColorSettingsModel *>(ui->preferencesListView->model());
+    QString currOption = model->data(ui->preferencesListView->currentIndex()).toString();
+    ColorOption currData;
+    for (int i = 0; i < model->rowCount(); i++) {
+        currData = model->data(model->index(i, Qt::UserRole)).value<ColorOption>();
+        if (currData.optionName == simpleTextOptionName) {
+            model->setColor(currOption, "text", currData.backgroundColor);
+        }
+    }
+}
+
+void ColorSchemePrefWidget::newColor(const QColor &color)
+{
+    if (ui->preferencesListView->currentIndex().row() == -1)
+        return;
+    QString sender = QObject::sender()->objectName();
+    QString option = ui->preferencesListView->model()->data(ui->preferencesListView->currentIndex(),
+                                                            Qt::UserRole).value<ColorOption>().optionName;
+    if (sender == "colorViewBack") {
+        static_cast<ColorSettingsModel *>(ui->preferencesListView->model())->setColor(option, "background",
+                                                                                      color);
+    } else {
+        static_cast<ColorSettingsModel *>(ui->preferencesListView->model())->setColor(option, "text",
+                                                                                      color);
+    }
+    static_cast<ColorViewButton *>(QObject::sender())->setColor(color);
+}
+
+void ColorSchemePrefWidget::indexChanged(const QModelIndex &ni)
+{
+    ui->colorViewBack->setColor(ni.data(Qt::UserRole).value<ColorOption>().backgroundColor);
+    ui->colorViewFore->setColor(ni.data(Qt::UserRole).value<ColorOption>().textColor);
+}
+
+ColorSettingsModel::ColorSettingsModel(const QJsonObject &pref,
+                                       QObject *parent) : QAbstractListModel (parent)
+{
+    m_data.reserve(pref.size());
+    for (const auto &it : pref.keys())
+        m_data.push_back({it,
+                          pref.value(it).toObject().value(simpleTextOptionName).toVariant().value<QColor>(),
+                          pref.value(it).toObject().value(defaultBackgroundOptionName).toVariant().value<QColor>()});
+}
+
+QVariant ColorSettingsModel::data(const QModelIndex &index, int role) const
+{
+    if (role == Qt::DisplayRole)
+        return QVariant::fromValue(m_data.at(index.row()).optionName);
+
+    if (role == Qt::UserRole)
+        return QVariant::fromValue(m_data.at(index.row()));
+
+    return QVariant();
+}
+
+void ColorSettingsModel::setColor(const QString &option, const QString &textOrBack,
+                                  const QColor &color)
+{
+    int row = 0;
+    for (auto &it : m_data) {
+        if (it.optionName == option) {
+            if (textOrBack == "background") {
+                it.backgroundColor = color;
+            } else if (textOrBack == "text") {
+                it.textColor = color;
+            }
+            emit dataChanged(index(row), index(row));
+            return;
+        }
+        row++;
+    }
+}

--- a/src/widgets/ColorSchemePrefWidget.h
+++ b/src/widgets/ColorSchemePrefWidget.h
@@ -1,0 +1,112 @@
+#ifndef COLORSCHEMEPREFWIDGET_H
+#define COLORSCHEMEPREFWIDGET_H
+
+#include <QFrame>
+#include <QListView>
+#include <QAbstractListModel>
+#include <QStyledItemDelegate>
+#include <QJsonObject>
+
+constexpr const char *simpleTextOptionName = "text";
+constexpr const char *defaultBackgroundOptionName = "background";
+constexpr const char *path = "/home/optizone/git/cutter/src/themes/schemes/ColorScheme.json";
+
+namespace Ui {
+class ColorSchemePrefWidget;
+}
+
+class ColorSchemePrefWidget : public QWidget
+{
+    Q_OBJECT
+public:
+    ColorSchemePrefWidget(QWidget *parent = nullptr);
+    virtual ~ColorSchemePrefWidget();
+
+public slots:
+    void apply();
+
+private slots:
+    void on_setDefBack_clicked();
+    void on_setDefFore_clicked();
+
+    void newColor(const QColor &color);
+
+    void indexChanged(const QModelIndex &ni);
+
+private:
+    Ui::ColorSchemePrefWidget *ui;
+};
+
+//===============SERVICE STUFF BELOW===============
+
+class ColorViewButton : public QFrame
+{
+    Q_OBJECT
+public:
+    ColorViewButton(QWidget *parent = nullptr);
+    virtual ~ColorViewButton() override {}
+
+public slots:
+    void setColor(const QColor &c);
+
+protected slots:
+    void mouseReleaseEvent(QMouseEvent *event) override;
+
+signals:
+    void newColor(const QColor &nc);
+};
+
+struct ColorOption {
+    QString optionName;
+    QColor textColor;
+    QColor backgroundColor;
+};
+Q_DECLARE_METATYPE(ColorOption);
+
+class ColorSettingsModel : public QAbstractListModel
+{
+    Q_OBJECT
+public:
+    ColorSettingsModel(const QJsonObject &pref, QObject *parent = nullptr);
+    virtual ~ColorSettingsModel() override {}
+
+    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+
+    void setColor(const QString &option,
+                  const QString &textOrBack,
+                  const QColor &color);
+
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override { return m_data.size(); }
+
+private:
+    QList<ColorOption> m_data;
+};
+
+class ColorOptionDelegate : public QStyledItemDelegate
+{
+    Q_OBJECT
+public:
+    ColorOptionDelegate(QObject *parent = nullptr) : QStyledItemDelegate (parent) {}
+    ~ColorOptionDelegate() override {}
+
+    void paint(QPainter *painter,
+               const QStyleOptionViewItem &option,
+               const QModelIndex &index) const override;
+};
+
+class PreferencesListView : public QListView
+{
+    Q_OBJECT
+public:
+    PreferencesListView(QWidget *parent = nullptr);
+    virtual ~PreferencesListView() override {}
+
+protected slots:
+    void currentChanged(const QModelIndex &current,
+                        const QModelIndex &previous) override;
+
+signals:
+    void indexChanged(const QModelIndex &ni);
+};
+
+#endif // COLORSCHEMEPREFWIDGET_H

--- a/src/widgets/ColorSchemePrefWidget.ui
+++ b/src/widgets/ColorSchemePrefWidget.ui
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ColorSchemePrefWidget</class>
+ <widget class="QWidget" name="ColorSchemePrefWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>670</width>
+    <height>306</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <widget class="PreferencesListView" name="preferencesListView"/>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <item>
+          <widget class="ColorViewButton" name="colorViewBack">
+           <property name="minimumSize">
+            <size>
+             <width>100</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="frameShape">
+            <enum>QFrame::StyledPanel</enum>
+           </property>
+           <property name="frameShadow">
+            <enum>QFrame::Raised</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="setDefBack">
+           <property name="text">
+            <string>Set Default</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <item>
+          <widget class="ColorViewButton" name="colorViewFore">
+           <property name="frameShape">
+            <enum>QFrame::StyledPanel</enum>
+           </property>
+           <property name="frameShadow">
+            <enum>QFrame::Raised</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="setDefFore">
+           <property name="text">
+            <string>Set Default</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PreferencesListView</class>
+   <extends>QListView</extends>
+   <header>widgets/ColorSchemePrefWidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>ColorViewButton</class>
+   <extends>QFrame</extends>
+   <header>widgets/ColorSchemePrefWidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
Hi there! I didn't know what's the best way: to create pull request or issue, and decided to do first.

It'd be great, if we had possibility to change color scheme of disassembly widget, coz on some desktops default scheme looks not good enough.
![image](https://user-images.githubusercontent.com/42874998/45510719-9819d600-b78a-11e8-8340-c10614f84cce.png)

And there is no way (except switch "Qt Theme" in preferences). So I decided to add this feature. And, if it is relevant I'll finish this. Now it can parse .json file, show current preferences and save. Looks like:

![image](https://user-images.githubusercontent.com/42874998/45510714-94864f00-b78a-11e8-9698-5aac0499ee13.png)

So what do you think?