### PR TITLE
Disable the debug window menu outside Debug/Emulation mode (resolves #859)

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -237,6 +237,7 @@ void MainWindow::initUI()
 
     // Set up dock widgets default layout
     resetToDefaultLayout();
+    enableDebugWidgetsMenu(false);
 
     // Restore saved settings
     this->readSettings();
@@ -680,6 +681,11 @@ void MainWindow::showDebugDocks()
     updateDockActionsChecked();
 }
 
+void MainWindow::enableDebugWidgetsMenu(bool enable)
+{
+    ui->menuAddDebugWidgets->setEnabled(enable);
+}
+
 void MainWindow::resetToDefaultLayout()
 {
     hideAllDocks();
@@ -960,6 +966,7 @@ void MainWindow::changeDebugView()
 {
     saveSettings();
     resetToDebugLayout();
+    enableDebugWidgetsMenu(true);
 }
 
 void MainWindow::changeDefinedView()
@@ -969,6 +976,7 @@ void MainWindow::changeDefinedView()
     hideAllDocks();
     restoreDocks();
     readSettings();
+    enableDebugWidgetsMenu(false);
     core->raisePrioritizedMemoryWidget(memType);
 }
 

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -245,6 +245,7 @@ private:
     void hideAllDocks();
     void showZenDocks();
     void showDebugDocks();
+    void enableDebugWidgetsMenu(bool enable);
 
     void toggleDockWidget(QDockWidget *dock_widget, bool show);
 


### PR DESCRIPTION
This commit grayes out the debug windows menu when not debugging.
I stumbled upon this project while browsing the hacktoberfest issues and really like it. Hope I can contribute in the future.

Best,
Michael