### PR TITLE
Following QT best-practices: use constants cbegin and cend

### DIFF
--- a/src/widgets/SearchWidget.cpp
+++ b/src/widgets/SearchWidget.cpp
@@ -131,7 +131,7 @@ SearchWidget::SearchWidget(MainWindow *main, QAction *action) :
 
     ui->searchInCombo->blockSignals(true);
     QMap<QString, QString>::const_iterator mapIter;
-    for (mapIter = kSearchBoundariesValues.begin(); mapIter != kSearchBoundariesValues.end(); ++mapIter)
+    for (mapIter = kSearchBoundariesValues.cbegin(); mapIter != kSearchBoundariesValues.cend(); ++mapIter)
         ui->searchInCombo->addItem(mapIter.value(), mapIter.key());
     ui->searchInCombo->blockSignals(false);
 


### PR DESCRIPTION
A tiny improvement for #873 -- now using constants `cbegin()` and `cend()` as [recommended by QT](https://wiki.qt.io/Coding_Conventions):

> Don't mix const and non-const iterators. This will silently crash on broken compilers.