### PR TITLE
DisassemblyWidget: fixed extra characters highlighting

### DIFF
--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -379,7 +379,6 @@ void DisassemblyWidget::highlightCurrentLine()
                 highlightSelection.format.setBackground(highlightWordColor);
             }
 
-            highlightSelection.cursor.movePosition(QTextCursor::EndOfWord, QTextCursor::KeepAnchor);
             extraSelections.append(highlightSelection);
         }
     }


### PR DESCRIPTION
Related to #798 
Fixes extra characters highlighting in a Disassembly widget only.

Previous behavior:
![image](https://user-images.githubusercontent.com/14978853/47884550-40225600-de42-11e8-9922-257058ee6383.png)

The problem was because extra cursor move has been applying:
![image](https://user-images.githubusercontent.com/14978853/47884603-6cd66d80-de42-11e8-98f5-4ea6cecc6086.png)

