### PR TITLE
Fix highlight stick out fix

### DIFF
--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -501,13 +501,13 @@ void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block)
                 }
 
                 int widthBefore = mFontMetrics->width(instr.plainText.left(pos));
-                if (widthBefore + charWidth * 7 > block.width) {
+                if (charWidth * 3 + widthBefore > block.width - (10 + 2 * charWidth)) {
                     continue;
                 }
 
                 int highlightWidth = tokenWidth;
-                if (widthBefore + tokenWidth >= block.width) {
-                    highlightWidth = block.width - widthBefore - charWidth * 5;
+                if (charWidth * 3 + widthBefore + tokenWidth >= block.width - (10 + 2 * charWidth)) {
+                    highlightWidth = block.width - widthBefore - (10 + 4 * charWidth);
                 }
 
                 p.fillRect(QRect(block.x + charWidth * 3 + widthBefore, y, highlightWidth,


### PR DESCRIPTION
This pull request improves my previous fix for sticking out highlighting on graph (#881). It was not working with few block widths and it didn't cut highlighting in the same place in every line.
