### PR TITLE
Fixed an extra empty row inside Vertical View in Function Widget

### DIFF
--- a/src/widgets/FunctionsWidget.cpp
+++ b/src/widgets/FunctionsWidget.cpp
@@ -60,7 +60,7 @@ int FunctionModel::rowCount(const QModelIndex &parent) const
 
     if (nested) {
         if (parent.internalId() == 0)
-            return ColumnCount; // sub-nodes for nested functions
+            return ColumnCount - 1; // sub-nodes for nested functions
         return 0;
     } else
         return 0;

--- a/src/widgets/FunctionsWidget.cpp
+++ b/src/widgets/FunctionsWidget.cpp
@@ -130,7 +130,7 @@ QVariant FunctionModel::data(const QModelIndex &index, int role) const
                 case 9:
                     return tr("Cost: %1").arg(function.cost);
                 case 10:
-                    return tr("Calls/OutDeg.: %1").arg(function.calls);
+                    return tr("Calls/OutDegree: %1").arg(function.calls);
                 case 11:
                     return tr("StackFrame: %1").arg(function.stackframe);
                 default:


### PR DESCRIPTION
![function_info](https://user-images.githubusercontent.com/30472260/46750723-35a6ed80-ccd6-11e8-8748-f2b274931923.PNG)
I made a mistake in my last PR which causes to show an extra empty row inside Vertical view in function widget. Fixed now.