### PR TITLE
Fixes #950

### DIFF
--- a/src/widgets/CutterSeekableWidget.cpp
+++ b/src/widgets/CutterSeekableWidget.cpp
@@ -1,7 +1,6 @@
 #include "MainWindow.h"
 #include "CutterSeekableWidget.h"
 
-const QString CutterSeekableWidget::UNSYNCED_TEXT = tr(" (unsynced)");
 
 CutterSeekableWidget::CutterSeekableWidget(QObject *parent)
     :

--- a/src/widgets/CutterSeekableWidget.h
+++ b/src/widgets/CutterSeekableWidget.h
@@ -20,8 +20,6 @@ public:
     void setIndependentOffset(RVA addr);
     void onSeekChanged(RVA addr);
 
-    static const QString UNSYNCED_TEXT;
-
 private:
     RVA independentOffset = RVA_INVALID;
     RVA prevIdenpendentOffset = RVA_INVALID;

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -144,7 +144,7 @@ void DisassemblerGraphView::toggleSync()
     if (seekable->getSyncWithCore()) {
         parentWidget()->setWindowTitle(windowTitle);
     } else {
-        parentWidget()->setWindowTitle(windowTitle + CutterSeekableWidget::UNSYNCED_TEXT);
+        parentWidget()->setWindowTitle(windowTitle + CutterSeekableWidget::tr(" (unsynced)"));
         seekable->setIndependentOffset(Core()->getOffset());
     }
 }
@@ -210,7 +210,7 @@ void DisassemblerGraphView::loadCurrentGraph()
         windowTitle += " (" + funcName + ")";
     }
     if (!seekable->getSyncWithCore()) {
-        parentWidget()->setWindowTitle(windowTitle + CutterSeekableWidget::UNSYNCED_TEXT);
+        parentWidget()->setWindowTitle(windowTitle + CutterSeekableWidget::tr(" (unsynced)"));
     } else {
         parentWidget()->setWindowTitle(windowTitle);
     }

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -184,7 +184,7 @@ void DisassemblyWidget::toggleSync()
     if (seekable->getSyncWithCore()) {
         setWindowTitle(windowTitle);
     } else {
-        setWindowTitle(windowTitle + CutterSeekableWidget::UNSYNCED_TEXT);
+        setWindowTitle(windowTitle + CutterSeekableWidget::tr(" (unsynced)"));
         seekable->setIndependentOffset(Core()->getOffset());
     }
 }

--- a/src/widgets/HexdumpWidget.cpp
+++ b/src/widgets/HexdumpWidget.cpp
@@ -643,7 +643,7 @@ void HexdumpWidget::toggleSync()
     if (seekable->getSyncWithCore()) {
         setWindowTitle(windowTitle);
     } else {
-        setWindowTitle(windowTitle + CutterSeekableWidget::UNSYNCED_TEXT);
+        setWindowTitle(windowTitle + CutterSeekableWidget::tr(" (unsynced)"));
         seekable->setIndependentOffset(Core()->getOffset());
     }
 }


### PR DESCRIPTION
`tr` evaluates at the early start even before `QCoreApplication` is instantiated and appropriate translators are set
related with commit a92fc9b

Closes #950
