### PR TITLE
afvn Context Menu functionality

### DIFF
--- a/src/Cutter.pro
+++ b/src/Cutter.pro
@@ -192,7 +192,8 @@ SOURCES += \
     dialogs/BreakpointsDialog.cpp \
     dialogs/AttachProcDialog.cpp \
     widgets/RegisterRefsWidget.cpp \
-    dialogs/SetToDataDialog.cpp
+    dialogs/SetToDataDialog.cpp \
+    dialogs/SetFunctionVarTypes.cpp
 
 HEADERS  += \
     Cutter.h \
@@ -287,7 +288,8 @@ HEADERS  += \
     dialogs/AttachProcDialog.h \
     widgets/RegisterRefsWidget.h \
     dialogs/SetToDataDialog.h \
-    utils/InitialOptions.h
+    utils/InitialOptions.h \
+    dialogs/SetFunctionVarTypes.h
 
 FORMS    += \
     dialogs/AboutDialog.ui \
@@ -341,7 +343,8 @@ FORMS    += \
     dialogs/BreakpointsDialog.ui \
     dialogs/AttachProcDialog.ui \
     widgets/RegisterRefsWidget.ui \
-    dialogs/SetToDataDialog.ui
+    dialogs/SetToDataDialog.ui \
+    dialogs/SetFunctionVarTypes.ui
 
 RESOURCES += \
     resources.qrc \

--- a/src/dialogs/SetFunctionVarTypes.cpp
+++ b/src/dialogs/SetFunctionVarTypes.cpp
@@ -1,0 +1,105 @@
+#include "SetFunctionVarTypes.h"
+#include "ui_SetFunctionVarTypes.h"
+
+#include <QMetaType>
+
+SetFunctionVarTypes::SetFunctionVarTypes(QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::SetFunctionVarTypes)
+{
+    ui->setupUi(this);
+    connect(ui->buttonBox, SIGNAL(accepted()), this, SLOT(on_OkPressed()));
+
+    allLoadedTypes = getAllTypes();
+
+}
+
+SetFunctionVarTypes::~SetFunctionVarTypes()
+{
+    delete ui;
+}
+
+void SetFunctionVarTypes::setUserMessage(const QString userMessage)
+{
+    ui->userMessage->setText(userMessage);
+}
+
+void SetFunctionVarTypes::setFcn(RCore* core, RAnalFunction *fcn)
+{
+    RListIter *iter;
+    RAnalVar *var;
+
+    if(!fcn)
+    {
+        ui->userMessage->setText(tr("You must be in a function to define variable types."));
+        ui->labelSetTypeTo->setVisible(false);
+        ui->selectedTypeForVar->setVisible(false);
+        ui->dropdownLocalVars->setVisible(false);
+
+        this->validFcn = false;
+        return;
+    }
+    ui->userMessage->setVisible(true);
+    ui->labelSetTypeTo->setVisible(true);
+    ui->selectedTypeForVar->setVisible(true);
+    ui->dropdownLocalVars->setVisible(true);
+
+    this->validFcn = true;
+    this->fcn = fcn;
+    this->fcnVars = r_anal_var_list(core->anal, this->fcn, R_ANAL_VAR_KIND_ANY);
+
+    for (iter = this->fcnVars->head; iter && (var = static_cast<RAnalVar*>(iter->data)); iter = iter->n)
+    {
+        ui->dropdownLocalVars->addItem(var->name,
+                                       QVariant::fromValue(static_cast<void*>(var)));
+    }
+}
+
+void SetFunctionVarTypes::on_OkPressed()
+{
+
+    RAnalVar *selectedVar;
+    QVariant selectedVarVariant;
+
+    if(!this->validFcn)
+    {
+        return;
+    }
+
+    selectedVarVariant = ui->dropdownLocalVars->currentData();
+    selectedVar = static_cast<RAnalVar*>(selectedVarVariant.value<void*>());
+
+    Core()->cmd(tr("afvt %1 %2")
+                .arg(selectedVar->name)
+                .arg(ui->selectedTypeForVar->currentText().toStdString().c_str()));
+}
+
+QStringList SetFunctionVarTypes::getAllTypes()
+{
+    //gets all loaded types, structures and enums and puts them in a list
+
+    QString res;
+    QStringList primitiveTypes;
+    QStringList userStructures;
+    QStringList userEnumerations;
+
+    res = Core()->cmd(tr("ts"));
+    userStructures = res.split("\n");
+    userStructures.removeAll(QString(""));
+    ui->selectedTypeForVar->addItems(userStructures);
+    ui->selectedTypeForVar->insertSeparator(ui->selectedTypeForVar->count());
+
+    res = Core()->cmd(tr("t"));
+    primitiveTypes = res.split("\n");
+    primitiveTypes.removeAll(QString(""));
+    ui->selectedTypeForVar->addItems(primitiveTypes);
+    ui->selectedTypeForVar->insertSeparator(ui->selectedTypeForVar->count());
+
+    res = Core()->cmd(tr("te"));
+    userStructures = res.split("\n");
+    userStructures.removeAll(QString(""));
+    ui->selectedTypeForVar->addItems(userStructures);
+
+    return userStructures + primitiveTypes + userEnumerations;
+
+}

