### PR TITLE
 Change edit dialog to allow no preview

### DIFF
--- a/src/dialogs/EditInstructionDialog.cpp
+++ b/src/dialogs/EditInstructionDialog.cpp
@@ -40,13 +40,13 @@ void EditInstructionDialog::setInstruction(const QString &instruction)
 void EditInstructionDialog::updatePreview(const QString &input)
 {
     QString result;
-    
+
     if (editMode == EDIT_NONE) {
         ui->instructionLabel->setText("");
         return;
     } else if (editMode == EDIT_BYTES) {
         result = Core()->disassemble(input).trimmed();
-    } else if (editMode == EDIT_TEXT){
+    } else if (editMode == EDIT_TEXT) {
         result = Core()->assemble(input).trimmed();
     }
 

--- a/src/dialogs/EditInstructionDialog.cpp
+++ b/src/dialogs/EditInstructionDialog.cpp
@@ -2,10 +2,10 @@
 #include "ui_EditInstructionDialog.h"
 #include "Cutter.h"
 
-EditInstructionDialog::EditInstructionDialog(QWidget *parent, bool isEditingBytes) :
+EditInstructionDialog::EditInstructionDialog(QWidget *parent, InstructionEditMode editMode) :
     QDialog(parent),
     ui(new Ui::EditInstructionDialog),
-    isEditingBytes(isEditingBytes)
+    editMode(editMode)
 {
     ui->setupUi(this);
     setWindowFlags(windowFlags() & (~Qt::WindowContextHelpButtonHint));
@@ -40,9 +40,13 @@ void EditInstructionDialog::setInstruction(const QString &instruction)
 void EditInstructionDialog::updatePreview(const QString &input)
 {
     QString result;
-    if (isEditingBytes) {
+    
+    if (editMode == EDIT_NONE) {
+        ui->instructionLabel->setText("");
+        return;
+    } else if (editMode == EDIT_BYTES) {
         result = Core()->disassemble(input).trimmed();
-    } else {
+    } else if (editMode == EDIT_TEXT){
         result = Core()->assemble(input).trimmed();
     }
 

--- a/src/dialogs/EditInstructionDialog.h
+++ b/src/dialogs/EditInstructionDialog.h
@@ -9,12 +9,16 @@ namespace Ui {
 class EditInstructionDialog;
 }
 
+enum InstructionEditMode {
+    EDIT_NONE, EDIT_BYTES, EDIT_TEXT
+};
+
 class EditInstructionDialog : public QDialog
 {
     Q_OBJECT
 
 public:
-    explicit EditInstructionDialog(QWidget *parent, bool isEditingBytes);
+    explicit EditInstructionDialog(QWidget *parent, InstructionEditMode isEditingBytes);
     ~EditInstructionDialog();
 
     QString getInstruction();
@@ -29,7 +33,7 @@ private slots:
 
 private:
     std::unique_ptr<Ui::EditInstructionDialog> ui;
-    bool isEditingBytes; // true if editing intruction **bytes**; false if editing instruction **text**
+    InstructionEditMode editMode; // true if editing intruction **bytes**; false if editing instruction **text**
 };
 
 #endif // EDITINSTRUCTIONDIALOG_H

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -40,7 +40,7 @@ DisassemblyContextMenu::DisassemblyContextMenu(QWidget *parent)
     addAction(&actionRename);
 
     initAction(&actionEditFunction, tr("Edit function"),
-            SLOT(on_actionEditFunction_triggered()));
+               SLOT(on_actionEditFunction_triggered()));
     addAction(&actionEditFunction);
 
     initAction(&actionRenameUsedHere, tr("Rename Flag/Fcn/Var Used Here"),
@@ -234,7 +234,7 @@ void DisassemblyContextMenu::aboutToShowSlot()
 {
     // check if set immediate base menu makes sense
     QJsonObject instObject = Core()->cmdj("aoj @ " + QString::number(
-                                              offset)).array().first().toObject();
+            offset)).array().first().toObject();
     auto keys = instObject.keys();
     bool immBase = keys.contains("val") || keys.contains("ptr");
     setBaseMenu->menuAction()->setVisible(immBase);
@@ -354,7 +354,7 @@ QKeySequence DisassemblyContextMenu::getRenameUsedHereSequence() const
 
 QKeySequence DisassemblyContextMenu::getRetypeSequence() const
 {
-     return {Qt::Key_Y};
+    return {Qt::Key_Y};
 }
 
 QKeySequence DisassemblyContextMenu::getXRefSequence() const
@@ -744,7 +744,7 @@ void DisassemblyContextMenu::setToData(int size, int repeat)
 }
 
 QAction *DisassemblyContextMenu::addAnonymousAction(QString name, const char *slot,
-                                                    QKeySequence keySequence)
+        QKeySequence keySequence)
 {
     auto action = new QAction();
     addAction(action);

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -374,7 +374,7 @@ QList<QKeySequence> DisassemblyContextMenu::getAddBPSequence() const
 
 void DisassemblyContextMenu::on_actionEditInstruction_triggered()
 {
-    EditInstructionDialog *e = new EditInstructionDialog(this, false);
+    EditInstructionDialog *e = new EditInstructionDialog(this, EDIT_TEXT);
     e->setWindowTitle(tr("Edit Instruction at %1").arg(RAddressString(offset)));
 
     QString oldInstructionOpcode = Core()->getInstructionOpcode(offset);
@@ -439,7 +439,7 @@ void DisassemblyContextMenu::on_actionJmpReverse_triggered()
 
 void DisassemblyContextMenu::on_actionEditBytes_triggered()
 {
-    EditInstructionDialog *e = new EditInstructionDialog(this, true);
+    EditInstructionDialog *e = new EditInstructionDialog(this, EDIT_BYTES);
     e->setWindowTitle(tr("Edit Bytes at %1").arg(RAddressString(offset)));
 
     QString oldBytes = Core()->getInstructionBytes(offset);

--- a/src/widgets/StackWidget.cpp
+++ b/src/widgets/StackWidget.cpp
@@ -123,8 +123,7 @@ void StackWidget::editStack()
     bool ok;
     int row = viewStack->selectionModel()->currentIndex().row();
     QString offset = viewStack->selectionModel()->currentIndex().sibling(row, 0).data().toString();
-    // FIXME: This is not correct because there should be no preview of anything
-    EditInstructionDialog *e = new EditInstructionDialog(this, false);
+    EditInstructionDialog *e = new EditInstructionDialog(this, EDIT_NONE);
     e->setWindowTitle(tr("Edit stack at %1").arg(offset));
 
     QString oldBytes = viewStack->selectionModel()->currentIndex().sibling(row, 1).data().toString();


### PR DESCRIPTION
**Test plan (required)**

Getting linking errors on my machine before any changes, which is new today. Would spend more time debugging, but said I'd open this by midnight. I'll try to get images on tomorrow, apologies.
All that needs done hopefully is to open the edit dialog through a bytes edit, instruction edit, and stack edit. Should have text, bytes, and no display respectively.

**Code formatting**

Ran astyle on all changed files

**Closing issues**

closes #700  
