### PR TITLE
Fix PE-Bear like sub-dock in the Section Widget

### DIFF
--- a/src/widgets/SectionsWidget.cpp
+++ b/src/widgets/SectionsWidget.cpp
@@ -3,6 +3,7 @@
 #include <QVBoxLayout>
 #include <QHBoxLayout>
 
+#include "common/Configuration.h"
 #include "SectionsWidget.h"
 #include "CutterTreeView.h"
 #include "MainWindow.h"
@@ -196,6 +197,7 @@ SectionsWidget::SectionsWidget(MainWindow *main, QAction *action) :
         }
     });
     connect(Core(), SIGNAL(seekChanged(RVA)), this, SLOT(onSectionsSeekChanged(RVA)));
+    connect(Config(), SIGNAL(colorsUpdated()), this, SLOT(refreshSections()));
 
     indicatorWidth = 600;
     indicatorHeight = 5;
@@ -272,16 +274,16 @@ void SectionsWidget::updateIndicator(SectionAddrDock *targetDock, QString name, 
 
 SectionAddrDock::SectionAddrDock(SectionsModel *model, AddrType type, QWidget *parent) :
     QDockWidget(parent),
-    header(new QLabel),
     graphicsScene(new QGraphicsScene),
     graphicsView(new QGraphicsView)
 {
+    setStyleSheet(QString("color:%1;").arg(ConfigColor("gui.dataoffset").name()));
     switch (type) {
         case SectionAddrDock::Raw:
-            header->setText(tr("Raw"));
+            setWindowTitle(tr("Raw"));
             break;
         case SectionAddrDock::Virtual:
-            header->setText(tr("Virtual"));
+            setWindowTitle(tr("Virtual"));
             break;
         default:
             return;
@@ -295,7 +297,6 @@ SectionAddrDock::SectionAddrDock(SectionsModel *model, AddrType type, QWidget *p
 
     QWidget *w = new QWidget();
     QVBoxLayout *layout = new QVBoxLayout();
-    layout->addWidget(header);
     layout->addWidget(graphicsView);
     w->setLayout(layout);
     setWidget(w);
@@ -304,6 +305,10 @@ SectionAddrDock::SectionAddrDock(SectionsModel *model, AddrType type, QWidget *p
     rectOffset = 100;
     rectWidth = 400;
     indicatorColor = ConfigColor("gui.navbar.err");
+
+    connect(this, &QDockWidget::featuresChanged, this, [ = ](){
+        setFeatures(QDockWidget::DockWidgetClosable);
+    });
 }
 
 void SectionAddrDock::updateDock()
@@ -312,7 +317,7 @@ void SectionAddrDock::updateDock()
 
     graphicsScene->clear();
 
-    header->setStyleSheet(QString("color:%1;").arg(ConfigColor("gui.dataoffset").name()));
+    setStyleSheet(QString("color:%1;").arg(ConfigColor("gui.dataoffset").name()));
     const QBrush bg = QBrush(ConfigColor("gui.background"));
     graphicsScene->setBackgroundBrush(bg);
 

--- a/src/widgets/SectionsWidget.h
+++ b/src/widgets/SectionsWidget.h
@@ -98,7 +98,6 @@ public:
     int rectWidth;
     QColor indicatorColor;
     explicit SectionAddrDock(SectionsModel *model, AddrType type, QWidget *parent = nullptr);
-    QLabel *header;
     QGraphicsScene *graphicsScene;
     SectionsProxyModel *proxyModel;
     AddrType addrType;


### PR DESCRIPTION
Refer to https://github.com/radareorg/cutter/commit/54ea5f014e555c0bc9f65f7ecfa4306510ab96a1

![gifrecord_2018-11-22_165013](https://user-images.githubusercontent.com/29271244/48888793-21c6dd80-ee77-11e8-820a-a70aeaa454e4.gif)

1. "Unlock Panels" setting affects the feature of PE-bear like sub-dock of the Section Widget too, but we want it to be closable all the time. Now it is.
2. The color of the PE-bear like sub-dock should be under the effect of the setting of the theme, but it wasn't. Now it is.
3. The title of the PE-bear like widget wasted some space, but now it does not.

Check the gif. 