### PR TITLE
Related to #865 - project saving on windows issue 

### DIFF
--- a/src/Cutter.cpp
+++ b/src/Cutter.cpp
@@ -2045,9 +2045,10 @@ void CutterCore::openProject(const QString &name)
 
 void CutterCore::saveProject(const QString &name)
 {
-    cmd("Ps " + name);
+    const QString &rv = cmd("Ps " + name.trimmed()).trimmed();
+    const bool ok = rv == name.trimmed();
     cmd("Pnj " + notes.toUtf8().toBase64());
-    emit projectSaved(name);
+    emit projectSaved(ok, name);
 }
 
 void CutterCore::deleteProject(const QString &name)

--- a/src/Cutter.h
+++ b/src/Cutter.h
@@ -628,7 +628,7 @@ signals:
     void refreshCodeViews();
     void stackChanged();
 
-    void projectSaved(const QString &name);
+    void projectSaved(bool successfully, const QString &name);
 
     /*!
      * emitted when config regarding disassembly display changes

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -265,7 +265,7 @@ void MainWindow::initUI()
     QShortcut *refresh_shortcut = new QShortcut(QKeySequence(QKeySequence::Refresh), this);
     connect(refresh_shortcut, SIGNAL(activated()), this, SLOT(refreshAll()));
 
-    connect(core, SIGNAL(projectSaved(const QString &)), this, SLOT(projectSaved(const QString &)));
+    connect(core, SIGNAL(projectSaved(bool, const QString &)), this, SLOT(projectSaved(bool, const QString &)));
 
     connect(core, &CutterCore::changeDebugView, this, &MainWindow::changeDebugView);
     connect(core, &CutterCore::changeDefinedView, this, &MainWindow::changeDefinedView);
@@ -781,9 +781,8 @@ void MainWindow::on_actionRun_Script_triggered()
     dialog.setViewMode(QFileDialog::Detail);
     dialog.setDirectory(QDir::home());
 
-    QString fileName;
-    fileName = dialog.getOpenFileName(this, tr("Select radare2 script"));
-    if (!fileName.length()) // Cancel was pressed
+    const QString &fileName = QDir::toNativeSeparators(dialog.getOpenFileName(this, tr("Select radare2 script")));
+    if (fileName.isEmpty()) // Cancel was pressed
         return;
     core->loadScript(fileName);
 }
@@ -897,7 +896,7 @@ void MainWindow::on_actionImportPDB_triggered()
         return;
     }
 
-    QString pdbFile = dialog.selectedFiles().first();
+    const QString &pdbFile = QDir::toNativeSeparators(dialog.selectedFiles().first());
 
     if (!pdbFile.isEmpty()) {
         core->loadPDB(pdbFile);
@@ -957,9 +956,12 @@ void MainWindow::on_actionExport_as_code_triggered()
 }
 
 
-void MainWindow::projectSaved(const QString &name)
+void MainWindow::projectSaved(bool successfully, const QString &name)
 {
-    core->message(tr("Project saved:") + " " + name);
+    if (successfully)
+        core->message(tr("Project saved: %1").arg(name));
+    else
+        core->message(tr("Failed to save project: %1").arg(name));
 }
 
 void MainWindow::changeDebugView()

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -167,7 +167,7 @@ private slots:
 
     void on_actionExport_as_code_triggered();
 
-    void projectSaved(const QString &name);
+    void projectSaved(bool successfully, const QString &name);
 
     void updateTasksIndicator();
 

--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -1,6 +1,7 @@
 #include "Configuration.h"
 #include <QJsonObject>
 #include <QJsonArray>
+#include <QDir>
 #include <QFontDatabase>
 #include <QFile>
 #include <QApplication>
@@ -73,12 +74,12 @@ QString Configuration::getDirProjects()
         setDirProjects(projectsDir);
     }
 
-    return projectsDir;
+    return QDir::toNativeSeparators(projectsDir);
 }
 
 void Configuration::setDirProjects(const QString &dir)
 {
-    s.setValue("dir.projects", dir);
+    s.setValue("dir.projects", QDir::toNativeSeparators(dir));
 }
 
 /**

--- a/src/dialogs/InitialOptionsDialog.cpp
+++ b/src/dialogs/InitialOptionsDialog.cpp
@@ -386,7 +386,7 @@ void InitialOptionsDialog::on_pdbSelectButton_clicked()
         return;
     }
 
-    QString fileName = dialog.selectedFiles().first();
+    const QString &fileName = QDir::toNativeSeparators(dialog.selectedFiles().first());
 
     if (!fileName.isEmpty()) {
         ui->pdbLineEdit->setText(fileName);
@@ -409,7 +409,7 @@ void InitialOptionsDialog::on_scriptSelectButton_clicked()
         return;
     }
 
-    QString fileName = dialog.selectedFiles().first();
+    const QString &fileName = QDir::toNativeSeparators(dialog.selectedFiles().first());
 
     if (!fileName.isEmpty()) {
         ui->scriptLineEdit->setText(fileName);

--- a/src/dialogs/OpenFileDialog.cpp
+++ b/src/dialogs/OpenFileDialog.cpp
@@ -23,10 +23,10 @@ void OpenFileDialog::on_selectFileButton_clicked()
 
 void OpenFileDialog::on_buttonBox_accepted()
 {
-    QString filePath = ui->filenameLineEdit->text();
+    const QString &filePath = QDir::toNativeSeparators(ui->filenameLineEdit->text());
     RVA mapAddress = RVA_INVALID;
     QString mapAddressStr = ui->mapAddressLineEdit->text();
-    if (mapAddressStr.length()) {
+    if (!mapAddressStr.isEmpty()) {
         mapAddress = Core()->math(mapAddressStr);
     }
     Core()->openFile(filePath, mapAddress);

--- a/src/dialogs/SaveProjectDialog.cpp
+++ b/src/dialogs/SaveProjectDialog.cpp
@@ -38,22 +38,15 @@ SaveProjectDialog::~SaveProjectDialog()
 
 void SaveProjectDialog::on_selectProjectsDirButton_clicked()
 {
-    QFileDialog dialog(this);
-    dialog.setFileMode(QFileDialog::DirectoryOnly);
-
     QString currentDir = ui->projectsDirEdit->text();
     if (currentDir.startsWith("~")) {
         currentDir = QDir::homePath() + currentDir.mid(1);
     }
-    dialog.setDirectory(currentDir);
 
-    dialog.setWindowTitle(tr("Select project path (dir.projects)"));
+    const QString& dir = QDir::toNativeSeparators(QFileDialog::getExistingDirectory(this,
+        tr("Select project path (dir.projects)"),
+        currentDir));
 
-    if (!dialog.exec()) {
-        return;
-    }
-
-    QString dir = dialog.selectedFiles().first();
     if (!dir.isEmpty()) {
         ui->projectsDirEdit->setText(dir);
     }


### PR DESCRIPTION
Wrong path separators have been used. The fix makes them consistent and correspond the Operating System.

If the issue opener confirms that the issue has fixed on the AppVeyor build, we can close it.