### PR TITLE
Centerize the indicator in the address maps in the Section Widget when seek changed.

### DIFF
--- a/src/widgets/SectionsWidget.cpp
+++ b/src/widgets/SectionsWidget.cpp
@@ -267,6 +267,7 @@ void SectionsWidget::updateIndicator(SectionAddrDock *targetDock, QString name, 
     QGraphicsRectItem *indicator = new QGraphicsRectItem(QRectF(0, y, indicatorWidth, indicatorHeight));
     indicator->setBrush(QBrush(color));
     targetDock->graphicsScene->addItem(indicator);
+    targetDock->graphicsView->centerOn(indicator);
 
     targetDock->addTextItem(color, QPoint(targetDock->rectOffset + targetDock->rectWidth, y - indicatorParamPosY), name);
     targetDock->addTextItem(color, QPoint(0, y - indicatorParamPosY), QString("0x%1").arg(offset, 0, 16));

--- a/src/widgets/SectionsWidget.h
+++ b/src/widgets/SectionsWidget.h
@@ -91,7 +91,13 @@ class SectionAddrDock : public QDockWidget
 {
     Q_OBJECT
 
-public:
+    friend SectionsWidget;
+
+private slots:
+    void updateDock();
+    void addTextItem(QColor color, QPoint pos, QString string);
+
+private:
     enum AddrType { Raw = 0, Virtual };
     int heightThreshold;
     int rectOffset;
@@ -99,17 +105,11 @@ public:
     QColor indicatorColor;
     explicit SectionAddrDock(SectionsModel *model, AddrType type, QWidget *parent = nullptr);
     QGraphicsScene *graphicsScene;
+    QGraphicsView *graphicsView;
     SectionsProxyModel *proxyModel;
     AddrType addrType;
     QHash<QString, int> namePosYMap;
     QHash<QString, int> nameHeightMap;
-
-public slots:
-    void updateDock();
-    void addTextItem(QColor color, QPoint pos, QString string);
-
-private:
-    QGraphicsView *graphicsView;
 };
 
 #endif // SECTIONSWIDGET_H


### PR DESCRIPTION
Currently the indicator bar in the Section Widget's address map is not focused when the seek changed, and now it is with this PR.