### PR TITLE
Fix sticking out highlighting on graph

### DIFF
--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -501,7 +501,16 @@ void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block)
                 }
 
                 int widthBefore = mFontMetrics->width(instr.plainText.left(pos));
-                p.fillRect(QRect(block.x + charWidth * 3 + widthBefore, y, tokenWidth,
+                if (widthBefore + charWidth * 7 > block.width) {
+                    continue;
+                }
+
+                int highlightWidth = tokenWidth;
+                if (widthBefore + tokenWidth >= block.width) {
+                    highlightWidth = block.width - widthBefore - charWidth * 5;
+                }
+
+                p.fillRect(QRect(block.x + charWidth * 3 + widthBefore, y, highlightWidth,
                                  charHeight), disassemblySelectionColor.lighter(250));
             }
 


### PR DESCRIPTION
Currently when disassembly line is cropped the token is still highlighted as if it isn't cropped:
![2018-10-27_17-27](https://user-images.githubusercontent.com/1407751/47606112-ed930500-da0f-11e8-91a3-43b68ee5d485.png)

This pull request fixes it so it looks like this:
![2018-10-27_17-43](https://user-images.githubusercontent.com/1407751/47606152-495d8e00-da10-11e8-8066-9e01fb02934d.png)
