### PR TITLE
Minimize the graph and makes it easy to move around.

### DIFF
--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -69,6 +69,7 @@ DisassemblerGraphView::DisassemblerGraphView(QWidget *parent)
     shortcut_zoom_reset->setContext(Qt::WidgetShortcut);
     connect(shortcut_zoom_reset, SIGNAL(activated()), this, SLOT(zoomReset()));
 
+    // Graph Overview shortcut
     QShortcut *shortcut_change_layout = new QShortcut(QKeySequence(Qt::Key_P), this);
     shortcut_change_layout->setContext(Qt::WidgetShortcut);
     connect(shortcut_change_layout, SIGNAL(activated()), this, SLOT(changeLayoutType()));
@@ -99,12 +100,11 @@ DisassemblerGraphView::DisassemblerGraphView(QWidget *parent)
     shortcuts.append(shortcut_zoom_in);
     shortcuts.append(shortcut_zoom_out);
     shortcuts.append(shortcut_zoom_reset);
+    shortcuts.append(shortcut_change_layout);
     shortcuts.append(shortcut_next_instr);
     shortcuts.append(shortcut_prev_instr);
     shortcuts.append(shortcut_next_instr_arrow);
     shortcuts.append(shortcut_prev_instr_arrow);
-
-    shortcuts.append(shortcut_change_layout);
 
     //Export Graph menu
     mMenu->addSeparator();
@@ -159,31 +159,23 @@ void DisassemblerGraphView::changeLayoutType()
 {
     switch (layoutType) {
         case LayoutType::Medium:
-            {
-                layoutType = LayoutType::Narrow;
-                prev_scale = current_scale;
-                current_scale = 0.3;
-                refreshView();
-                DisassemblyBlock *db = blockForAddress(Core()->getOffset());
-                transition_dont_seek = true;
-                showBlock(&blocks[db->entry], true);
-                prepareHeader();
-            }
+            layoutType = LayoutType::Narrow;
+            prev_scale = current_scale;
+            current_scale = 0.3;
             break;
         case LayoutType::Narrow:
-            {
-                layoutType = LayoutType::Medium;
-                current_scale = prev_scale;
-                refreshView();
-                DisassemblyBlock *db = blockForAddress(Core()->getOffset());
-                transition_dont_seek = true;
-                showBlock(&blocks[db->entry], true);
-                prepareHeader();
-            }
+            layoutType = LayoutType::Medium;
+            current_scale = prev_scale;
             break;
         default:
+            msgBox.showMessage("DisassemblerGraphView::changeLayoutType: Illegal LayoutType");
             break;
     }
+    refreshView();
+    DisassemblyBlock *db = blockForAddress(Core()->getOffset());
+    transition_dont_seek = true;
+    showBlock(&blocks[db->entry], true);
+    prepareHeader();
 }
 
 void DisassemblerGraphView::refreshView()

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -921,13 +921,22 @@ void DisassemblerGraphView::blockDoubleClicked(GraphView::GraphBlock &block, QMo
 void DisassemblerGraphView::blockHelpEvent(GraphView::GraphBlock &block, QHelpEvent *event,
                                            QPoint pos)
 {
+    if (layoutType == LayoutType::Narrow) {
+        QString s = QString();
+        DisassemblyBlock &db = disassembly_blocks[block.entry];
+        for (Instr &instr : db.instrs) {
+            s += instr.text.ToQString();
+            s += '\n';
+        }
+        QToolTip::showText(event->globalPos(), s);
+        return;
+    }
     Instr *instr = getInstrForMouseEvent(block, &pos);
     if (!instr || instr->fullText.lines.empty()) {
         QToolTip::hideText();
         event->ignore();
         return;
     }
-
     QToolTip::showText(event->globalPos(), instr->fullText.ToQString());
 }
 

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -59,13 +59,13 @@ DisassemblerGraphView::DisassemblerGraphView(QWidget *parent)
     connect(shortcut_escape, SIGNAL(activated()), this, SLOT(seekPrev()));
 
     // Zoom shortcuts
-    QShortcut *shortcut_zoom_in = new QShortcut(QKeySequence(Qt::Key_Plus), this);
+    shortcut_zoom_in = new QShortcut(QKeySequence(Qt::Key_Plus), this);
     shortcut_zoom_in->setContext(Qt::WidgetShortcut);
     connect(shortcut_zoom_in, SIGNAL(activated()), this, SLOT(zoomIn()));
-    QShortcut *shortcut_zoom_out = new QShortcut(QKeySequence(Qt::Key_Minus), this);
+    shortcut_zoom_out = new QShortcut(QKeySequence(Qt::Key_Minus), this);
     shortcut_zoom_out->setContext(Qt::WidgetShortcut);
     connect(shortcut_zoom_out, SIGNAL(activated()), this, SLOT(zoomOut()));
-    QShortcut *shortcut_zoom_reset = new QShortcut(QKeySequence(Qt::Key_Equal), this);
+    shortcut_zoom_reset = new QShortcut(QKeySequence(Qt::Key_Equal), this);
     shortcut_zoom_reset->setContext(Qt::WidgetShortcut);
     connect(shortcut_zoom_reset, SIGNAL(activated()), this, SLOT(zoomReset()));
 
@@ -162,10 +162,16 @@ void DisassemblerGraphView::changeLayoutType()
             layoutType = LayoutType::Narrow;
             prev_scale = current_scale;
             current_scale = 0.3;
+            disconnect(shortcut_zoom_in, SIGNAL(activated()), this, SLOT(zoomIn()));
+            disconnect(shortcut_zoom_out, SIGNAL(activated()), this, SLOT(zoomOut()));
+            disconnect(shortcut_zoom_reset, SIGNAL(activated()), this, SLOT(zoomReset()));
             break;
         case LayoutType::Narrow:
             layoutType = LayoutType::Medium;
             current_scale = prev_scale;
+            connect(shortcut_zoom_in, SIGNAL(activated()), this, SLOT(zoomIn()));
+            connect(shortcut_zoom_out, SIGNAL(activated()), this, SLOT(zoomOut()));
+            connect(shortcut_zoom_reset, SIGNAL(activated()), this, SLOT(zoomReset()));
             break;
         default:
             msgBox.showMessage("DisassemblerGraphView::changeLayoutType: Illegal LayoutType");

--- a/src/widgets/DisassemblerGraphView.h
+++ b/src/widgets/DisassemblerGraphView.h
@@ -123,6 +123,7 @@ public:
                                                            GraphView::GraphBlock *to) override;
     virtual void blockTransitionedTo(GraphView::GraphBlock *to) override;
 
