### PR TITLE
Fix instruction preview dialog

### DIFF
--- a/src/dialogs/EditInstructionDialog.cpp
+++ b/src/dialogs/EditInstructionDialog.cpp
@@ -10,7 +10,7 @@ EditInstructionDialog::EditInstructionDialog(QWidget *parent, bool isEditingByte
     ui->setupUi(this);
     setWindowFlags(windowFlags() & (~Qt::WindowContextHelpButtonHint));
 
-    ui->lineEdit->installEventFilter(this);
+    connect(ui->lineEdit, SIGNAL(textEdited(const QString &)), this, SLOT(updatePreview(const QString &)));
 }
 
 EditInstructionDialog::~EditInstructionDialog() {}
@@ -50,23 +50,4 @@ void EditInstructionDialog::updatePreview(const QString &input)
     } else {
         ui->instructionLabel->setText(result);
     }
-}
-
-bool EditInstructionDialog::eventFilter(QObject *obj, QEvent *event)
-{
-    Q_UNUSED(obj);
-
-    if (event->type() == QEvent::KeyPress) {
-        QKeyEvent *keyEvent = static_cast <QKeyEvent *>(event);
-
-        // Update instruction preview
-        QString lineText = ui->lineEdit->text();
-        if (keyEvent->key() == Qt::Key_Backspace) {
-            updatePreview(lineText.left(lineText.size() - 1));
-        } else {
-            updatePreview(lineText + keyEvent->text());
-        }
-    }
-
-    return false;
 }

--- a/src/dialogs/EditInstructionDialog.h
+++ b/src/dialogs/EditInstructionDialog.h
@@ -20,18 +20,16 @@ public:
     QString getInstruction();
     void setInstruction(const QString &instruction);
 
-    void updatePreview(const QString &input);
-
 private slots:
     void on_buttonBox_accepted();
 
     void on_buttonBox_rejected();
 
+    void updatePreview(const QString &input);
+
 private:
     std::unique_ptr<Ui::EditInstructionDialog> ui;
     bool isEditingBytes; // true if editing intruction **bytes**; false if editing instruction **text**
-
-    bool eventFilter(QObject *obj, QEvent *event);
 };
 
 #endif // EDITINSTRUCTIONDIALOG_H


### PR DESCRIPTION
Without this commit when you use edit dialog it is appending every typed character at the end, so when you e.g. have "e87cfeaaa" and you add "b" at the beggining it shows "be87cfeaaa" but is dissasembled as if it was "e87cfeaaab"