### PR TITLE
Fix tabs max-width

### DIFF
--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -35,10 +35,11 @@ QMainWindow &gt; QTabBar::tab {
     border-bottom-color: #2180a9;
     border-top-left-radius: 0px;
     border-top-right-radius: 0px;
-    min-width: 8ex;
+    min-width: 8px;
+    max-width: 200px;
     padding: 5px;
-	margin-bottom: 3px;
-	margin-top: 3px;
+    margin-bottom: 3px;
+    margin-top: 3px;
 }
 
 QMainWindow &gt; QTabBar::tab:selected {


### PR DESCRIPTION
Setting `max-width` to tabs.

Before:

![image](https://user-images.githubusercontent.com/20182642/47787705-5af8ab80-dd18-11e8-90c8-8aab60978379.png)


After:
![image](https://user-images.githubusercontent.com/20182642/47787629-24bb2c00-dd18-11e8-94b4-9a19c417ae4a.png)
