### PR TITLE
[WIP] Allow multi selection of entries in QTreeView widgets

### DIFF
--- a/src/Cutter.pro
+++ b/src/Cutter.pro
@@ -209,7 +209,8 @@ SOURCES += \
     dialogs/SetFunctionVarTypes.cpp \
     widgets/ColorSchemePrefWidget.cpp \
     common/ColorSchemeFileSaver.cpp \
-    dialogs/EditFunctionDialog.cpp
+    dialogs/EditFunctionDialog.cpp \
+    widgets/CutterTreeView.cpp
 
 HEADERS  += \
     Cutter.h \
@@ -310,7 +311,8 @@ HEADERS  += \
     dialogs/SetFunctionVarTypes.h \
     common/ColorSchemeFileSaver.h \
     widgets/ColorSchemePrefWidget.h \
-    dialogs/EditFunctionDialog.h 
+    dialogs/EditFunctionDialog.h \
+    widgets/CutterTreeView.h
 
 FORMS    += \
     dialogs/AboutDialog.ui \
@@ -367,7 +369,8 @@ FORMS    += \
     widgets/RegisterRefsWidget.ui \
     dialogs/SetToDataDialog.ui \
     dialogs/SetFunctionVarTypes.ui \
-    widgets/ColorSchemePrefWidget.ui
+    widgets/ColorSchemePrefWidget.ui \
+    widgets/CutterTreeView.ui
 
 RESOURCES += \
     resources.qrc \

--- a/src/widgets/BreakpointWidget.ui
+++ b/src/widgets/BreakpointWidget.ui
@@ -28,9 +28,9 @@
      <number>0</number>
     </property>
     <item>
-     <widget class="QTreeView" name="breakpointTreeView">
+     <widget class="CutterTreeView" name="breakpointTreeView">
       <property name="styleSheet">
