### PR TITLE
MAC Build: fixed problem when you cannot open Cutter on MacOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,9 +72,7 @@ script:
 after_success:
   - export CUTTER_VERSION=$(python ../scripts/get_version.py)
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      mv Cutter.app/Contents/MacOS/Cutter Cutter.app/Contents/MacOS/Cutter.bin &&
-      cp ../src/macos/Cutter Cutter.app/Contents/MacOS/Cutter && chmod +x Cutter.app/Contents/MacOS/Cutter &&
-      macdeployqt Cutter.app -executable=Cutter.app/Contents/MacOS/Cutter &&
+      macdeployqt Cutter.app -executable=Cutter.app/Contents/MacOS/Cutter -libpath="../Frameworks" &&
       "$TRAVIS_BUILD_DIR/scripts/appbundle_embed_python.sh" "$PYTHON_FRAMEWORK_DIR/Python.framework" Cutter.app Cutter.app/Contents/MacOS/Cutter &&
       mkdir -p Cutter.app/Contents/Resources/r2/share &&
       cp -a /usr/local/share/radare2 Cutter.app/Contents/Resources/r2/share/ &&

--- a/src/macos/Cutter
+++ b/src/macos/Cutter
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-echo "Cutter Launch Script for macOS"
-
-EXECDIR=$(dirname "$0")
-export DYLD_LIBRARY_PATH="$EXECDIR/../Frameworks"
-export DYLD_FRAMEWORK_PATH="$EXECDIR/../Frameworks"
-"$EXECDIR/Cutter.bin" "$@"


### PR DESCRIPTION
 due to missing Frameworks

Solution:
* instead of use startup shell script which sets Frameworks directory as a library path `DYLD_LIBRARY_PATH` and frameworks path `DYLD_FRAMEWORK_PATH`, we use legitimate `-libpath` option of `macdeployqt` so it will take care about that.

P.S. When we have to deploy libraries/frameworks into different folders (such as radare2 plugins) we just need to adjust this option