--- a/src/dialogs/SetFunctionVarTypes.h
+++ b/src/dialogs/SetFunctionVarTypes.h
@@ -1,0 +1,36 @@
+#ifndef SETFUNCTIONVARTYPES_H
+#define SETFUNCTIONVARTYPES_H
+
+#include "Cutter.h"
+#include <QDialog>
+
+namespace Ui {
+class SetFunctionVarTypes;
+}
+
+class SetFunctionVarTypes : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit SetFunctionVarTypes(QWidget *parent = nullptr);
+    ~SetFunctionVarTypes();
+
+    void setUserMessage(const QString userMessage);
+    void setFcn(RCore* core, RAnalFunction *fcn);
+
+public slots:
+    void on_OkPressed();
+
+
+private:
+    RList                   *fcnVars;
+    RAnalFunction           *fcn;
+    Ui::SetFunctionVarTypes *ui;
+    bool                    validFcn;
+    QStringList          allLoadedTypes;
+    QStringList           getAllTypes();
+
+};
+
+#endif // SETFUNCTIONVARTYPES_H

--- a/src/dialogs/SetFunctionVarTypes.ui
+++ b/src/dialogs/SetFunctionVarTypes.ui
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SetFunctionVarTypes</class>
+ <widget class="QDialog" name="SetFunctionVarTypes">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>636</width>
+    <height>327</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <widget class="QDialogButtonBox" name="buttonBox">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>290</y>
+     <width>621</width>
+     <height>32</height>
+    </rect>
+   </property>
+   <property name="orientation">
+    <enum>Qt::Horizontal</enum>
+   </property>
+   <property name="standardButtons">
+    <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+   </property>
+  </widget>
+  <widget class="QLabel" name="userMessage">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>10</y>
+     <width>601</width>
+     <height>17</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string/>
+   </property>
+  </widget>
+  <widget class="QComboBox" name="dropdownLocalVars">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>60</y>
+     <width>251</width>
+     <height>25</height>
+    </rect>
+   </property>
+  </widget>
+  <widget class="QLabel" name="labelSetTypeTo">
+   <property name="geometry">
+    <rect>
+     <x>30</x>
+     <y>180</y>
+     <width>91</width>
+     <height>17</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Set Type To:</string>
+   </property>
+  </widget>
+  <widget class="QComboBox" name="selectedTypeForVar">
+   <property name="geometry">
+    <rect>
+     <x>30</x>
+     <y>210</y>
+     <width>261</width>
+     <height>31</height>
+    </rect>
+   </property>
+   <property name="editable">
+    <bool>true</bool>
+   </property>
+   <property name="maxVisibleItems">
+    <number>15</number>
+   </property>
+  </widget>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>SetFunctionVarTypes</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>SetFunctionVarTypes</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -5,6 +5,7 @@
 #include "dialogs/FlagDialog.h"
 #include "dialogs/RenameDialog.h"
 #include "dialogs/XrefsDialog.h"
+#include "dialogs/SetFunctionVarTypes.h"
 #include "dialogs/SetToDataDialog.h"
 #include <QtCore>
 #include <QShortcut>
