### PR TITLE
[TESTING] AppVeyor: disable precompilation of Python modules

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -63,8 +63,8 @@ after_build:
   - cmd: python -m pip install -I --no-compile -t "%ARTIFACT_PATH%\python36\site-packages" jupyter
   - cmd: if exist "%ARTIFACT_PATH%\python36\site-packages\test" ( rd /s /q "%ARTIFACT_PATH%\python36\site-packages\test" )
   - cmd: for /d %%p in ("%ARTIFACT_PATH%\python36\site-packages\*.dist-info" "%ARTIFACT_PATH%\python36\site-packages\*.egg-info") do rd /s /q "%%p"
-  - cmd: python -O -m compileall -b -q "%ARTIFACT_PATH%\python36\site-packages"
-  - cmd: del /s "%ARTIFACT_PATH%\python36\site-packages\*.py"
+  #- cmd: python -O -m compileall -b -q "%ARTIFACT_PATH%\python36\site-packages"
+  #- cmd: del /s "%ARTIFACT_PATH%\python36\site-packages\*.py"
   - cmd: powershell -c "Get-ChildItem -Path \"%ARTIFACT_PATH%\python36\site-packages\" -Include '__pycache__' -Recurse -Force | Remove-Item -Force -Recurse"
   - cmd: copy python_embed\python36.zip "%ARTIFACT_PATH%\python36\"
   - cmd: copy python_embed\*.pyd "%ARTIFACT_PATH%\python36\"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -61,7 +61,7 @@ after_build:
   - ps: $env:py_url = "https://www.python.org/ftp/python/${env:py_version}/python-${env:py_version}-embed-${env:py_platform}.zip"
   - cmd: powershell -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; wget %py_url% -OutFile python_embed.zip; Expand-Archive .\python_embed.zip -DestinationPath .\python_embed"
   - cmd: python -m pip install -I --no-compile -t "%ARTIFACT_PATH%\python36\site-packages" jupyter
-  - cmd: if exist "%ARTIFACT_PATH%\python36\site-packages\test" ( rd /s /q "%ARTIFACT_PATH%\python36\site-packages\test" )
+  #- cmd: if exist "%ARTIFACT_PATH%\python36\site-packages\test" ( rd /s /q "%ARTIFACT_PATH%\python36\site-packages\test" )
   - cmd: for /d %%p in ("%ARTIFACT_PATH%\python36\site-packages\*.dist-info" "%ARTIFACT_PATH%\python36\site-packages\*.egg-info") do rd /s /q "%%p"
   #- cmd: python -O -m compileall -b -q "%ARTIFACT_PATH%\python36\site-packages"
   #- cmd: del /s "%ARTIFACT_PATH%\python36\site-packages\*.py"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -48,7 +48,7 @@ install:
 
 before_build:
   - cmd: git submodule update --init
-  - cmd: python scripts\compile_python_resources.py
+  #- cmd: python scripts\compile_python_resources.py
 
 # Build config
 build_script:


### PR DESCRIPTION
I don't why but some modules can't be imported.