### PR TITLE
[Fix] Fixed issue #805

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -423,9 +423,7 @@ bool MainWindow::saveProject(bool quit)
 bool MainWindow::saveProjectAs(bool quit)
 {
     SaveProjectDialog dialog(quit, this);
-    int result = dialog.exec();
-
-    return !quit || result != SaveProjectDialog::Rejected;
+    return SaveProjectDialog::Rejected == dialog.exec();
 }
 
 void MainWindow::refreshOmniBar(const QStringList &flags)
@@ -445,23 +443,22 @@ void MainWindow::closeEvent(QCloseEvent *event)
     QMessageBox::StandardButton ret = QMessageBox::question(this, APPNAME,
                                                             tr("Do you really want to exit?\nSave your project before closing!"),
                                                             (QMessageBox::StandardButtons)(QMessageBox::Save | QMessageBox::Discard | QMessageBox::Cancel));
-    if (ret == QMessageBox::Save) {
-        if (saveProject(true) && !core->currentlyDebugging) {
-            saveSettings();
-        } else if (core->currentlyDebugging) {
-            core->stopDebug();
-        }
-        QMainWindow::closeEvent(event);
-    } else if (ret == QMessageBox::Discard) {
-        if (!core->currentlyDebugging) {
-            saveSettings();
-        } else if (core->currentlyDebugging) {
-            core->stopDebug();
-        }
-        QMainWindow::closeEvent(event);
-    } else {
+    if (ret == QMessageBox::Cancel) {
         event->ignore();
+        return;
     }
+
+    if (ret == QMessageBox::Save && !saveProject(true)) {
+        event->ignore();
+        return;
+    }
+
+    if (!core->currentlyDebugging) {
+        saveSettings();
+    } else {
+        core->stopDebug();
+    }
+    QMainWindow::closeEvent(event);
 }
 
 void MainWindow::readSettings()

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -83,7 +83,7 @@ public:
 
     /*!
      * @param quit whether to show destructive button in dialog
-     * @return if quit is true, false if the application should not close
+     * @return false if the application should not close
      */
     bool saveProjectAs(bool quit = false);
 

--- a/src/dialogs/SaveProjectDialog.cpp
+++ b/src/dialogs/SaveProjectDialog.cpp
@@ -61,22 +61,19 @@ void SaveProjectDialog::on_selectProjectsDirButton_clicked()
 
 void SaveProjectDialog::on_buttonBox_clicked(QAbstractButton *button)
 {
-    switch (ui->buttonBox->buttonRole(button)) {
-    case QDialogButtonBox::DestructiveRole:
-        QDialog::done(Destructive);
-        break;
-
-    case QDialogButtonBox::RejectRole:
-        QDialog::done(Rejected);
-        break;
-
-    default:
-        break;
+    if (QDialogButtonBox::DestructiveRole == ui->buttonBox->buttonRole(button)) { 
+        QDialog::done(QDialog::Accepted);
     }
 }
 
 void SaveProjectDialog::accept()
 {
+    const QString& projectName = ui->nameEdit->text().trimmed();
+    if (!CutterCore::isProjectNameValid(projectName)) {
+        QMessageBox::critical(this, tr("Save project"), tr("Invalid project name."));
+        ui->nameEdit->setFocus();
+        return;
+    }
     TempConfig tempConfig;
     Config()->setDirProjects(ui->projectsDirEdit->text().toUtf8().constData());
     tempConfig.set("dir.projects", Config()->getDirProjects())
@@ -85,18 +82,7 @@ void SaveProjectDialog::accept()
     .set("prj.git", ui->gitCheckBox->isChecked())
     .set("prj.zip", ui->zipCheckBox->isChecked());
 
-    QString projectName = ui->nameEdit->text().trimmed();
-    if (!CutterCore::isProjectNameValid(projectName)) {
-        QMessageBox::critical(this, tr("Save project"), tr("Invalid project name."));
-        return;
-    }
-
     Core()->saveProject(projectName);
 
-    QDialog::done(Saved);
-}
-
-void SaveProjectDialog::reject()
-{
-    done(Rejected);
+    QDialog::accept();
 }

--- a/src/dialogs/SaveProjectDialog.h
+++ b/src/dialogs/SaveProjectDialog.h
@@ -15,13 +15,11 @@ class SaveProjectDialog : public QDialog
     Q_OBJECT
 
 public:
-    enum Result { Saved, Rejected, Destructive };
 
     explicit SaveProjectDialog(bool quit, QWidget *parent = nullptr);
     ~SaveProjectDialog();
 
     virtual void accept() override;
-    virtual void reject() override;
 
 private slots:
     void on_buttonBox_clicked(QAbstractButton *button);


### PR DESCRIPTION
- wrong handling of `Close` button in `Save Project` dialog which had a `Discard` meaning.
- a new project's name validation fixed