### PR TITLE
Toggle the address maps in the Section Widget

### DIFF
--- a/src/widgets/SectionsWidget.cpp
+++ b/src/widgets/SectionsWidget.cpp
@@ -187,10 +187,10 @@ SectionsWidget::SectionsWidget(MainWindow *main, QAction *action) :
     addrDockWidget->setLayout(addrDockLayout);
     layout->addWidget(addrDockWidget);
 
-    QPixmap base(":/img/icons/previous.svg");
+    QPixmap map(":/img/icons/previous.svg");
     QTransform transform;
-    QTransform trans = transform.rotate(90);
-    QPixmap map(base.transformed(trans));
+    transform = transform.rotate(90);
+    map = map.transformed(transform);
     QIcon icon;
     icon.addPixmap(map);
 

--- a/src/widgets/SectionsWidget.cpp
+++ b/src/widgets/SectionsWidget.cpp
@@ -187,11 +187,16 @@ SectionsWidget::SectionsWidget(MainWindow *main, QAction *action) :
     addrDockWidget->setLayout(addrDockLayout);
     layout->addWidget(addrDockWidget);
 
+    QPixmap base(":/img/icons/previous.svg");
+    QTransform transform;
+    QTransform trans = transform.rotate(90);
+    QPixmap map(base.transformed(trans));
+    QIcon icon;
+    icon.addPixmap(map);
+
     toggleButton = new QToolButton;
     toggleButton->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     toggleButton->setFixedHeight(30);
-    QIcon icon;
-    icon.addFile(QStringLiteral(":/img/icons/previous.svg"), QSize(), QIcon::Normal, QIcon::Off);
     toggleButton->setIcon(icon);
     toggleButton->setIconSize(QSize(16, 12));
     toggleButton->setAutoRaise(true);

--- a/src/widgets/SectionsWidget.h
+++ b/src/widgets/SectionsWidget.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <map>
 
+#include <QtWidgets/QToolButton>
 #include <QAbstractListModel>
 #include <QSortFilterProxyModel>
 #include <QGraphicsScene>
@@ -77,14 +78,17 @@ private:
     QWidget *dockWidgetContents;
     QuickFilterView *quickFilterView;
 
+    QWidget *addrDockWidget;
     SectionAddrDock *rawAddrDock;
     SectionAddrDock *virtualAddrDock;
+    QToolButton *toggleButton;
 
     int indicatorWidth;
     int indicatorHeight;
     int indicatorParamPosY;
     void drawIndicatorOnAddrDocks();
     void updateIndicator(SectionAddrDock *targetDock, QString name, float ratio);
+    void updateToggle();
 };
 
 class SectionAddrDock : public QDockWidget


### PR DESCRIPTION
![gifrecord_2018-11-25_172116](https://user-images.githubusercontent.com/29271244/48977091-e6c2e500-f0d6-11e8-8e4f-076318a9761c.gif)

Adding a toggle button to the address maps in the Section Widget. Check the gif. 