### PR TITLE
Add try again option for write error dialog

### DIFF
--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -391,7 +391,9 @@ void DisassemblyContextMenu::on_actionEditInstruction_triggered()
             // check if the write failed
             auto newInstructionBytes = Core()->getInstructionBytes(offset);
             if (newInstructionBytes == oldInstructionBytes) {
-                writeFailed();
+                if(!writeFailed()) {
+                    Core()->editInstruction(offset, userInstructionOpcode);
+                }
             }
         }
     }
@@ -405,7 +407,9 @@ void DisassemblyContextMenu::on_actionNopInstruction_triggered()
 
     QString newBytes = Core()->getInstructionBytes(offset);
     if (oldBytes == newBytes) {
-        writeFailed();
+        if (!writeFailed()) {
+            Core()->nopInstruction(offset);
+        }
     }
 }
 
@@ -434,7 +438,9 @@ void DisassemblyContextMenu::on_actionJmpReverse_triggered()
 
     QString newBytes = Core()->getInstructionBytes(offset);
     if (oldBytes == newBytes) {
-        writeFailed();
+        if (!writeFailed()) {
+            Core()->jmpReverse(offset);
+        }
     }
 }
 
@@ -453,28 +459,31 @@ void DisassemblyContextMenu::on_actionEditBytes_triggered()
 
             QString newBytes = Core()->getInstructionBytes(offset);
             if (oldBytes == newBytes) {
-                writeFailed();
+                if (!writeFailed()) {
+                    Core()->editBytes(offset, bytes);
+                }
             }
         }
     }
 }
 
-void DisassemblyContextMenu::writeFailed()
+bool DisassemblyContextMenu::writeFailed()
 {
     QMessageBox msgBox;
     msgBox.setIcon(QMessageBox::Icon::Critical);
     msgBox.setWindowTitle(tr("Write error"));
-    msgBox.setText(tr("Unable to complete write operation. Consider opening in write mode."));
+    msgBox.setText(tr("Unable to complete write operation. Consider opening in write mode. \n\nWARNING: In write mode any changes will be commited to disk"));
     msgBox.addButton(tr("OK"), QMessageBox::NoRole);
-    QAbstractButton *reopenButton = msgBox.addButton(tr("Reopen in write mode"), QMessageBox::YesRole);
+    QAbstractButton *reopenButton = msgBox.addButton(tr("Reopen in write mode and try again"), QMessageBox::YesRole);
 
     msgBox.exec();
 
     if (msgBox.clickedButton() == reopenButton) {
-        QMessageBox::warning(this, "File reopened in write mode",
-                             "WARNING: Any chages will now be commited to disk");
         Core()->cmd("oo+");
+        return false;
     }
+
+    return true;
 }
 
 void DisassemblyContextMenu::on_actionCopy_triggered()

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -234,7 +234,7 @@ void DisassemblyContextMenu::aboutToShowSlot()
 {
     // check if set immediate base menu makes sense
     QJsonObject instObject = Core()->cmdj("aoj @ " + QString::number(
-            offset)).array().first().toObject();
+                                              offset)).array().first().toObject();
     auto keys = instObject.keys();
     bool immBase = keys.contains("val") || keys.contains("ptr");
     setBaseMenu->menuAction()->setVisible(immBase);
@@ -275,14 +275,11 @@ void DisassemblyContextMenu::aboutToShowSlot()
     }
 
     //only show retype for local vars if in a function
-    if(in_fcn)
-    {
+    if (in_fcn) {
         actionSetFunctionVarTypes.setVisible(true);
         actionEditFunction.setVisible(true);
         actionEditFunction.setText(tr("Edit function \"%1\"").arg(in_fcn->name));
-    }
-    else
-    {
+    } else {
         actionSetFunctionVarTypes.setVisible(false);
         actionEditFunction.setVisible(false);
     }
@@ -391,7 +388,7 @@ void DisassemblyContextMenu::on_actionEditInstruction_triggered()
             // check if the write failed
             auto newInstructionBytes = Core()->getInstructionBytes(offset);
             if (newInstructionBytes == oldInstructionBytes) {
-                if(!writeFailed()) {
+                if (!writeFailed()) {
                     Core()->editInstruction(offset, userInstructionOpcode);
                 }
             }
@@ -472,9 +469,11 @@ bool DisassemblyContextMenu::writeFailed()
     QMessageBox msgBox;
     msgBox.setIcon(QMessageBox::Icon::Critical);
     msgBox.setWindowTitle(tr("Write error"));
-    msgBox.setText(tr("Unable to complete write operation. Consider opening in write mode. \n\nWARNING: In write mode any changes will be commited to disk"));
+    msgBox.setText(
+        tr("Unable to complete write operation. Consider opening in write mode. \n\nWARNING: In write mode any changes will be commited to disk"));
     msgBox.addButton(tr("OK"), QMessageBox::NoRole);
-    QAbstractButton *reopenButton = msgBox.addButton(tr("Reopen in write mode and try again"), QMessageBox::YesRole);
+    QAbstractButton *reopenButton = msgBox.addButton(tr("Reopen in write mode and try again"),
+                                                     QMessageBox::YesRole);
 
     msgBox.exec();
 
@@ -632,8 +631,7 @@ void DisassemblyContextMenu::on_actionSetFunctionVarTypes_triggered()
 
     dialog = new SetFunctionVarTypes(this);
 
-    if(fcn)
-    {
+    if (fcn) {
         dialog->setWindowTitle(tr("Set Variable Types for Function: %1").arg(fcn->name));
     }
     dialog->setFcn(fcn);
@@ -756,7 +754,7 @@ void DisassemblyContextMenu::setToData(int size, int repeat)
 }
 
 QAction *DisassemblyContextMenu::addAnonymousAction(QString name, const char *slot,
-        QKeySequence keySequence)
+                                                    QKeySequence keySequence)
 {
     auto action = new QAction();
     addAction(action);

--- a/src/menus/DisassemblyContextMenu.h
+++ b/src/menus/DisassemblyContextMenu.h
@@ -29,7 +29,7 @@ private slots:
     void on_actionJmpReverse_triggered();
     void on_actionEditBytes_triggered();
     void showReverseJmpQuery();
-    void writeFailed();
+    bool writeFailed();
 
     void on_actionCopy_triggered();
     void on_actionCopyAddr_triggered();


### PR DESCRIPTION
Currently when somebody edits instruction and gets write error - new instruction is lost. This pull request changes error dialog so it retries on changing mode to write-mode.

I am 99% sure that if somebody decided to reopen in write-mode he/she also wanted to save changes ;)

![screenshot_20181027_170141](https://user-images.githubusercontent.com/1407751/47605695-0dbfc580-da0a-11e8-836a-fa2b5f8f0322.png)

