### PR TITLE
[WIP] Some cleanup

### DIFF
--- a/src/AnalTask.cpp
+++ b/src/AnalTask.cpp
@@ -99,7 +99,7 @@ void AnalTask::runTask()
 
     if (!options.analCmd.empty()) {
         log(tr("Analyzing..."));
-        for (QString cmd : options.analCmd) {
+        for (const QString &cmd : options.analCmd) {
             if (isInterrupted()) {
                 return;
             }

--- a/src/Cutter.cpp
+++ b/src/Cutter.cpp
@@ -314,11 +314,6 @@ QJsonDocument CutterCore::parseJson(const char *res, const char *cmd)
     return doc;
 }
 
-QJsonDocument CutterCore::parseJson(const char *res, const QString &cmd)
-{
-    return parseJson(res, cmd.isNull() ? nullptr : cmd.toLocal8Bit().constData());
-}
-
 /**
  * @brief CutterCore::loadFile
  * Load initial file. TODO Maybe use the "o" commands?
@@ -772,15 +767,10 @@ void CutterCore::cmdEsil(const char *command)
     }
 }
 
-void CutterCore::cmdEsil(QString command)
-{
-    cmdEsil(command.toUtf8().constData());
-}
-
 QString CutterCore::createFunctionAt(RVA addr, QString name)
 {
-    static const QRegExp pattern("[^a-zA-Z0-9_]");
-    name.remove(pattern);
+    static const QRegExp regExp("[^a-zA-Z0-9_]");
+    name.remove(regExp);
     QString command = "af " + name + " " + RAddressString(addr);
     QString ret = cmd(command);
     emit functionsChanged();

--- a/src/Cutter.cpp
+++ b/src/Cutter.cpp
@@ -292,14 +292,14 @@ QJsonDocument CutterCore::cmdjTask(const QString &str)
 
 QJsonDocument CutterCore::parseJson(const char *res, const char *cmd)
 {
-    QString resString = QString(res);
+    QByteArray json(res);
 
-    if (resString.isEmpty()) {
+    if (json.isEmpty()) {
         return QJsonDocument();
     }
 
     QJsonParseError jsonError;
-    QJsonDocument doc = res ? QJsonDocument::fromJson(resString.toUtf8(), &jsonError) : QJsonDocument();
+    QJsonDocument doc = QJsonDocument::fromJson(json, &jsonError);
 
     if (jsonError.error != QJsonParseError::NoError) {
         if (cmd) {
@@ -308,7 +308,7 @@ QJsonDocument CutterCore::parseJson(const char *res, const char *cmd)
         } else {
             eprintf("Failed to parse JSON: %s\n", jsonError.errorString().toLocal8Bit().constData());
         }
-        eprintf("%s\n", resString.toLocal8Bit().constData());
+        eprintf("%s\n", json.constData());
     }
 
     return doc;

--- a/src/Cutter.cpp
+++ b/src/Cutter.cpp
@@ -254,16 +254,11 @@ QString CutterCore::cmd(const char *str)
     return o;
 }
 
-QString CutterCore::cmd(const QString &str)
-{
-    return cmd(str.toUtf8().constData());
-}
-
 QString CutterCore::cmdRaw(const QString &str)
 {
     QString cmdStr = str;
     cmdStr.replace('\"', QStringLiteral("\\\""));
-    return cmd("\"" + cmdStr + "\"");
+    return cmd(cmdStr.prepend('\"').append('\"'));
 }
 
 QJsonDocument CutterCore::cmdj(const char *str)
@@ -277,11 +272,6 @@ QJsonDocument CutterCore::cmdj(const char *str)
     r_mem_free(res);
 
     return doc;
-}
-
-QJsonDocument CutterCore::cmdj(const QString &str)
-{
-    return cmdj(str.toUtf8().constData());
 }
 
 QString CutterCore::cmdTask(const QString &str)
@@ -631,35 +621,34 @@ ut64 CutterCore::math(const QString &expr)
     return r_num_math(this->core_ ? this->core_->num : NULL, expr.toUtf8().constData());
 }
 
-void CutterCore::setConfig(const QString &k, const QString &v)
+void CutterCore::setConfig(const char *k, const QString &v)
 {
     CORE_LOCK();
-    r_config_set(core_->config, k.toUtf8().constData(), v.toUtf8().constData());
+    r_config_set(core_->config, k, v.toUtf8().constData());
 }
 
-void CutterCore::setConfig(const QString &k, int v)
+void CutterCore::setConfig(const char *k, int v)
 {
     CORE_LOCK();
-    r_config_set_i(core_->config, k.toUtf8().constData(), static_cast<ut64>(v));
+    r_config_set_i(core_->config, k, static_cast<ut64>(v));
 }
 
-void CutterCore::setConfig(const QString &k, bool v)
+void CutterCore::setConfig(const char *k, bool v)
 {
     CORE_LOCK();
-    r_config_set_i(core_->config, k.toUtf8().constData(), v ? 1 : 0);
+    r_config_set_i(core_->config, k, v ? 1 : 0);
 }
 
-int CutterCore::getConfigi(const QString &k)
+int CutterCore::getConfigi(const char *k)
 {
     CORE_LOCK();
-    QByteArray key = k.toUtf8();
-    return static_cast<int>(r_config_get_i(core_->config, key.constData()));
+    return static_cast<int>(r_config_get_i(core_->config, k));
 }
 
-bool CutterCore::getConfigb(const QString &k)
+bool CutterCore::getConfigb(const char *k)
 {
     CORE_LOCK();
-    return r_config_get_i(core_->config, k.toUtf8().constData()) != 0;
+    return r_config_get_i(core_->config, k) != 0;
 }
 
 void CutterCore::triggerRefreshAll()
@@ -689,14 +678,13 @@ void CutterCore::message(const QString &msg, bool debug)
     emit newMessage(msg);
 }
 
-QString CutterCore::getConfig(const QString &k)
+QString CutterCore::getConfig(const char *k)
 {
     CORE_LOCK();
-    QByteArray key = k.toUtf8();
-    return QString(r_config_get(core_->config, key.constData()));
+    return QString(r_config_get(core_->config, k));
 }
 
-void CutterCore::setConfig(const QString &k, const QVariant &v)
+void CutterCore::setConfig(const char *k, const QVariant &v)
 {
     switch (v.type()) {
     case QVariant::Type::Bool:

--- a/src/Cutter.h
+++ b/src/Cutter.h
@@ -18,7 +18,7 @@
 #include <QErrorMessage>
 
 #define CutterRListForeach(list, it, type, x) \
-    if (list) for (it = list->head; it && ((x=(type*)it->data)); it = it->n)
+    if (list) for (it = list->head; it && ((x=static_cast<type*>(it->data))); it = it->n)
 
 #define APPNAME "Cutter"
 
@@ -383,16 +383,12 @@ public:
     /* Core functions (commands) */
     static QString sanitizeStringForCommand(QString s);
     QString cmd(const char *str);
-    QString cmd(const QString &str);
+    QString cmd(const QString &str) { return cmd(str.toUtf8().constData()); }
     QString cmdRaw(const QString &str);
     QJsonDocument cmdj(const char *str);
-    QJsonDocument cmdj(const QString &str);
-    QStringList cmdList(const QString &str)
-    {
-        auto l = cmd(str).split("\n");
-        l.removeAll("");
-        return l;
-    }
+    QJsonDocument cmdj(const QString &str) { return cmdj(str.toUtf8().constData()); }
+    QStringList cmdList(const char *str) { return cmd(str).split('\n', QString::SkipEmptyParts); }
+    QStringList cmdList(const QString &str) { return cmdList(str.toUtf8().constData()); }
     QString cmdTask(const QString &str);
     QJsonDocument cmdjTask(const QString &str);
     void cmdEsil(const char *command);
@@ -475,14 +471,22 @@ public:
     ut64 math(const QString &expr);
 
     /* Config functions */
-    void setConfig(const QString &k, const QString &v);
-    void setConfig(const QString &k, int v);
-    void setConfig(const QString &k, bool v);
+    void setConfig(const char *k, const QString &v);
+    void setConfig(const QString &k, const QString &v) { setConfig(k.toUtf8().constData(), v); }
+    void setConfig(const char *k, int v);
+    void setConfig(const QString &k, int v) { setConfig(k.toUtf8().constData(), v); }
+    void setConfig(const char *k, bool v);
+    void setConfig(const QString &k, bool v) { setConfig(k.toUtf8().constData(), v); }
+    void setConfig(const char *k, const char *v) { setConfig(k, QString(v)); }
     void setConfig(const QString &k, const char *v) { setConfig(k, QString(v)); }
-    void setConfig(const QString &k, const QVariant &v);
-    int getConfigi(const QString &k);
-    bool getConfigb(const QString &k);
-    QString getConfig(const QString &k);
+    void setConfig(const char *k, const QVariant &v);
+    void setConfig(const QString &k, const QVariant &v) { setConfig(k.toUtf8().constData(), v); }
+    int getConfigi(const char *k);
+    int getConfigi(const QString &k) { return getConfigi(k.toUtf8().constData()); }
+    bool getConfigb(const char *k);
+    bool getConfigb(const QString &k) { return getConfigb(k.toUtf8().constData()); }
+    QString getConfig(const char *k);
+    QString getConfig(const QString &k) { return getConfig(k.toUtf8().constData()); }
     QList<QString> getColorThemes();
 
     /* Assembly related methods */

--- a/src/Cutter.h
+++ b/src/Cutter.h
@@ -392,7 +392,7 @@ public:
     QString cmdTask(const QString &str);
     QJsonDocument cmdjTask(const QString &str);
     void cmdEsil(const char *command);
-    void cmdEsil(QString command) { cmdEsil(command.toUtf8().constData()); }
+    void cmdEsil(const QString &command) { cmdEsil(command.toUtf8().constData()); }
     QString getVersionInformation();
 
     QJsonDocument parseJson(const char *res, const char *cmd = nullptr);

--- a/src/Cutter.h
+++ b/src/Cutter.h
@@ -392,11 +392,14 @@ public:
     QString cmdTask(const QString &str);
     QJsonDocument cmdjTask(const QString &str);
     void cmdEsil(const char *command);
-    void cmdEsil(QString command);
+    void cmdEsil(QString command) { cmdEsil(command.toUtf8().constData()); }
     QString getVersionInformation();
 
     QJsonDocument parseJson(const char *res, const char *cmd = nullptr);
-    QJsonDocument parseJson(const char *res, const QString &cmd = QString());
+    QJsonDocument parseJson(const char *res, const QString &cmd = QString())
+    {
+        return parseJson(res, cmd.isNull() ? nullptr : cmd.toLocal8Bit().constData());
+    }
 
     /* Functions methods */
     void renameFunction(const QString &oldName, const QString &newName);
@@ -436,7 +439,7 @@ public:
 
     /* File related methods */
     bool loadFile(QString path, ut64 baddr = 0LL, ut64 mapaddr = 0LL, int perms = R_PERM_R,
-                  int va = 0, bool loadbin = false, const QString &forceBinPlugin = nullptr);
+                  int va = 0, bool loadbin = false, const QString &forceBinPlugin = QString());
     bool tryFile(QString path, bool rw);
     void openFile(QString path, RVA mapaddr);
     void loadScript(const QString &scriptname);
@@ -477,8 +480,6 @@ public:
     void setConfig(const QString &k, int v) { setConfig(k.toUtf8().constData(), v); }
     void setConfig(const char *k, bool v);
     void setConfig(const QString &k, bool v) { setConfig(k.toUtf8().constData(), v); }
-    void setConfig(const char *k, const char *v) { setConfig(k, QString(v)); }
-    void setConfig(const QString &k, const char *v) { setConfig(k, QString(v)); }
     void setConfig(const char *k, const QVariant &v);
     void setConfig(const QString &k, const QVariant &v) { setConfig(k.toUtf8().constData(), v); }
     int getConfigi(const char *k);
@@ -573,7 +574,7 @@ public:
     static bool isProjectNameValid(const QString &name);
 
     /* Widgets */
-    QList<RBinPluginDescription> getRBinPluginDescriptions(const QString &type = nullptr);
+    QList<RBinPluginDescription> getRBinPluginDescriptions(const QString &type = QString());
     QList<RIOPluginDescription> getRIOPluginDescriptions();
     QList<RCorePluginDescription> getRCorePluginDescriptions();
     QList<RAsmPluginDescription> getRAsmPluginDescriptions();
@@ -587,7 +588,7 @@ public:
     QList<RelocDescription> getAllRelocs();
     QList<StringDescription> getAllStrings();
     QList<FlagspaceDescription> getAllFlagspaces();
-    QList<FlagDescription> getAllFlags(QString flagspace = NULL);
+    QList<FlagDescription> getAllFlags(QString flagspace = QString());
     QList<SectionDescription> getAllSections();
     QList<SegmentDescription> getAllSegments();
     QList<EntrypointDescription> getAllEntrypoint();

--- a/src/Cutter.h
+++ b/src/Cutter.h
@@ -382,8 +382,10 @@ public:
 
     /* Core functions (commands) */
     static QString sanitizeStringForCommand(QString s);
+    QString cmd(const char *str);
     QString cmd(const QString &str);
     QString cmdRaw(const QString &str);
+    QJsonDocument cmdj(const char *str);
     QJsonDocument cmdj(const QString &str);
     QStringList cmdList(const QString &str)
     {
@@ -393,9 +395,11 @@ public:
     }
     QString cmdTask(const QString &str);
     QJsonDocument cmdjTask(const QString &str);
+    void cmdEsil(const char *command);
     void cmdEsil(QString command);
     QString getVersionInformation();
 
+    QJsonDocument parseJson(const char *res, const char *cmd = nullptr);
     QJsonDocument parseJson(const char *res, const QString &cmd = QString());
 
     /* Functions methods */
@@ -521,7 +525,7 @@ public:
     void delAllBreakpoints();
     void enableBreakpoint(RVA addr);
     void disableBreakpoint(RVA addr);
-    bool isBreakpoint(QList<RVA> breakpoints, RVA addr);
+    bool isBreakpoint(const QList<RVA> &breakpoints, RVA addr);
     QList<RVA> getBreakpointsAddresses();
     QString getActiveDebugPlugin();
     QStringList getDebugPlugins();

--- a/src/CutterApplication.cpp
+++ b/src/CutterApplication.cpp
@@ -42,7 +42,7 @@ CutterApplication::CutterApplication(int &argc, char **argv) : QApplication(argc
 
     QString langPrefix;
     if (language != "en") {
-        for (auto &it : allLocales) {
+        for (const QLocale &it : allLocales) {
             langPrefix = it.bcp47Name();
             if (langPrefix == language) {
                 const QString &cutterTranslationPath = QCoreApplication::applicationDirPath() + QDir::separator()

--- a/src/common/ColorSchemeFileSaver.cpp
+++ b/src/common/ColorSchemeFileSaver.cpp
@@ -39,7 +39,7 @@ ColorSchemeFileSaver::ColorSchemeFileSaver(QObject *parent) : QObject (parent)
     dirs.removeOne(QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation));
     standardR2ThemesLocationPath = "";
 
-    for (auto &it : dirs) {
+    for (const QString &it : dirs) {
         currDir = QDir(it).filePath("radare2");
         if (currDir.exists()) {
             break;
@@ -90,7 +90,7 @@ QFile::FileError ColorSchemeFileSaver::copy(const QString &srcThemeName,
         Core()->cmd(QString("eco %1").arg(theme));
         QColor back = Config()->getColor(standardBackgroundOptionName);
         _obj[standardBackgroundOptionName] = QJsonArray({back.red(), back.green(), back.blue()});
-        for (auto &it : _obj.keys()) {
+        for (const QString &it : _obj.keys()) {
             QJsonArray rgb = _obj[it].toArray();
             if (rgb.size() != 3) {
                 continue;
@@ -103,7 +103,7 @@ QFile::FileError ColorSchemeFileSaver::copy(const QString &srcThemeName,
     }
 
     QStringList tmp;
-    for (auto &it : src) {
+    for (const QString &it : src) {
         if (it.isEmpty()) {
             continue;
         }
@@ -117,7 +117,7 @@ QFile::FileError ColorSchemeFileSaver::copy(const QString &srcThemeName,
         }
     }
 
-    for (auto &it : options) {
+    for (const QString &it : options) {
         if (cutterSpecificOptions.contains(it))  {
             fOut.write("#~");
         } else {
@@ -146,7 +146,7 @@ QFile::FileError ColorSchemeFileSaver::save(const QString &scheme, const QString
 
 bool ColorSchemeFileSaver::isCustomScheme(const QString &schemeName) const
 {
-    for (auto &it : QDir(customR2ThemesLocationPath).entryInfoList())
+    for (const QFileInfo &it : QDir(customR2ThemesLocationPath).entryInfoList())
         if (it.fileName() == schemeName)
             return true;
     return false;
@@ -166,7 +166,7 @@ QMap<QString, QColor> ColorSchemeFileSaver::getCutterSpecific() const
 
     QMap<QString, QColor> ret;
     QStringList data = QString(f.readAll()).split('\n');
-    for (auto &it : data) {
+    for (const QString &it : data) {
         if (it.length() > 2 && it.left(2) == "#~") {
             QStringList currLine = it.split(' ');
             if (currLine.size() > 1) {

--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -322,14 +322,14 @@ void Configuration::setColorTheme(QString theme)
 
 void Configuration::resetToDefaultAsmOptions()
 {
-    for (auto it = asmOptions.begin(); it != asmOptions.end(); it++) {
+    for (auto it = asmOptions.cbegin(); it != asmOptions.cend(); it++) {
         setConfig(it.key(), it.value());
     }
 }
 
 void Configuration::applySavedAsmOptions()
 {
-    for (auto it = asmOptions.begin(); it != asmOptions.end(); it++) {
+    for (auto it = asmOptions.cbegin(); it != asmOptions.cend(); it++) {
         Core()->setConfig(it.key(), s.value(it.key(), it.value()));
     }
 }

--- a/src/common/JsonTreeItem.cpp
+++ b/src/common/JsonTreeItem.cpp
@@ -76,7 +76,7 @@ JsonTreeItem *JsonTreeItem::load(const QJsonValue &value, JsonTreeItem *parent)
     if ( value.isObject()) {
 
         //Get all QJsonValue childs
-        for (QString key : value.toObject().keys()) {
+        for (const QString &key : value.toObject().keys()) {
             QJsonValue v = value.toObject().value(key);
             JsonTreeItem *child = load(v, rootItem);
             child->setKey(key);
@@ -87,7 +87,7 @@ JsonTreeItem *JsonTreeItem::load(const QJsonValue &value, JsonTreeItem *parent)
     } else if ( value.isArray()) {
         //Get all QJsonValue childs
         int index = 0;
-        for (QJsonValue v : value.toArray()) {
+        for (const QJsonValue &v : value.toArray()) {
 
             JsonTreeItem *child = load(v, rootItem);
             child->setKey(QString::number(index));

--- a/src/common/TempConfig.cpp
+++ b/src/common/TempConfig.cpp
@@ -6,7 +6,7 @@
 
 TempConfig::~TempConfig()
 {
-    for (auto i = resetValues.begin(); i != resetValues.end(); i++) {
+    for (auto i = resetValues.constBegin(); i != resetValues.constEnd(); i++) {
         switch (i.value().type()) {
         case QVariant::String:
             Core()->setConfig(i.key(), i.value().toString());

--- a/src/dialogs/InitialOptionsDialog.cpp
+++ b/src/dialogs/InitialOptionsDialog.cpp
@@ -24,7 +24,7 @@ InitialOptionsDialog::InitialOptionsDialog(MainWindow *main):
 
     // Fill the plugins combo
     asm_plugins = core->getAsmPluginNames();
-    for (auto plugin : asm_plugins)
+    for (const auto &plugin : asm_plugins)
         ui->archComboBox->addItem(plugin, plugin);
     ui->archComboBox->setToolTip(core->cmd("e? asm.arch").trimmed());
 
@@ -42,7 +42,7 @@ InitialOptionsDialog::InitialOptionsDialog(MainWindow *main):
 
     ui->entry_analbb->setToolTip(core->cmd("e? anal.bb.maxsize").trimmed());
 
-    for (auto plugin : core->getRBinPluginDescriptions("bin"))
+    for (const auto &plugin : core->getRBinPluginDescriptions("bin"))
         ui->formatComboBox->addItem(plugin.name, QVariant::fromValue(plugin));
 
     ui->hideFrame->setVisible(false);

--- a/src/dialogs/NewFileDialog.cpp
+++ b/src/dialogs/NewFileDialog.cpp
@@ -323,7 +323,7 @@ void NewFileDialog::fillIOPluginsList()
 
     int index = 1;
     QList<RIOPluginDescription> ioPlugins = Core()->getRIOPluginDescriptions();
-    for (RIOPluginDescription plugin : ioPlugins) {
+    for (const RIOPluginDescription &plugin : ioPlugins) {
         // Hide debug plugins
         if (plugin.permissions.contains('d')) {
             continue;

--- a/src/dialogs/R2PluginsDialog.cpp
+++ b/src/dialogs/R2PluginsDialog.cpp
@@ -10,7 +10,7 @@ R2PluginsDialog::R2PluginsDialog(QWidget *parent) :
 {
     ui->setupUi(this);
 
-    for (auto plugin : Core()->getRBinPluginDescriptions()) {
+    for (const auto &plugin : Core()->getRBinPluginDescriptions()) {
         QTreeWidgetItem *item = new QTreeWidgetItem();
         item->setText(0, plugin.name);
         item->setText(1, plugin.description);
@@ -20,7 +20,7 @@ R2PluginsDialog::R2PluginsDialog(QWidget *parent) :
     }
     qhelpers::adjustColumns(ui->RBinTreeWidget, 0);
 
-    for (auto plugin : Core()->getRIOPluginDescriptions()) {
+    for (const auto &plugin : Core()->getRIOPluginDescriptions()) {
         QTreeWidgetItem *item = new QTreeWidgetItem();
         item->setText(0, plugin.name);
         item->setText(1, plugin.description);
@@ -30,7 +30,7 @@ R2PluginsDialog::R2PluginsDialog(QWidget *parent) :
     }
     qhelpers::adjustColumns(ui->RIOTreeWidget, 0);
 
-    for (auto plugin : Core()->getRCorePluginDescriptions()) {
+    for (const auto &plugin : Core()->getRCorePluginDescriptions()) {
         QTreeWidgetItem *item = new QTreeWidgetItem();
         item->setText(0, plugin.name);
         item->setText(1, plugin.description);
@@ -38,7 +38,7 @@ R2PluginsDialog::R2PluginsDialog(QWidget *parent) :
     }
     qhelpers::adjustColumns(ui->RCoreTreeWidget, 0);
 
-    for (auto plugin : Core()->getRAsmPluginDescriptions()) {
+    for (const auto &plugin : Core()->getRAsmPluginDescriptions()) {
         QTreeWidgetItem *item = new QTreeWidgetItem();
         item->setText(0, plugin.name);
         item->setText(1, plugin.architecture);

--- a/src/dialogs/SetFunctionVarTypes.cpp
+++ b/src/dialogs/SetFunctionVarTypes.cpp
@@ -75,7 +75,7 @@ void SetFunctionVarTypes::on_OkPressed()
                 .arg(ui->selectedTypeForVar->currentText()));
 
     Core()->cmd(QString("afvn %1 %2")
-                .arg(ui->newVarName->text().replace(" ", "_"))
+                .arg(ui->newVarName->text().replace(' ', '_'))
                 .arg(ui->dropdownLocalVars->currentText()));
 }
 
@@ -89,29 +89,24 @@ void SetFunctionVarTypes::populateTypesComboBox()
 {
     //gets all loaded types, structures and enums and puts them in a list
 
-    QString res;
     QStringList userStructures;
     QStringList userEnumerations;
     QList<TypeDescription> primitiveTypesTypeList;
 
-    res = Core()->cmd(QString("ts"));
-    userStructures = res.split("\n");
-    userStructures.removeAll(QString(""));
+    userStructures = Core()->cmdList("ts");
     ui->selectedTypeForVar->addItems(userStructures);
     ui->selectedTypeForVar->insertSeparator(ui->selectedTypeForVar->count());
 
     primitiveTypesTypeList = Core()->getAllTypes();
 
-    for (TypeDescription thisType : primitiveTypesTypeList) {
+    for (const TypeDescription &thisType : primitiveTypesTypeList) {
         ui->selectedTypeForVar->addItem(thisType.type);
     }
 
     ui->selectedTypeForVar->insertSeparator(ui->selectedTypeForVar->count());
 
-    res = Core()->cmd(QString("te"));
-    userStructures = res.split("\n");
-    userStructures.removeAll(QString(""));
-    ui->selectedTypeForVar->addItems(userStructures);
+    userEnumerations = Core()->cmdList("te");
+    ui->selectedTypeForVar->addItems(userEnumerations);
 
     return;
 

--- a/src/dialogs/preferences/AppearanceOptionsWidget.cpp
+++ b/src/dialogs/preferences/AppearanceOptionsWidget.cpp
@@ -23,7 +23,7 @@ static const QHash<QString, ColorFlags> kRelevantSchemes = {
     { "onedark", DarkFlag },
     { "solarized", DarkFlag },
     { "zenburn", DarkFlag },
-     { "cutter", LightFlag },
+    { "cutter", LightFlag },
     { "dark", LightFlag },
     { "matrix", LightFlag },
     { "tango", LightFlag },
@@ -103,7 +103,7 @@ void AppearanceOptionsWidget::updateThemeFromConfig()
     for (auto &it : kCutterQtThemesList) {
         ui->themeComboBox->addItem(it.name);
     }
-    uint curQtThemeIndex = Config()->getTheme();
+    int curQtThemeIndex = Config()->getTheme();
     if (curQtThemeIndex >= kCutterQtThemesList.size()) {
         curQtThemeIndex = 0;
         Config()->setTheme(curQtThemeIndex);
@@ -161,7 +161,7 @@ void AppearanceOptionsWidget::on_colorComboBox_currentIndexChanged(int index)
 {
     QString theme = ui->colorComboBox->itemText(index);
 
-    uint curQtThemeIndex = Config()->getTheme();
+    int curQtThemeIndex = Config()->getTheme();
     if (curQtThemeIndex >= kCutterQtThemesList.size()) {
         curQtThemeIndex = 0;
         Config()->setTheme(curQtThemeIndex);

--- a/src/dialogs/preferences/AsmOptionsWidget.cpp
+++ b/src/dialogs/preferences/AsmOptionsWidget.cpp
@@ -9,10 +9,12 @@
 #include "common/Helpers.h"
 #include "common/Configuration.h"
 
-AsmOptionsWidget::AsmOptionsWidget(PreferencesDialog */*dialog*/, QWidget *parent)
+AsmOptionsWidget::AsmOptionsWidget(PreferencesDialog *dialog, QWidget *parent)
     : QDialog(parent),
       ui(new Ui::AsmOptionsWidget)
 {
+    Q_UNUSED(dialog)
+
     ui->setupUi(this);
 
     ui->syntaxComboBox->blockSignals(true);

--- a/src/dialogs/preferences/DebugOptionsWidget.cpp
+++ b/src/dialogs/preferences/DebugOptionsWidget.cpp
@@ -29,7 +29,7 @@ void DebugOptionsWidget::updateDebugPlugin()
                SLOT(on_pluginComboBox_currentIndexChanged(const QString &)));
 
     QStringList plugins = Core()->getDebugPlugins();
-    for (QString str : plugins)
+    for (const QString &str : plugins)
         ui->pluginComboBox->addItem(str);
 
     QString plugin = Core()->getActiveDebugPlugin();

--- a/src/dialogs/preferences/GraphOptionsWidget.cpp
+++ b/src/dialogs/preferences/GraphOptionsWidget.cpp
@@ -9,10 +9,12 @@
 #include "common/Helpers.h"
 #include "common/Configuration.h"
 
-GraphOptionsWidget::GraphOptionsWidget(PreferencesDialog */*dialog*/, QWidget *parent)
+GraphOptionsWidget::GraphOptionsWidget(PreferencesDialog *dialog, QWidget *parent)
     : QDialog(parent),
       ui(new Ui::GraphOptionsWidget)
 {
+    Q_UNUSED(dialog)
+
     ui->setupUi(this);
 
     updateOptionsFromVars();

--- a/src/widgets/BacktraceWidget.cpp
+++ b/src/widgets/BacktraceWidget.cpp
@@ -39,7 +39,7 @@ void BacktraceWidget::setBacktraceGrid()
 {
     QJsonArray backtraceValues = Core()->getBacktrace().array();
     int i = 0;
-    for (QJsonValueRef value : backtraceValues) {
+    for (const QJsonValue &value : backtraceValues) {
         QJsonObject backtraceItem = value.toObject();
         QString progCounter = RAddressString(backtraceItem["pc"].toVariant().toULongLong());
         QString stackPointer = RAddressString(backtraceItem["sp"].toVariant().toULongLong());

--- a/src/widgets/BreakpointWidget.cpp
+++ b/src/widgets/BreakpointWidget.cpp
@@ -183,8 +183,8 @@ void BreakpointWidget::addBreakpointDialog()
     if (dialog->exec()) {
         QString bps = dialog->getBreakpoints();
         if (!bps.isEmpty()) {
-            QStringList bpList = bps.split(" ", QString::SkipEmptyParts);
-            for ( QString bp : bpList) {
+            QStringList bpList = bps.split(' ', QString::SkipEmptyParts);
+            for (const QString &bp : bpList) {
                 Core()->toggleBreakpoint(bp);
             }
         }

--- a/src/widgets/ColorSchemePrefWidget.h
+++ b/src/widgets/ColorSchemePrefWidget.h
@@ -69,14 +69,17 @@ public:
 
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
 
-    void setColor(const QString &option,
-                  const QColor &color);
+    void setColor(const QString &option, const QColor &color);
 
     QColor getBackroundColor() const;
 
     QColor getTextColor() const;
 
-    int rowCount(const QModelIndex &parent = QModelIndex()) const override { return m_data.size(); }
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override
+    {
+        Q_UNUSED(parent)
+        return m_data.size();
+    }
 
     void updateScheme();
 

--- a/src/widgets/CommentsWidget.cpp
+++ b/src/widgets/CommentsWidget.cpp
@@ -327,7 +327,7 @@ void CommentsWidget::refreshTree()
 
     comments = Core()->getAllComments("CCu");
     nestedComments.clear();
-    for (CommentDescription comment : comments) {
+    for (const CommentDescription &comment : comments) {
         QString fcnName = Core()->cmdFunctionAt(comment.offset);
         nestedComments[fcnName].append(comment);
     }

--- a/src/widgets/Dashboard.cpp
+++ b/src/widgets/Dashboard.cpp
@@ -136,7 +136,7 @@ void Dashboard::updateContents()
         }
     }
 
-    for (QString lib : lines) {
+    for (const QString &lib : lines) {
         QLabel *label = new QLabel(this);
         label->setText(lib);
         label->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -218,8 +218,8 @@ void DisassemblerGraphView::loadCurrentGraph()
     RVA entry = func["offset"].toVariant().toULongLong();
 
     setEntry(entry);
-    for (QJsonValueRef blockRef : func["blocks"].toArray()) {
-        QJsonObject block = blockRef.toObject();
+    for (const QJsonValue &value : func["blocks"].toArray()) {
+        QJsonObject block = value.toObject();
         RVA block_entry = block["offset"].toVariant().toULongLong();
         RVA block_size = block["size"].toVariant().toULongLong();
         RVA block_fail = block["fail"].toVariant().toULongLong();

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -450,7 +450,7 @@ void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block)
     // Draw different background for selected instruction
     if (selected_instruction != RVA_INVALID) {
         int y = block.y + (2 * charWidth) + (db.header_text.lines.size() * charHeight);
-        for (Instr &instr : db.instrs) {
+        for (const Instr &instr : db.instrs) {
             if (instr.addr > selected_instruction) {
                 break;
             }
@@ -489,7 +489,7 @@ void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block)
         int y = block.y + (2 * charWidth) + (db.header_text.lines.size() * charHeight);
         int tokenWidth = mFontMetrics->width(highlight_token->content);
 
-        for (Instr &instr : db.instrs) {
+        for (const Instr &instr : db.instrs) {
             int pos = -1;
 
             while ((pos = instr.plainText.indexOf(highlight_token->content, pos + 1)) != -1) {
@@ -521,7 +521,7 @@ void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block)
     // highlight program counter
     if (PCInBlock) {
         int y = block.y + (2 * charWidth) + (db.header_text.lines.size() * charHeight);
-        for (Instr &instr : db.instrs) {
+        for (const Instr &instr : db.instrs) {
             if (instr.addr > PCAddr) {
                 break;
             }
@@ -541,7 +541,7 @@ void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block)
         RichTextPainter::paintRichText(&p, x, y, block.width, charHeight, 0, line, mFontMetrics);
         y += charHeight;
     }
-    for (Instr &instr : db.instrs) {
+    for (const Instr &instr : db.instrs) {
         if (Core()->isBreakpoint(breakpoints, instr.addr)) {
             p.fillRect(QRect(block.x + charWidth, y, block.width - (10 + 2 * charWidth),
                              int(instr.text.lines.size()) * charHeight), ConfigColor("gui.breakpoint_background"));
@@ -663,7 +663,7 @@ DisassemblerGraphView::DisassemblyBlock *DisassemblerGraphView::blockForAddress(
 {
     for (auto &blockIt : disassembly_blocks) {
         DisassemblyBlock &db = blockIt.second;
-        for (Instr i : db.instrs) {
+        for (const Instr &i : db.instrs) {
             if (i.addr == RVA_INVALID || i.size == RVA_INVALID) {
                 continue;
             }

--- a/src/widgets/DisassemblerGraphView.h
+++ b/src/widgets/DisassemblerGraphView.h
@@ -46,8 +46,8 @@ class DisassemblerGraphView : public GraphView
         QString ToQString() const
         {
             QString result;
-            for (auto &line : lines) {
-                for (auto &t : line) {
+            for (const auto &line : lines) {
+                for (const auto &t : line) {
                     result += t.text;
                 }
             }

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -228,7 +228,7 @@ void DisassemblyWidget::refreshDisasm(RVA offset)
     mDisasTextEdit->document()->clear();
     QTextCursor cursor(mDisasTextEdit->document());
     QTextBlockFormat regular = cursor.blockFormat();
-    for (DisassemblyLine line : disassemblyLines) {
+    for (const DisassemblyLine &line : disassemblyLines) {
         if (line.offset < topOffset) { // overflow
             break;
         }

--- a/src/widgets/EntrypointWidget.cpp
+++ b/src/widgets/EntrypointWidget.cpp
@@ -28,7 +28,7 @@ EntrypointWidget::~EntrypointWidget() {}
 void EntrypointWidget::fillEntrypoint()
 {
     ui->entrypointTreeWidget->clear();
-    for (auto i : Core()->getAllEntrypoint()) {
+    for (const EntrypointDescription &i : Core()->getAllEntrypoint()) {
         QTreeWidgetItem *item = new QTreeWidgetItem();
         item->setText(0, RAddressString(i.vaddr));
         item->setText(1, i.type);

--- a/src/widgets/FlagsWidget.cpp
+++ b/src/widgets/FlagsWidget.cpp
@@ -221,7 +221,7 @@ void FlagsWidget::refreshFlagspaces()
     ui->flagspaceCombo->clear();
     ui->flagspaceCombo->addItem(tr("(all)"));
 
-    for (auto i : Core()->getAllFlagspaces()) {
+    for (const FlagspaceDescription &i : Core()->getAllFlagspaces()) {
         ui->flagspaceCombo->addItem(i.name, QVariant::fromValue(i));
     }
 
@@ -250,7 +250,7 @@ void FlagsWidget::refreshFlags()
     
     // TODO: this is not a very good place for the following:
     QStringList flagNames;
-    for (auto i : flags)
+    for (const FlagDescription &i : flags)
         flagNames.append(i.name);
     main->refreshOmniBar(flagNames);
 }

--- a/src/widgets/FunctionsWidget.cpp
+++ b/src/widgets/FunctionsWidget.cpp
@@ -564,7 +564,7 @@ void FunctionsWidget::refreshTree()
         this->functions = functions;
 
         importAddresses.clear();
-        for (ImportDescription import : Core()->getAllImports()) {
+        for (const ImportDescription &import : Core()->getAllImports()) {
             importAddresses.insert(import.plt);
         }
 

--- a/src/widgets/SdbDock.cpp
+++ b/src/widgets/SdbDock.cpp
@@ -33,7 +33,7 @@ void SdbDock::reload(QString _path)
     QList<QString> keys;
     /* key-values */
     keys = Core()->sdbListKeys(path);
-    for (QString key : keys) {
+    for (const QString &key : keys) {
         QTreeWidgetItem *tempItem = new QTreeWidgetItem();
         tempItem->setText(0, key);
         tempItem->setText(1, Core()->sdbGet(path, key));
@@ -45,7 +45,7 @@ void SdbDock::reload(QString _path)
     /* namespaces */
     keys = Core()->sdbList(path);
     keys.append("..");
-    for (QString key : keys) {
+    for (const QString &key : keys) {
         QTreeWidgetItem *tempItem = new QTreeWidgetItem();
         tempItem->setText(0, key + "/");
         tempItem->setText(1, "");

--- a/src/widgets/SidebarWidget.cpp
+++ b/src/widgets/SidebarWidget.cpp
@@ -184,7 +184,7 @@ void SidebarWidget::fillOffsetInfo(QString off)
     ui->offsetTreeWidget->clear();
     QString raw = Core()->cmd(QString("ao@") + off).trimmed();
     QList<QString> lines = raw.split("\n", QString::SkipEmptyParts);
-    for (QString line : lines) {
+    for (const QString &line : lines) {
         QList<QString> eles = line.split(":", QString::SkipEmptyParts);
         if (eles.length() < 2) {
             continue;
@@ -225,11 +225,11 @@ void SidebarWidget::fillRegistersInfo()
     ui->regInfoTreeWidget->clear();
 
     QJsonObject jsonRoot = Core()->getRegistersInfo().object();
-    for (QString key : jsonRoot.keys()) {
+    for (const QString &key : jsonRoot.keys()) {
         QTreeWidgetItem *tempItem = new QTreeWidgetItem();
         QString tempString;
         tempItem->setText(0, key.toUpper());
-        for (QJsonValue value : jsonRoot[key].toArray()) {
+        for (const QJsonValue &value : jsonRoot[key].toArray()) {
             tempString.append(value.toString() + " ");
         }
         tempItem->setText(1, tempString);

--- a/src/widgets/StackWidget.cpp
+++ b/src/widgets/StackWidget.cpp
@@ -51,7 +51,7 @@ void StackWidget::setStackGrid()
 {
     QJsonArray stackValues = Core()->getStack().array();
     int i = 0;
-    for (QJsonValueRef value : stackValues) {
+    for (const QJsonValue &value : stackValues) {
         QJsonObject stackItem = value.toObject();
         QString addr = RAddressString(stackItem["addr"].toVariant().toULongLong());
         QString valueStack = RAddressString(stackItem["value"].toVariant().toULongLong());

--- a/src/widgets/StringsWidget.cpp
+++ b/src/widgets/StringsWidget.cpp
@@ -218,7 +218,7 @@ void StringsWidget::refreshSectionCombo()
     combo->clear();
     combo->addItem(tr("(all)"));
 
-    for (QString &section : Core()->getSectionList()) {
+    for (const QString &section : Core()->getSectionList()) {
         combo->addItem(section, section);
     }
 

--- a/src/widgets/VisualNavbar.cpp
+++ b/src/widgets/VisualNavbar.cpp
@@ -241,7 +241,7 @@ void VisualNavbar::mouseMoveEvent(QMouseEvent *event)
 
 RVA VisualNavbar::localXToAddress(double x)
 {
-    for (auto x2a : xToAddress) {
+    for (const XToAddress &x2a : xToAddress) {
         if ((x2a.x_start <= x) && (x <= x2a.x_end)) {
             double offset = (x - x2a.x_start) / (x2a.x_end - x2a.x_start);
             double size = x2a.address_to - x2a.address_from;
@@ -253,7 +253,7 @@ RVA VisualNavbar::localXToAddress(double x)
 
 double VisualNavbar::addressToLocalX(RVA address)
 {
-    for (auto x2a : xToAddress) {
+    for (const XToAddress &x2a : xToAddress) {
         if ((x2a.address_from <= address) && (address < x2a.address_to)) {
             double offset = (double)(address - x2a.address_from) / (double)(x2a.address_to - x2a.address_from);
             double size = x2a.x_end - x2a.x_start;
@@ -267,7 +267,7 @@ QList<QString> VisualNavbar::sectionsForAddress(RVA address)
 {
     QList<QString> ret;
     QList<SectionDescription> sections = Core()->getAllSections();
-    for (const auto &section : sections) {
+    for (const SectionDescription &section : sections) {
         if (address >= section.vaddr && address < section.vaddr + section.vsize) {
             ret << section.name;
         }
@@ -282,7 +282,7 @@ QString VisualNavbar::toolTipForAddress(RVA address)
     if (sections.count()) {
         ret += "\nSections: \n";
         bool first = true;
-        for (auto section : sections) {
+        for (const QString &section : sections) {
             if (!first) {
                 ret += "\n";
             } else {

--- a/src/widgets/ZignaturesWidget.cpp
+++ b/src/widgets/ZignaturesWidget.cpp
@@ -48,7 +48,7 @@ QVariant ZignaturesModel::data(const QModelIndex &index, int role) const
                               "\n    Edges: " + RSizeString(zignature.edges) +
                               "\n    Ebbs: " + RSizeString(zignature.ebbs) +
                               "\n\nRefs:\n");
-        for (QString ref : zignature.refs) {
+        for (const QString &ref : zignature.refs) {
             tmp.append("\n    " + ref);
         }
         return tmp;


### PR DESCRIPTION
- Add overloads for `CutterCore::cmd`,  `CutterCore::cmdj`, `CutterCore::cmdEsil`, `CutterCore::parseJson`, `CutterCore::getConfig`, `CutterCore::getConfigi`, `CutterCore::getConfigb`, `CutterCore::setConfig`
- Use `QStringLiteral` instead of `QLatin1Literal` for JSON keys since `QJsonObject::value(QLatin1String)` still creates `QString` from `QLatin1String`
- Use `for (const QJsonValue &jsonValue : jsonArray)` everywhere for iterating over `QJsonArray`

There is no real difference (at least for MSVC) between:
1)
```c++
for (const QJsonValue &jsonValue : jsonArray) {
    QJsonObject jsonObject = jsonValue.toObject();
    ...
} 
```
2)
```c++
for (QJsonValue jsonValue : jsonArray) {
    QJsonObject jsonObject = jsonValue.toObject();
    ...
} 
```
3)
```c++
for (QJsonValueRef jsonValue : jsonArray) {
    QJsonObject jsonObject = jsonValue.toObject();
    ...
} 
```
But I think it is better to use non-helper class (`QJsonValueRef`) and use it in more explicit way.