### PR TITLE
Bye bye "General Settings", welcome "Appearance"

### DIFF
--- a/src/Cutter.pro
+++ b/src/Cutter.pro
@@ -155,7 +155,7 @@ SOURCES += \
     widgets/VisualNavbar.cpp \
     widgets/GraphView.cpp \
     dialogs/preferences/PreferencesDialog.cpp \
-    dialogs/preferences/GeneralOptionsWidget.cpp \
+    dialogs/preferences/AppearanceOptionsWidget.cpp \
     dialogs/preferences/GraphOptionsWidget.cpp \
     dialogs/preferences/PreferenceCategory.cpp \
     widgets/QuickFilterView.cpp \
@@ -250,7 +250,7 @@ HEADERS  += \
     widgets/VisualNavbar.h \
     widgets/GraphView.h \
     dialogs/preferences/PreferencesDialog.h \
-    dialogs/preferences/GeneralOptionsWidget.h \
+    dialogs/preferences/AppearanceOptionsWidget.h \
     dialogs/preferences/PreferenceCategory.h \
     dialogs/preferences/GraphOptionsWidget.h \
     widgets/QuickFilterView.h \
@@ -327,7 +327,7 @@ FORMS    += \
     widgets/HexdumpWidget.ui \
     dialogs/SaveProjectDialog.ui \
     dialogs/preferences/PreferencesDialog.ui \
-    dialogs/preferences/GeneralOptionsWidget.ui \
+    dialogs/preferences/AppearanceOptionsWidget.ui \
     dialogs/preferences/GraphOptionsWidget.ui \
     widgets/QuickFilterView.ui \
     widgets/PseudocodeWidget.ui \

--- a/src/dialogs/preferences/AppearanceOptionsWidget.cpp
+++ b/src/dialogs/preferences/AppearanceOptionsWidget.cpp
@@ -5,8 +5,8 @@
 
 #include <QComboBox>
 #include "PreferencesDialog.h"
-#include "GeneralOptionsWidget.h"
-#include "ui_GeneralOptionsWidget.h"
+#include "AppearanceOptionsWidget.h"
+#include "ui_AppearanceOptionsWidget.h"
 
 #include "utils/Helpers.h"
 #include "utils/Configuration.h"
@@ -14,9 +14,9 @@
 #include "utils/ColorSchemeFileSaver.h"
 #include "widgets/ColorSchemePrefWidget.h"
 
-GeneralOptionsWidget::GeneralOptionsWidget(PreferencesDialog *dialog, QWidget *parent)
+AppearanceOptionsWidget::AppearanceOptionsWidget(PreferencesDialog *dialog, QWidget *parent)
     : QDialog(parent),
