### PR TITLE
Temporarily disable macOS Mojave Dark Mode in Info.plist (Fix #772)

### DIFF
--- a/src/macos/Info.plist
+++ b/src/macos/Info.plist
@@ -22,6 +22,8 @@
 	<string>NSApplication</string>
 	<key>NSSupportsAutomaticGraphicsSwitching</key>
 	<true/>
+	<key>NSRequiresAquaSystemAppearance</key>
+	<true/>
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
Fix #772