### PR TITLE
Make the text in About Dialog selectable

### DIFF
--- a/src/dialogs/AboutDialog.cpp
+++ b/src/dialogs/AboutDialog.cpp
@@ -60,6 +60,7 @@ void AboutDialog::on_showVersionButton_clicked()
 {
     QMessageBox popup(this);
     popup.setWindowTitle(tr("radare2 version information"));
+    popup.setTextInteractionFlags(Qt::TextSelectableByMouse);
     auto versionInformation = Core()->getVersionInformation();
     popup.setText(versionInformation);
     popup.exec();

--- a/src/dialogs/AboutDialog.ui
+++ b/src/dialogs/AboutDialog.ui
@@ -100,6 +100,9 @@
      <property name="margin">
       <number>5</number>
      </property>
+     <property name="textInteractionFlags">
+      <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+     </property>
     </widget>
    </item>
    <item>


### PR DESCRIPTION
Until now, it was har to share the version info of radare2 and Cutter since the text i the About dialog wasn't selectable. Now it is --

![image](https://user-images.githubusercontent.com/20182642/47339867-357afa80-d6a5-11e8-8767-d41ffaf423bc.png)
