### PR TITLE
Windows&Unicode - build scripts. Fixes #589

### DIFF
--- a/meson.py
+++ b/meson.py
@@ -54,6 +54,7 @@ def build(args):
             defines.append('-Dradare2:r2_incdir=radare2/include')
             defines.append('-Dradare2:r2_libdir=radare2/lib')
             defines.append('-Dradare2:r2_datdir=radare2/share')
+            defines.append('c_args=-D_UNICODE -DUNICODE')
         r2_meson_mod.meson(os.path.join(ROOT, 'src'), cutter_builddir,
                            prefix=cutter_builddir, backend=args.backend,
                            release=args.release, shared=False, options=defines)

--- a/meson.py
+++ b/meson.py
@@ -54,7 +54,7 @@ def build(args):
             defines.append('-Dradare2:r2_incdir=radare2/include')
             defines.append('-Dradare2:r2_libdir=radare2/lib')
             defines.append('-Dradare2:r2_datdir=radare2/share')
-            defines.append('c_args=-D_UNICODE -DUNICODE')
+            defines.append('-Dc_args=-D_UNICODE -DUNICODE')
         r2_meson_mod.meson(os.path.join(ROOT, 'src'), cutter_builddir,
                            prefix=cutter_builddir, backend=args.backend,
                            release=args.release, shared=False, options=defines)

--- a/prepare_r2.bat
+++ b/prepare_r2.bat
@@ -16,6 +16,6 @@ ECHO Building radare2 (%PLATFORM%)
 CD radare2
 git clean -xfd
 RMDIR /S /Q ..\%R2DIST%
-python sys\meson.py --release --shared --install=..\%R2DIST% --options r2_datdir=radare2/share
+python sys\meson.py --release --shared --install=..\%R2DIST% --options "r2_datdir=radare2/share" "c_args=-D_UNICODE -DUNICODE"
 IF !ERRORLEVEL! NEQ 0 EXIT /B 1
 COPY /Y build\shlr\libr2sdb.a ..\%R2DIST%\lib\r_sdb.lib

--- a/src/widgets/Dashboard.cpp
+++ b/src/widgets/Dashboard.cpp
@@ -39,7 +39,13 @@ void Dashboard::updateContents()
     QJsonObject item = docu.object()["core"].toObject();
     QJsonObject item2 = docu.object()["bin"].toObject();
 
-    this->ui->fileEdit->setText(item["file"].toString());
+#ifdef Q_OS_WIN
+    QString fname = item["file"].toString();
+    fname = QString::fromUtf8(fname.toLatin1());
+#else // Q_OS_WIN
+    QString fname = item["file"].toString();
+#endif // Q_OS_WIN
+    this->ui->fileEdit->setText(fname);
     this->ui->formatEdit->setText(item["format"].toString());
     this->ui->modeEdit->setText(item["mode"].toString());
     this->ui->typeEdit->setText(item["type"].toString());


### PR DESCRIPTION
Build scripts were updated
Fixed utf8 file path displaying in Dashboard widget
Closes #589 

![image](https://user-images.githubusercontent.com/14978853/47716313-6635d380-dc53-11e8-9b86-645a11a4d777.png)

![image](https://user-images.githubusercontent.com/14978853/47716383-92e9eb00-dc53-11e8-8057-b551d86541e6.png)

In the radare2 fixed also project saving for unicode`%USERNAME%`:
![image](https://user-images.githubusercontent.com/14978853/47716397-a006da00-dc53-11e8-9872-7eca03d10044.png)