+
     void loadCurrentGraph();
     QString windowTitle;
     bool isGraphEmpty();
@@ -145,8 +146,13 @@ public slots:
     void nextInstr();
     void prevInstr();
 
+
+protected slots:
+    virtual void changeLayoutType() override;
+
 protected:
     virtual void wheelEvent(QWheelEvent *event) override;
+
 
 private slots:
     void seekPrev();

--- a/src/widgets/DisassemblerGraphView.h
+++ b/src/widgets/DisassemblerGraphView.h
@@ -7,6 +7,7 @@
 #include <QPainter>
 #include <QShortcut>
 #include <QLabel>
+#include <QErrorMessage>
 
 #include "widgets/GraphView.h"
 #include "menus/DisassemblyContextMenu.h"
@@ -218,6 +219,8 @@ private:
 
     QLabel *emptyText = nullptr;
     SyntaxHighlighter *highlighter = nullptr;
+
+    QErrorMessage msgBox;
 };
 
 #endif // DISASSEMBLERGRAPHVIEW_H

--- a/src/widgets/DisassemblerGraphView.h
+++ b/src/widgets/DisassemblerGraphView.h
@@ -187,6 +187,9 @@ private:
     void seekLocal(RVA addr, bool update_viewport = true);
     void seekInstruction(bool previous_instr);
     CutterSeekableWidget *seekable = nullptr;
+    QShortcut *shortcut_zoom_in;
+    QShortcut *shortcut_zoom_out;
+    QShortcut *shortcut_zoom_reset;
     QList<QShortcut *> shortcuts;
     QList<RVA> breakpoints;
 

--- a/src/widgets/GraphView.cpp
+++ b/src/widgets/GraphView.cpp
@@ -916,3 +916,7 @@ void GraphView::wheelEvent(QWheelEvent *event)
     verticalScrollBar()->setValue(verticalScrollBar()->value() + y_delta * (1 / current_scale));
     event->accept();
 }
+
+void GraphView::changeLayoutType()
+{
+}

--- a/src/widgets/GraphView.h
+++ b/src/widgets/GraphView.h
@@ -24,7 +24,6 @@ public:
         Medium,
         Wide,
         Narrow,
-        Count
     };
 
     struct GraphBlock;

--- a/src/widgets/GraphView.h
+++ b/src/widgets/GraphView.h
@@ -19,12 +19,14 @@ class GraphView : public QAbstractScrollArea
 {
     Q_OBJECT
 
+public:
     enum class LayoutType {
         Medium,
         Wide,
         Narrow,
+        Count
     };
-public:
+
     struct GraphBlock;
 
     struct Point {
@@ -94,6 +96,9 @@ public:
     void showBlock(GraphBlock &block, bool animated = false);
     void showBlock(GraphBlock *block, bool animated = false);
 
+protected slots:
+    virtual void changeLayoutType();
+
 protected:
     std::unordered_map<ut64, GraphBlock> blocks;
     QColor backgroundColor = QColor(Qt::white);
@@ -106,6 +111,7 @@ protected:
 
     // Zoom data
     double current_scale = 1.0;
+    double prev_scale = 1.0;
 
     int unscrolled_render_offset_x = 0;
     int unscrolled_render_offset_y = 0;
@@ -127,6 +133,9 @@ protected:
     void adjustSize(int new_width, int new_height, QPoint mouse = QPoint(0, 0));
 
     bool event(QEvent *event) override;
+
+    // Layout type
+    LayoutType layoutType = LayoutType::Medium;
 private:
     bool checkPointClicked(QPointF &point, int x, int y, bool above_y = false);
 
@@ -135,8 +144,6 @@ private:
     void computeGraphLayout(GraphBlock &block);
     void adjustGraphLayout(GraphBlock &block, int col, int row);
 
-    // Layout type
-    LayoutType layoutType = LayoutType::Medium;
 
     int width = 0;
     int height = 0;


### PR DESCRIPTION
Press 'p' and minigraph will be activated.
You can see the whole map of the graph.
You can also 
![gifrecord_2018-11-16_111125](https://user-images.githubusercontent.com/29271244/48598708-8d0c3d80-e9a7-11e8-8bf5-295023cf94e0.gif)
hover the mouse to see what's in each graph block.
Click one of the graph and you'll be back to the normal mode with the graph focused.
