### PR TITLE
Improve icon sizes and colors

### DIFF
--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -94,7 +94,7 @@ QToolTip {
      <rect>
       <x>378</x>
       <y>100</y>
-      <width>151</width>
+      <width>139</width>
       <height>240</height>
      </rect>
     </property>
@@ -239,8 +239,8 @@ QToolTip {
    </property>
    <property name="iconSize">
     <size>
-     <width>18</width>
-     <height>18</height>
+     <width>16</width>
+     <height>16</height>
     </size>
    </property>
    <property name="toolButtonStyle">

--- a/src/img/icons/media-skip-forward_light.svg
+++ b/src/img/icons/media-skip-forward_light.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="8" height="8" viewBox="0 0 8 8">
-  <g fill="#aaacaf">
-    <path d="M0 0v6l4-3-4-3zm4 3v3l4-3-4-3v3z" transform="translate(0 1)" fill="#aaacaf"/>
+  <g fill="#78de82">
+    <path d="M0 0v6l4-3-4-3zm4 3v3l4-3-4-3v3z" transform="translate(0 1)" fill="#78de82"/>
   </g>
 </svg>

--- a/src/img/icons/spin_light.svg
+++ b/src/img/icons/spin_light.svg
@@ -1,6 +1,6 @@
 <!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd'>
 <svg style="enable-background:new 0 0 28 32" xmlns="http://www.w3.org/2000/svg" xml:space="preserve" height="32px" width="28px" version="1.1" y="0px" x="0px" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 28 32">
-	<g fill="#78de82">
+        <g fill="#67d2ef">
 		<path d="m24 6.1l-2.8 2.8c2 2.1 3 4.1 3 7.1 0 5.5-4.5 10-10 10v-2l-4 4 4 4v-2c7.7 0 14-6.3 14-14 0-4-1-7.3-4-9.9z"/>
 		<path d="m18 4l-4-4v2c-7.7 0-14 6.3-14 14 0 3.7 1.5 7.3 4.1 9.9l2.8-2.8c-1.9-2-2.9-4-2.9-7 0-6 4.5-10 10-10v2l4-4z"/>
 	</g>

--- a/src/widgets/DebugToolbar.cpp
+++ b/src/widgets/DebugToolbar.cpp
@@ -13,7 +13,7 @@ DebugToolbar::DebugToolbar(MainWindow *main, QWidget *parent) :
     main(main)
 {
     setObjectName("debugToolbar");
-    setIconSize(QSize(20, 20));
+    setIconSize(QSize(16, 16));
 
     // define icons
     QIcon startDebugIcon = QIcon(":/img/icons/play_light_debug.svg");
@@ -30,7 +30,7 @@ DebugToolbar::DebugToolbar(MainWindow *main, QWidget *parent) :
     QIcon restartIcon = QIcon(":/img/icons/spin_light.svg");
 
     // define action labels
-    QString startDebugLabel = tr("Start debug");
+    QString startDebugLabel          = tr("Start debug");
     QString startEmulLabel = tr("Start emulation");
     QString startAttachLabel = tr("Attach to process");
     QString stopDebugLabel = tr("Stop debug");
@@ -89,8 +89,8 @@ DebugToolbar::DebugToolbar(MainWindow *main, QWidget *parent) :
 
     // define toolbar widgets and actions
     addWidget(startButton);
-    addAction(actionStop);
     addAction(actionContinue);
+    addAction(actionStop);
     actionAllContinues = addWidget(continueUntilButton);
     addAction(actionStep);
     addAction(actionStepOver);

--- a/src/widgets/DebugToolbar.cpp
+++ b/src/widgets/DebugToolbar.cpp
@@ -30,7 +30,7 @@ DebugToolbar::DebugToolbar(MainWindow *main, QWidget *parent) :
     QIcon restartIcon = QIcon(":/img/icons/spin_light.svg");
 
     // define action labels
-    QString startDebugLabel          = tr("Start debug");
+    QString startDebugLabel = tr("Start debug");
     QString startEmulLabel = tr("Start emulation");
     QString startAttachLabel = tr("Attach to process");
     QString stopDebugLabel = tr("Stop debug");

--- a/src/widgets/VisualNavbar.cpp
+++ b/src/widgets/VisualNavbar.cpp
@@ -51,8 +51,8 @@ VisualNavbar::VisualNavbar(MainWindow *main, QWidget *parent) :
     graphicsScene->setBackgroundBrush(bg);
 
     this->graphicsView->setAlignment(Qt::AlignLeft);
-    this->graphicsView->setMinimumHeight(20);
-    this->graphicsView->setMaximumHeight(20);
+    this->graphicsView->setMinimumHeight(15);
+    this->graphicsView->setMaximumHeight(15);
     this->graphicsView->setFrameShape(QFrame::NoFrame);
     this->graphicsView->setRenderHints(0);
     this->graphicsView->setScene(graphicsScene);


### PR DESCRIPTION
Make colors and icon sizes better.

Not in debug mode:

![image](https://user-images.githubusercontent.com/20182642/46474655-1a2a7700-c7ec-11e8-8737-39ab0e8fe142.png)

In debug/emulation mode:

![image](https://user-images.githubusercontent.com/20182642/46474681-29a9c000-c7ec-11e8-8195-95ed69327681.png)

Also, decresed the height of the visual navbar