### PR TITLE
Jupyter Notebook fix, broken dependency

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -54,7 +54,7 @@ after_build:
   - ps: $env:py_platform = If ($env:ARCH -eq "x64") {"amd64"} Else {"win32"}
   - ps: $env:py_url = "https://www.python.org/ftp/python/${env:py_version}/python-${env:py_version}-embed-${env:py_platform}.zip"
   - cmd: powershell -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; wget %py_url% -OutFile python_embed.zip; Expand-Archive .\python_embed.zip -DestinationPath .\python_embed"
-  - cmd: python -m pip install -I --no-compile -t "%ARTIFACT_PATH%\python36\site-packages" jupyter
+  - cmd: python -m pip install -I --no-compile -t "%ARTIFACT_PATH%\python36\site-packages" jupyter ipykernel==4.8.2
   - cmd: if exist "%ARTIFACT_PATH%\python36\site-packages\test" ( rd /s /q "%ARTIFACT_PATH%\python36\site-packages\test" )
   - cmd: for /d %%p in ("%ARTIFACT_PATH%\python36\site-packages\*.dist-info" "%ARTIFACT_PATH%\python36\site-packages\*.egg-info") do rd /s /q "%%p"
   - cmd: python -O -m compileall -b -q "%ARTIFACT_PATH%\python36\site-packages"


### PR DESCRIPTION
Broken dependent library `ipykernel` has released in Cutter `1.7.2`. It was downgraded, so we bundle old good one v `4.8.2`