-       <string notr="true">QTreeView::item
+       <string notr="true">CutterTreeView::item
 {
     padding-top: 1px;
     padding-bottom: 1px;
@@ -78,6 +78,14 @@
    </layout>
   </widget>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>CutterTreeView</class>
+   <extends>QTreeView</extends>
+   <header>widgets/CutterTreeView.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/widgets/ClassesWidget.ui
+++ b/src/widgets/ClassesWidget.ui
@@ -31,9 +31,9 @@
      <number>0</number>
     </property>
     <item>
-     <widget class="QTreeView" name="classesTreeView">
+     <widget class="CutterTreeView" name="classesTreeView">
       <property name="styleSheet">
-       <string notr="true">QTreeView::item
+       <string notr="true">CutterTreeView::item
 {
     padding-top: 1px;
     padding-bottom: 1px;
@@ -105,6 +105,14 @@
    </layout>
   </widget>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>CutterTreeView</class>
+   <extends>QTreeView</extends>
+   <header>widgets/CutterTreeView.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/widgets/CommentsWidget.ui
+++ b/src/widgets/CommentsWidget.ui
@@ -31,7 +31,7 @@
      <number>0</number>
     </property>
     <item>
-     <widget class="QTreeView" name="commentsTreeView">
+     <widget class="CutterTreeView" name="commentsTreeView">
       <property name="sortingEnabled">
        <bool>true</bool>
       </property>
@@ -69,6 +69,12 @@
   </action>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>CutterTreeView</class>
+   <extends>QTreeView</extends>
+   <header>widgets/CutterTreeView.h</header>
+   <container>1</container>
+  </customwidget>
   <customwidget>
    <class>QuickFilterView</class>
    <extends>QWidget</extends>

--- a/src/widgets/CutterTreeView.cpp
+++ b/src/widgets/CutterTreeView.cpp
@@ -1,0 +1,9 @@
+#include "CutterTreeView.h"
+#include "ui_CutterTreeView.h"
+
+CutterTreeView::CutterTreeView(QWidget *parent) :
+    QWidget(parent),
+    ui(new Ui::CutterTreeView())
+{
+    ui->setupUi(this);
+}

--- a/src/widgets/CutterTreeView.cpp
+++ b/src/widgets/CutterTreeView.cpp
@@ -2,8 +2,11 @@
 #include "ui_CutterTreeView.h"
 
 CutterTreeView::CutterTreeView(QWidget *parent) :
-    QWidget(parent),
+    QTreeView(parent),
     ui(new Ui::CutterTreeView())
 {
     ui->setupUi(this);
+    this->setSelectionMode(QAbstractItemView::ExtendedSelection);
 }
+
+CutterTreeView::~CutterTreeView() {}

--- a/src/widgets/CutterTreeView.h
+++ b/src/widgets/CutterTreeView.h
@@ -2,6 +2,7 @@
 #define CUTTERTREEVIEW_H
 
 #include <memory>
+#include <QAbstractItemView>
 #include <QTreeView>
 
 namespace Ui {

--- a/src/widgets/CutterTreeView.h
+++ b/src/widgets/CutterTreeView.h
@@ -1,0 +1,23 @@
+#ifndef CUTTERTREEVIEW_H
+#define CUTTERTREEVIEW_H
+
+#include <memory>
+#include <QTreeView>
+
+namespace Ui {
+class CutterTreeView;
+}
+
+class CutterTreeView : public QTreeView
+{
+    Q_OBJECT
+
+public:
+    explicit CutterTreeView(QWidget *parent = nullptr);
+    ~CutterTreeView();
+
+private:
+    std::unique_ptr<Ui::CutterTreeView> ui;
+};
+
+#endif //CUTTERTREEVIEW_H

--- a/src/widgets/CutterTreeView.ui
+++ b/src/widgets/CutterTreeView.ui
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>CutterTreeView</class>
+</ui>

--- a/src/widgets/CutterTreeView.ui
+++ b/src/widgets/CutterTreeView.ui
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>CutterTreeView</class>
+ <widget class="QTreeView" name="CutterTreeView">
+ </widget>
 </ui>

--- a/src/widgets/Dashboard.cpp
+++ b/src/widgets/Dashboard.cpp
@@ -6,8 +6,8 @@
 #include "common/TempConfig.h"
 #include "dialogs/VersionInfoDialog.h"
 
-
 #include "MainWindow.h"
+#include "CutterTreeView.h"
 
 #include <QDebug>
 #include <QJsonArray>
@@ -19,7 +19,6 @@
 #include <QString>
 #include <QMessageBox>
 #include <QDialog>
-#include <QTreeView>
 #include <QTreeWidget>
 
 Dashboard::Dashboard(MainWindow *main, QAction *action) :
@@ -176,12 +175,12 @@ void Dashboard::updateContents()
 void Dashboard::on_certificateButton_clicked()
 {
     static QDialog *viewDialog = nullptr;
-    static QTreeView *view = nullptr;
+    static CutterTreeView *view = nullptr;
     static JsonModel *model = nullptr;
     static QString qstrCertificates;
     if (!viewDialog) {
         viewDialog = new QDialog(this);
-        view = new QTreeView(viewDialog);
+        view = new CutterTreeView(viewDialog);
         model = new JsonModel();
         QJsonDocument qjsonCertificatesDoc = Core()->getSignatureInfo();
         qstrCertificates = qjsonCertificatesDoc.toJson(QJsonDocument::Compact);

--- a/src/widgets/ExportsWidget.ui
+++ b/src/widgets/ExportsWidget.ui
@@ -28,9 +28,9 @@
      <number>0</number>
     </property>
     <item>
-     <widget class="QTreeView" name="exportsTreeView">
+     <widget class="CutterTreeView" name="exportsTreeView">
       <property name="styleSheet">
-       <string notr="true">QTreeView::item
+       <string notr="true">CutterTreeView::item
 {
     padding-top: 1px;
     padding-bottom: 1px;
@@ -57,6 +57,12 @@
   </widget>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>CutterTreeView</class>
+   <extends>QTreeView</extends>
+   <header>widgets/CutterTreeView.h</header>
+   <container>1</container>
+  </customwidget>
   <customwidget>
    <class>QuickFilterView</class>
    <extends>QWidget</extends>

--- a/src/widgets/FlagsWidget.ui
+++ b/src/widgets/FlagsWidget.ui
@@ -31,9 +31,9 @@
      <number>0</number>
     </property>
     <item>
-     <widget class="QTreeView" name="flagsTreeView">
+     <widget class="CutterTreeView" name="flagsTreeView">
       <property name="styleSheet">
-       <string notr="true">QTreeView::item
+       <string notr="true">CutterTreeView::item
 {
     padding-top: 1px;
     padding-bottom: 1px;
@@ -105,6 +105,14 @@
    </property>
   </action>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>CutterTreeView</class>
+   <extends>QTreeView</extends>
+   <header>widgets/CutterTreeView.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/widgets/FunctionsWidget.h
+++ b/src/widgets/FunctionsWidget.h
@@ -4,11 +4,11 @@
 #include <memory>
 
 #include <QSortFilterProxyModel>
-#include <QTreeView>
 
 #include "Cutter.h"
 #include "CutterDockWidget.h"
 #include "CutterTreeWidget.h"
+#include "CutterTreeView.h"
 
 class MainWindow;
 class QTreeWidgetItem;

--- a/src/widgets/FunctionsWidget.ui
+++ b/src/widgets/FunctionsWidget.ui
@@ -46,7 +46,7 @@
      <number>0</number>
     </property>
     <item>
-     <widget class="QTreeView" name="functionsTreeView">
+     <widget class="CutterTreeView" name="functionsTreeView">
       <property name="sizePolicy">
        <sizepolicy hsizetype="Ignored" vsizetype="Expanding">
         <horstretch>0</horstretch>
@@ -58,7 +58,7 @@
       </property>
       <property name="styleSheet">
        <string notr="true">
-QTreeView::item
+CutterTreeView::item
 {
    padding-top: 1px;
    padding-bottom: 1px;
@@ -128,6 +128,12 @@ QTreeView::item
   </action>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>CutterTreeView</class>
+   <extends>QTreeView</extends>
+   <header>widgets/CutterTreeView.h</header>
+   <container>1</container>
+  </customwidget>
   <customwidget>
    <class>QuickFilterView</class>
    <extends>QWidget</extends>

--- a/src/widgets/HeadersWidget.ui
+++ b/src/widgets/HeadersWidget.ui
@@ -28,9 +28,9 @@
      <number>0</number>
     </property>
     <item>
-     <widget class="QTreeView" name="headersTreeView">
+     <widget class="CutterTreeView" name="headersTreeView">
       <property name="styleSheet">
-       <string notr="true">QTreeView::item
+       <string notr="true">CutterTreeView::item
 {
     padding-top: 1px;
     padding-bottom: 1px;
@@ -53,6 +53,14 @@
    </layout>
   </widget>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>CutterTreeView</class>
+   <extends>QTreeView</extends>
+   <header>widgets/CutterTreeView.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/widgets/ImportsWidget.ui
+++ b/src/widgets/ImportsWidget.ui
@@ -28,9 +28,9 @@
      <number>0</number>
     </property>
     <item>
-     <widget class="QTreeView" name="importsTreeView">
+     <widget class="CutterTreeView" name="importsTreeView">
       <property name="styleSheet">
-       <string notr="true">QTreeView::item
+       <string notr="true">CutterTreeView::item
 {
     padding-top: 1px;
     padding-bottom: 1px;
@@ -57,6 +57,12 @@
   </widget>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>CutterTreeView</class>
+   <extends>QTreeView</extends>
+   <header>widgets/CutterTreeView.h</header>
+   <container>1</container>
+  </customwidget>
   <customwidget>
    <class>QuickFilterView</class>
    <extends>QWidget</extends>

--- a/src/widgets/MemoryMapWidget.ui
+++ b/src/widgets/MemoryMapWidget.ui
@@ -28,9 +28,9 @@
      <number>0</number>
     </property>
     <item>
-     <widget class="QTreeView" name="memoryTreeView">
+     <widget class="CutterTreeView" name="memoryTreeView">
       <property name="styleSheet">
-       <string notr="true">QTreeView::item
+       <string notr="true">CutterTreeView::item
 {
     padding-top: 1px;
     padding-bottom: 1px;
@@ -53,6 +53,14 @@
    </layout>
   </widget>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>CutterTreeView</class>
+   <extends>QTreeView</extends>
+   <header>widgets/CutterTreeView.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/widgets/RegisterRefsWidget.ui
+++ b/src/widgets/RegisterRefsWidget.ui
@@ -28,9 +28,9 @@
      <number>0</number>
     </property>
     <item>
-     <widget class="QTreeView" name="registerRefTreeView">
+     <widget class="CutterTreeView" name="registerRefTreeView">
       <property name="styleSheet">
-       <string notr="true">QTreeView::item
+       <string notr="true">CutterTreeView::item
 {
     padding-top: 1px;
     padding-bottom: 1px;
@@ -57,6 +57,12 @@
   </widget>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>CutterTreeView</class>
+   <extends>QTreeView</extends>
+   <header>widgets/CutterTreeView.h</header>
+   <container>1</container>
+  </customwidget>
   <customwidget>
    <class>QuickFilterView</class>
    <extends>QWidget</extends>

--- a/src/widgets/RelocsWidget.ui
+++ b/src/widgets/RelocsWidget.ui
@@ -28,9 +28,9 @@
      <number>0</number>
     </property>
     <item>
-     <widget class="QTreeView" name="relocsTreeView">
+     <widget class="CutterTreeView" name="relocsTreeView">
       <property name="styleSheet">
-       <string notr="true">QTreeView::item
+       <string notr="true">CutterTreeView::item
 {
     padding-top: 1px;
     padding-bottom: 1px;
@@ -54,6 +54,12 @@
   </widget>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>CutterTreeView</class>
+   <extends>QTreeView</extends>
+   <header>widgets/CutterTreeView.h</header>
+   <container>1</container>
+  </customwidget>
   <customwidget>
    <class>QuickFilterView</class>
    <extends>QWidget</extends>

--- a/src/widgets/ResourcesWidget.cpp
+++ b/src/widgets/ResourcesWidget.cpp
@@ -84,7 +84,7 @@ ResourcesWidget::ResourcesWidget(MainWindow *main, QAction *action) :
     this->setWindowTitle(tr("Resources"));
 
     // Add resources tree view
-    view = new QTreeView(this);
+    view = new CutterTreeView(this);
     view->setModel(model);
     view->show();
     this->setWidget(view);

--- a/src/widgets/ResourcesWidget.h
+++ b/src/widgets/ResourcesWidget.h
@@ -3,9 +3,9 @@
 
 #include "Cutter.h"
 #include "CutterDockWidget.h"
+#include "CutterTreeView.h"
 
 #include <QAbstractListModel>
-#include <QTreeView>
 
 class MainWindow;
 class ResourcesWidget;
@@ -37,7 +37,7 @@ class ResourcesWidget : public CutterDockWidget
 
 private:
     ResourcesModel *model;
-    QTreeView *view;
+    CutterTreeView *view;
     QList<ResourcesDescription> resources;
 
 public:

--- a/src/widgets/SearchWidget.ui
+++ b/src/widgets/SearchWidget.ui
@@ -31,9 +31,9 @@
      <number>0</number>
     </property>
     <item>
-     <widget class="QTreeView" name="searchTreeView">
+     <widget class="CutterTreeView" name="searchTreeView">
       <property name="styleSheet">
-       <string notr="true">QTreeView::item
+       <string notr="true">CutterTreeView::item
 {
     padding-top: 1px;
     padding-bottom: 1px;
@@ -116,6 +116,14 @@
    </layout>
   </widget>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>CutterTreeView</class>
+   <extends>QTreeView</extends>
+   <header>widgets/CutterTreeView.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/widgets/SectionsWidget.cpp
+++ b/src/widgets/SectionsWidget.cpp
@@ -1,7 +1,6 @@
-#include <QTreeView>
-
 #include "SectionsWidget.h"
 
+#include "CutterTreeView.h"
 #include "MainWindow.h"
 #include "QuickFilterView.h"
 #include "common/Helpers.h"
@@ -131,7 +130,7 @@ SectionsWidget::SectionsWidget(MainWindow *main, QAction *action) :
     setObjectName("SectionsWidget");
     setWindowTitle(QStringLiteral("Sections"));
 
-    sectionsTable = new QTreeView;
+    sectionsTable = new CutterTreeView;
     sectionsModel = new SectionsModel(&sections, this);
     auto proxyModel = new SectionsProxyModel(sectionsModel, this);
 

--- a/src/widgets/SectionsWidget.h
+++ b/src/widgets/SectionsWidget.h
@@ -9,7 +9,7 @@
 #include "Cutter.h"
 #include "CutterDockWidget.h"
 
-class QTreeView;
+class CutterTreeView;
 class QAbstractItemView;
 class MainWindow;
 class SectionsWidget;
@@ -63,7 +63,7 @@ private slots:
 private:
     QList<SectionDescription> sections;
     SectionsModel *sectionsModel;
-    QTreeView *sectionsTable;
+    CutterTreeView *sectionsTable;
     MainWindow *main;
     QWidget *dockWidgetContents;
     QuickFilterView *quickFilterView;

--- a/src/widgets/SegmentsWidget.cpp
+++ b/src/widgets/SegmentsWidget.cpp
@@ -1,7 +1,6 @@
-#include <QTreeView>
-
 #include "SegmentsWidget.h"
 
+#include "CutterTreeView.h"
 #include "MainWindow.h"
 #include "QuickFilterView.h"
 #include "common/Helpers.h"
@@ -127,7 +126,7 @@ SegmentsWidget::SegmentsWidget(MainWindow *main, QAction *action) :
     setObjectName("SegmentsWidget");
     setWindowTitle(QStringLiteral("Segments"));
 
-    segmentsTable = new QTreeView;
+    segmentsTable = new CutterTreeView;
     segmentsModel = new SegmentsModel(&segments, this);
     auto proxyModel = new SegmentsProxyModel(segmentsModel, this);
 

--- a/src/widgets/SegmentsWidget.h
+++ b/src/widgets/SegmentsWidget.h
@@ -7,9 +7,10 @@
 #include <QSortFilterProxyModel>
 
 #include "Cutter.h"
+#include "CutterTreeView.h"
 #include "CutterDockWidget.h"
 
-class QTreeView;
+class CutterTreeView;
 class QAbstractItemView;
 class MainWindow;
 class SegmentsWidget;
@@ -63,7 +64,7 @@ private slots:
 private:
     QList<SegmentDescription> segments;
     SegmentsModel *segmentsModel;
-    QTreeView *segmentsTable;
+    CutterTreeView *segmentsTable;
     MainWindow *main;
     QWidget *dockWidgetContents;
     QuickFilterView *quickFilterView;

--- a/src/widgets/StringsWidget.ui
+++ b/src/widgets/StringsWidget.ui
@@ -31,7 +31,7 @@
      <number>0</number>
     </property>
     <item>
-     <widget class="QTreeView" name="stringsTreeView">
+     <widget class="CutterTreeView" name="stringsTreeView">
       <property name="sizePolicy">
        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
         <horstretch>0</horstretch>
@@ -93,6 +93,12 @@
   </action>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>CutterTreeView</class>
+   <extends>QTreeView</extends>
+   <header>widgets/CutterTreeView.h</header>
+   <container>1</container>
+  </customwidget>
   <customwidget>
    <class>QuickFilterView</class>
    <extends>QWidget</extends>

--- a/src/widgets/SymbolsWidget.ui
+++ b/src/widgets/SymbolsWidget.ui
@@ -28,7 +28,7 @@
      <number>0</number>
     </property>
     <item>
-     <widget class="QTreeView" name="symbolsTreeView">
+     <widget class="CutterTreeView" name="symbolsTreeView">
       <property name="sortingEnabled">
        <bool>true</bool>
       </property>
@@ -44,6 +44,12 @@
   </widget>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>CutterTreeView</class>
+   <extends>QTreeView</extends>
+   <header>widgets/CutterTreeView.h</header>
+   <container>1</container>
+  </customwidget>
   <customwidget>
    <class>QuickFilterView</class>
    <extends>QWidget</extends>

--- a/src/widgets/TypesWidget.ui
+++ b/src/widgets/TypesWidget.ui
@@ -28,9 +28,9 @@
      <number>0</number>
     </property>
     <item>
-     <widget class="QTreeView" name="typesTreeView">
+     <widget class="CutterTreeView" name="typesTreeView">
       <property name="styleSheet">
-       <string notr="true">QTreeView::item
+       <string notr="true">CutterTreeView::item
 {
     padding-top: 1px;
     padding-bottom: 1px;
@@ -53,6 +53,14 @@
    </layout>
   </widget>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>CutterTreeView</class>
+   <extends>QTreeView</extends>
+   <header>widgets/CutterTreeView.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/widgets/VTablesWidget.ui
+++ b/src/widgets/VTablesWidget.ui
@@ -38,7 +38,7 @@
      <number>0</number>
     </property>
     <item>
-     <widget class="QTreeView" name="vTableTreeView">
+     <widget class="CutterTreeView" name="vTableTreeView">
       <property name="sizePolicy">
        <sizepolicy hsizetype="Ignored" vsizetype="Expanding">
         <horstretch>0</horstretch>
@@ -50,7 +50,7 @@
       </property>
       <property name="styleSheet">
        <string notr="true">
-QTreeView::item
+CutterTreeView::item
 {
    padding-top: 1px;
    padding-bottom: 1px;
@@ -81,6 +81,12 @@ QTreeView::item
   </widget>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>CutterTreeView</class>
+   <extends>QTreeView</extends>
+   <header>widgets/CutterTreeView.h</header>
+   <container>1</container>
+  </customwidget>
   <customwidget>
    <class>QuickFilterView</class>
    <extends>QWidget</extends>

--- a/src/widgets/ZignaturesWidget.ui
+++ b/src/widgets/ZignaturesWidget.ui
@@ -28,9 +28,9 @@
      <number>0</number>
     </property>
     <item>
-     <widget class="QTreeView" name="zignaturesTreeView">
+     <widget class="CutterTreeView" name="zignaturesTreeView">
       <property name="styleSheet">
-       <string notr="true">QTreeView::item
+       <string notr="true">CutterTreeView::item
 {
     padding-top: 1px;
     padding-bottom: 1px;
@@ -65,6 +65,14 @@
    </layout>
   </widget>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>CutterTreeView</class>
+   <extends>QTreeView</extends>
+   <header>widgets/CutterTreeView.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
Refers to #766. So far, I'm trying to subclass `QTreeView` and create a version in which
```
this->setSelectionMode(QAbstractItemView::ExtendedSelection);
```
is called in initialization.

Currently, only the `QTreeView` in `FunctionsWidget` is changed to the subclass `CutterTreeView`. The linker fails with:
```
[100%] Linking CXX executable Cutter
/usr/bin/ld: CMakeFiles/Cutter.dir/widgets/FunctionsWidget.cpp.o: in function `Ui_FunctionsWidget::setupUi(QDockWidget*)':
FunctionsWidget.cpp:(.text._ZN18Ui_FunctionsWidget7setupUiEP11QDockWidget[_ZN18Ui_FunctionsWidget7setupUiEP11QDockWidget]+0x674): undefined reference to `CutterTreeView::CutterTreeView(QWidget*)'
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/Cutter.dir/build.make:1677: Cutter] Error 1
make[1]: *** [CMakeFiles/Makefile2:73: CMakeFiles/Cutter.dir/all] Error 2
make: *** [Makefile:84: all] Error 2
```

Open to any suggestions and redirections: perhaps I'm just going against QT's way of working.
