### PR TITLE
Fixed Dashboard file name displaying

### DIFF
--- a/src/widgets/Dashboard.cpp
+++ b/src/widgets/Dashboard.cpp
@@ -38,13 +38,7 @@ void Dashboard::updateContents()
     QJsonObject item = docu.object()["core"].toObject();
     QJsonObject item2 = docu.object()["bin"].toObject();
 
-#ifdef Q_OS_WIN
-    QString fname = item["file"].toString();
-    fname = QString::fromUtf8(fname.toLatin1());
-#else // Q_OS_WIN
-    QString fname = item["file"].toString();
-#endif // Q_OS_WIN
-    this->ui->fileEdit->setText(fname);
+    this->ui->fileEdit->setText(item["file"].toString());
     this->ui->formatEdit->setText(item["format"].toString());
     this->ui->modeEdit->setText(item["mode"].toString());
     this->ui->typeEdit->setText(item["type"].toString());


### PR DESCRIPTION
due to utf8 json serialization in radare2 has been fixed, we don't need encoding kludge anymore

Fixes this:
![image](https://user-images.githubusercontent.com/14978853/49180140-e8094180-f364-11e8-9819-2b5d15137e3c.png)

to be this:
![image](https://user-images.githubusercontent.com/14978853/49180166-f48d9a00-f364-11e8-9e4d-be8e793b4ca2.png)