@@ -40,6 +41,10 @@ DisassemblyContextMenu::DisassemblyContextMenu(QWidget *parent)
     initAction(&actionRenameUsedHere, tr("Rename Flag/Fcn/Var Used Here"),
                SLOT(on_actionRenameUsedHere_triggered()), getRenameUsedHereSequence());
     addAction(&actionRenameUsedHere);
+
+    initAction(&actionSetFunctionVarTypes, tr("Re-type function local vars"),
+               SLOT(on_actionSetFunctionVarTypes_triggered()), getRetypeSequence());
+    addAction(&actionSetFunctionVarTypes);
 
     initAction(&actionDeleteComment, tr("Delete comment"), SLOT(on_actionDeleteComment_triggered()));
     addAction(&actionDeleteComment);
@@ -253,6 +258,7 @@ void DisassemblyContextMenu::aboutToShowSlot()
 
     RCore *core = Core()->core();
     RAnalFunction *fcn = r_anal_get_fcn_at (core->anal, offset, R_ANAL_FCN_TYPE_NULL);
+    RAnalFunction *in_fcn = Core()->functionAt(offset);
     RFlagItem *f = r_flag_get_i (core->flags, offset);
 
     actionDeleteFlag.setVisible(f ? true : false);
@@ -267,6 +273,16 @@ void DisassemblyContextMenu::aboutToShowSlot()
         actionRename.setText(tr("Rename flag \"%1\"").arg(f->name));
     } else {
         actionRename.setVisible(false);
+    }
+
+    //only show retype for local vars if in a function
+    if(in_fcn)
+    {
+        actionSetFunctionVarTypes.setVisible(true);
+    }
+    else
+    {
+        actionSetFunctionVarTypes.setVisible(false);
     }
 
 
@@ -336,6 +352,11 @@ QKeySequence DisassemblyContextMenu::getRenameSequence() const
 QKeySequence DisassemblyContextMenu::getRenameUsedHereSequence() const
 {
     return {Qt::SHIFT + Qt::Key_N};
+}
+
+QKeySequence DisassemblyContextMenu::getRetypeSequence() const
+{
+     return {Qt::Key_Y};
 }
 
 QKeySequence DisassemblyContextMenu::getXRefSequence() const
@@ -549,6 +570,26 @@ void DisassemblyContextMenu::on_actionRenameUsedHere_triggered()
             }
         }
     }
+}
+
+void DisassemblyContextMenu::on_actionSetFunctionVarTypes_triggered()
+{
+    RCore *core = Core()->core();
+    SetFunctionVarTypes *dialog;
+
+
+    RAnalFunction *fcn = Core()->functionAt(offset);
+
+    dialog = new SetFunctionVarTypes(this);
+
+    if(fcn)
+    {
+        dialog->setWindowTitle(tr("Set Variable Types for Function: %1").arg(fcn->name));
+    }
+    dialog->setFcn(core, fcn);
+
+    dialog->exec();
+
 }
 
 void DisassemblyContextMenu::on_actionXRefs_triggered()

--- a/src/menus/DisassemblyContextMenu.h
+++ b/src/menus/DisassemblyContextMenu.h
@@ -36,6 +36,7 @@ private slots:
     void on_actionAddFlag_triggered();
     void on_actionRename_triggered();
     void on_actionRenameUsedHere_triggered();
+    void on_actionSetFunctionVarTypes_triggered();
     void on_actionXRefs_triggered();
     void on_actionDisplayOptions_triggered();
 
@@ -60,6 +61,7 @@ private:
     QKeySequence getAddFlagSequence() const;
     QKeySequence getRenameSequence() const;
     QKeySequence getRenameUsedHereSequence() const;
+    QKeySequence getRetypeSequence() const;
     QKeySequence getXRefSequence() const;
     QKeySequence getDisplayOptionsSequence() const;
     QList<QKeySequence> getAddBPSequence() const;
@@ -86,6 +88,7 @@ private:
     QAction actionAnalyzeFunction;
     QAction actionRename;
     QAction actionRenameUsedHere;
+    QAction actionSetFunctionVarTypes;
     QAction actionXRefs;
     QAction actionDisplayOptions;
 


### PR DESCRIPTION
Added ability to re-type local vars in Dissassembly Widget.  Can re-type to any loaded structs, types or enums.

Only shows when current seeked offset is within a defined function