-      ui(new Ui::GeneralOptionsWidget)
+      ui(new Ui::AppearanceOptionsWidget)
 {
     Q_UNUSED(dialog);
     ui->setupUi(this);
@@ -24,7 +24,7 @@ GeneralOptionsWidget::GeneralOptionsWidget(PreferencesDialog *dialog, QWidget *p
     updateFontFromConfig();
     updateThemeFromConfig();
 
-    connect(Config(), &Configuration::fontsUpdated, this, &GeneralOptionsWidget::updateFontFromConfig);
+    connect(Config(), &Configuration::fontsUpdated, this, &AppearanceOptionsWidget::updateFontFromConfig);
     connect(ui.get()->colorComboBox, &QComboBox::currentTextChanged, [&](const QString & name) {
         static_cast<ColorSchemePrefWidget *>(ui.get()->colorSchemePrefWidget)->setNewScheme(name);
     });
@@ -32,15 +32,15 @@ GeneralOptionsWidget::GeneralOptionsWidget(PreferencesDialog *dialog, QWidget *p
     (ui.get()->colorSchemePrefWidget)->setNewScheme(Config()->getCurrentTheme());
 }
 
-GeneralOptionsWidget::~GeneralOptionsWidget() {}
+AppearanceOptionsWidget::~AppearanceOptionsWidget() {}
 
-void GeneralOptionsWidget::updateFontFromConfig()
+void AppearanceOptionsWidget::updateFontFromConfig()
 {
     QFont currentFont = Config()->getFont();
     ui->fontSelectionLabel->setText(currentFont.toString());
 }
 
-void GeneralOptionsWidget::updateThemeFromConfig()
+void AppearanceOptionsWidget::updateThemeFromConfig()
 {
     // Disconnect currentIndexChanged because clearing the comboxBox and refiling it causes its index to change.
     disconnect(ui->colorComboBox, SIGNAL(currentIndexChanged(int)), this,
@@ -68,7 +68,7 @@ void GeneralOptionsWidget::updateThemeFromConfig()
             SLOT(on_colorComboBox_currentIndexChanged(int)));
 }
 
-void GeneralOptionsWidget::on_fontSelectionButton_clicked()
+void AppearanceOptionsWidget::on_fontSelectionButton_clicked()
 {
     QFont currentFont = Config()->getFont();
     bool ok;
@@ -79,20 +79,20 @@ void GeneralOptionsWidget::on_fontSelectionButton_clicked()
     }
 }
 
-void GeneralOptionsWidget::on_themeComboBox_currentIndexChanged(int index)
+void AppearanceOptionsWidget::on_themeComboBox_currentIndexChanged(int index)
 {
     //disconnect(Config(), SIGNAL(colorsUpdated()), this, SLOT(updateThemeFromConfig()));
     Config()->setTheme(index);
     //connect(Config(), SIGNAL(colorsUpdated()), this, SLOT(updateThemeFromConfig()));
 }
 
-void GeneralOptionsWidget::on_colorComboBox_currentIndexChanged(int index)
+void AppearanceOptionsWidget::on_colorComboBox_currentIndexChanged(int index)
 {
     QString theme = ui->colorComboBox->itemText(index);
     Config()->setColorTheme(theme);
 }
 
-void GeneralOptionsWidget::on_copyButton_clicked()
+void AppearanceOptionsWidget::on_copyButton_clicked()
 {
     QString newSchemeName;
     do {
@@ -110,7 +110,7 @@ void GeneralOptionsWidget::on_copyButton_clicked()
     ui.get()->colorComboBox->setCurrentIndex(ui.get()->colorComboBox->findText(newSchemeName));
 }
 
-void GeneralOptionsWidget::on_deleteButton_clicked()
+void AppearanceOptionsWidget::on_deleteButton_clicked()
 {
     ColorSchemeFileWorker().deleteScheme(Config()->getCurrentTheme());
 }

--- a/src/dialogs/preferences/AppearanceOptionsWidget.h
+++ b/src/dialogs/preferences/AppearanceOptionsWidget.h
@@ -1,6 +1,6 @@
 
-#ifndef GENERALOPTIONSWIDGET_H
-#define GENERALOPTIONSWIDGET_H
+#ifndef AppearanceOptionsWidget_H
+#define AppearanceOptionsWidget_H
 
 #include <QDialog>
 #include <QPushButton>
@@ -11,19 +11,19 @@
 class PreferencesDialog;
 
 namespace Ui {
-class GeneralOptionsWidget;
+class AppearanceOptionsWidget;
 }
 
-class GeneralOptionsWidget : public QDialog
+class AppearanceOptionsWidget : public QDialog
 {
     Q_OBJECT
 
 public:
-    explicit GeneralOptionsWidget(PreferencesDialog *dialog, QWidget *parent = nullptr);
-    ~GeneralOptionsWidget();
+    explicit AppearanceOptionsWidget(PreferencesDialog *dialog, QWidget *parent = nullptr);
+    ~AppearanceOptionsWidget();
 
 private:
-    std::unique_ptr<Ui::GeneralOptionsWidget> ui;
+    std::unique_ptr<Ui::AppearanceOptionsWidget> ui;
 
 private slots:
     void updateFontFromConfig();

--- a/src/dialogs/preferences/AppearanceOptionsWidget.ui
+++ b/src/dialogs/preferences/AppearanceOptionsWidget.ui
@@ -1,4 +1,4 @@
-\<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>AppearanceOptionsWidget</class>
  <widget class="QWidget" name="AppearanceOptionsWidget">

--- a/src/dialogs/preferences/AppearanceOptionsWidget.ui
+++ b/src/dialogs/preferences/AppearanceOptionsWidget.ui
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+\<?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>AppearanceOptionsWidget</class>
  <widget class="QWidget" name="AppearanceOptionsWidget">
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>General</string>
+   <string>Appearance</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="sizeConstraint">

--- a/src/dialogs/preferences/AppearanceOptionsWidget.ui
+++ b/src/dialogs/preferences/AppearanceOptionsWidget.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>GeneralOptionsWidget</class>
- <widget class="QWidget" name="GeneralOptionsWidget">
+ <class>AppearanceOptionsWidget</class>
+ <widget class="QWidget" name="AppearanceOptionsWidget">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/src/dialogs/preferences/PreferencesDialog.cpp
+++ b/src/dialogs/preferences/PreferencesDialog.cpp
@@ -3,7 +3,7 @@
 #include "PreferencesDialog.h"
 #include "ui_PreferencesDialog.h"
 
-#include "GeneralOptionsWidget.h"
+#include "AppearanceOptionsWidget.h"
 #include "AsmOptionsWidget.h"
 #include "GraphOptionsWidget.h"
 #include "DebugOptionsWidget.h"
@@ -22,11 +22,7 @@ PreferencesDialog::PreferencesDialog(QWidget *parent)
     ui->setupUi(this);
 
     QList<PreferenceCategory> prefs {
-        {
-            "General",
-            new GeneralOptionsWidget(this),
-            QIcon(":/img/icons/cog_light.svg")
-        },
+
         {
             "Assembly",
             new AsmOptionsWidget(this),
@@ -43,6 +39,11 @@ PreferencesDialog::PreferencesDialog(QWidget *parent)
             "Debug",
             new DebugOptionsWidget(this),
             QIcon(":/img/icons/bug_light.svg")
+        },
+        {
+            "Appearance",
+            new AppearanceOptionsWidget(this),
+            QIcon(":/img/icons/polar_light.svg")
         }
     };
 
@@ -68,7 +69,7 @@ void PreferencesDialog::showSection(PreferencesDialog::Section section)
 {
     QTreeWidgetItem *defitem;
     switch (section) {
-    case Section::General:
+    case Section::Appearance:
         ui->configPanel->setCurrentIndex(0);
         defitem = ui->configCategories->topLevelItem(0);
         ui->configCategories->setCurrentItem(defitem, 0);

--- a/src/dialogs/preferences/PreferencesDialog.h
+++ b/src/dialogs/preferences/PreferencesDialog.h
@@ -18,7 +18,7 @@ class PreferencesDialog : public QDialog
     Q_OBJECT
 
 public:
-    enum class Section { General, Disassembly };
+    enum class Section { Appearance, Disassembly };
 
     explicit PreferencesDialog(QWidget *parent = nullptr);
     ~PreferencesDialog();


### PR DESCRIPTION
Since "General" used to hold only UI related settings (color themes, qt themes, font size, ...) I change it to "Appearance". I have nothing against "General" settings, but if we want it, we should put general settings in it.
Still need to find a better Icon for this, but this is for another time.

Before (outdated Cutter version):
![image](https://user-images.githubusercontent.com/20182642/47029836-28c24800-d175-11e8-899e-02bbf58fec44.png)


After:
![image](https://user-images.githubusercontent.com/20182642/47029915-4becf780-d175-11e8-8414-946e5a549119.png)

