### PR TITLE
Fix build error in MacOS with clang

### DIFF
--- a/src/Cutter.cpp
+++ b/src/Cutter.cpp
@@ -111,7 +111,7 @@ QList<QString> CutterCore::sdbListKeys(QString path)
         SdbList *l = sdb_foreach_list(root, false);
         ls_foreach(l, iter, vsi) {
             SdbKv *nsi = (SdbKv *)vsi;
-            list << nsi->base.key;
+            list << reinterpret_cast<char *>(nsi->base.key);
         }
     }
     return list;


### PR DESCRIPTION
https://github.com/radare/radare2/blob/master/shlr/sdb/src/sdbht.h#L14

```
clang++  -v
Apple LLVM version 10.0.0 (clang-1000.10.44.4)
Target: x86_64-apple-darwin18.2.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```

```
make
/Library/Developer/CommandLineTools/usr/bin/clang++ -c -mmacosx-version-min=10.7 -std=gnu0x -stdlib=libc++ -O2 -std=gnu++11  -arch x86_64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk -mmacosx-version-min=10.11 -Wall -W -fPIC -DCUTTER_ENABLE_JUPYTER -D_CRT_NONSTDC_NO_DEPRECATE -D_CRT_SECURE_NO_WARNINGS -DQT_NO_DEBUG -DQT_SVG_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -I../src -I. -I../src -I../../local/include/libr -I/usr/local/include/libr -I/usr/local/include/libr -I/usr/local/opt/python/Frameworks/Python.framework/Versions/3.7/include/python3.7m -I/usr/local/Cellar/qt/5.11.2/lib/QtSvg.framework/Headers -I/usr/local/Cellar/qt/5.11.2/lib/QtWidgets.framework/Headers -I/usr/local/Cellar/qt/5.11.2/lib/QtGui.framework/Headers -I/usr/local/Cellar/qt/5.11.2/lib/QtNetwork.framework/Headers -I/usr/local/Cellar/qt/5.11.2/lib/QtCore.framework/Headers -I. -I/Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk/System/Library/Frameworks/OpenGL.framework/Headers -I/Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk/System/Library/Frameworks/AGL.framework/Headers -I. -I/usr/local/Cellar/qt/5.11.2/mkspecs/macx-clang -F/usr/local/Cellar/qt/5.11.2/lib -o Cutter.o ../src/Cutter.cpp
../src/Cutter.cpp:114:18: error: invalid operands to binary expression ('QList<QString>' and 'void *')
            list << nsi->base.key;
            ~~~~ ^  ~~~~~~~~~~~~~
/usr/local/Cellar/qt/5.11.2/lib/QtCore.framework/Headers/qdebug.h:372:1: note: candidate function not viable: no known conversion from 'QList<QString>' to 'QDebug' for 1st argument
operator<<(QDebug dbg, T value)
^
/usr/local/Cellar/qt/5.11.2/lib/QtCore.framework/Headers/qjsonvalue.h:250:22: note: candidate function not viable: no known conversion from 'QList<QString>' to 'QDebug' for 1st argument
Q_CORE_EXPORT QDebug operator<<(QDebug, const QJsonValue &);
                     ^
/usr/local/Cellar/qt/5.11.2/lib/QtCore.framework/Headers/qlist.h:385:22: note: candidate function not viable: cannot convert argument of incomplete type 'void *' to 'const QString' for 1st argument
    inline QList<T> &operator<< (const T &t)
                     ^
/usr/local/Cellar/qt/5.11.2/lib/QtCore.framework/Headers/qlist.h:387:22: note: candidate function not viable: cannot convert argument of incomplete type 'void *' to 'const QList<QString>' for 1st argument
    inline QList<T> &operator<<(const QList<T> &l)
                     ^
/usr/local/Cellar/qt/5.11.2/lib/QtCore.framework/Headers/qvariant.h:563:28: note: candidate function not viable: no known conversion from 'QList<QString>' to 'QDataStream &' for 1st argument
Q_CORE_EXPORT QDataStream& operator<< (QDataStream& s, const QVariant& p);
                           ^
/usr/local/Cellar/qt/5.11.2/lib/QtCore.framework/Headers/qvariant.h:881:22: note: candidate function not viable: no known conversion from 'QList<QString>' to 'QDebug' for 1st argument
Q_CORE_EXPORT QDebug operator<<(QDebug, const QVariant &);
                     ^
/usr/local/Cellar/qt/5.11.2/lib/QtGui.framework/Headers/qmatrix.h:184:27: note: candidate function not viable: no known conversion from 'QList<QString>' to 'QDataStream &' for 1st argument
Q_GUI_EXPORT QDataStream &operator<<(QDataStream &, const QMatrix &);
                          ^
...
/usr/local/Cellar/qt/5.11.2/lib/QtCore.framework/Headers/qdatastream.h:405:21: note: candidate template ignored: could not match 'QVector<type-parameter-0-0>' against 'void *'
inline QDataStream &operator<<(QDataStream &s, const QVector<T> &v)
                    ^
/usr/local/Cellar/qt/5.11.2/lib/QtCore.framework/Headers/qdatastream.h:417:21: note: candidate template ignored: could not match 'QSet<type-parameter-0-0>' against 'void *'
inline QDataStream &operator<<(QDataStream &s, const QSet<T> &set)
                    ^
/usr/local/Cellar/qt/5.11.2/lib/QtCore.framework/Headers/qdatastream.h:429:21: note: candidate template ignored: could not match 'QHash<type-parameter-0-0, type-parameter-0-1>' against 'void *'
inline QDataStream &operator<<(QDataStream &s, const QHash<Key, T> &hash)
                    ^
/usr/local/Cellar/qt/5.11.2/lib/QtCore.framework/Headers/qdatastream.h:441:21: note: candidate template ignored: could not match 'QMap<type-parameter-0-0, type-parameter-0-1>' against 'void *'
inline QDataStream &operator<<(QDataStream &s, const QMap<Key, T> &map)
                    ^
/usr/local/Cellar/qt/5.11.2/lib/QtCore.framework/Headers/qdatastream.h:455:21: note: candidate template ignored: could not match 'QPair<type-parameter-0-0, type-parameter-0-1>' against 'void *'
inline QDataStream& operator<<(QDataStream& s, const QPair<T1, T2>& p)
                    ^
1 error generated.
make: *** [Cutter.o] Error 1
```