### PR TITLE
Fixes #965 - Fail to duplicate color theme on windows.

### DIFF
--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -67,7 +67,7 @@ Configuration *Configuration::instance()
 void Configuration::loadInitial()
 {
     setTheme(getTheme());
-    setColorTheme(getCurrentTheme());
+    setColorTheme(getColorTheme());
     applySavedAsmOptions();
 }
 
@@ -234,7 +234,7 @@ void Configuration::setFont(const QFont &font)
 QString Configuration::getLastThemeOf(const CutterQtTheme &currQtTheme) const
 {
     return s.value("lastThemeOf." + currQtTheme.name,
-                   Config()->getCurrentTheme()).toString();
+                   Config()->getColorTheme()).toString();
 }
 
 void Configuration::setTheme(int theme)
@@ -287,21 +287,21 @@ const QColor Configuration::getColor(const QString &name) const
     }
 }
 
-void Configuration::setColorTheme(QString theme)
+void Configuration::setColorTheme(const QString &theme)
 {
     if (theme == "default") {
         Core()->cmd("ecd");
         s.setValue("theme", "default");
     } else {
-        Core()->cmd(QString("eco %1").arg(theme));
+        Core()->cmd(QStringLiteral("eco %1").arg(theme));
         s.setValue("theme", theme);
     }
     // Duplicate interesting colors into our Cutter Settings
     // Dirty fix for arrow colors, TODO refactor getColor, setColor, etc.
     QJsonDocument colors = Core()->cmdj("ecj");
     QJsonObject colorsObject = colors.object();
-    QJsonObject::iterator it;
-    for (it = colorsObject.begin(); it != colorsObject.end(); it++) {
+
+    for (auto it = colorsObject.constBegin(); it != colorsObject.constEnd(); it++) {
         QJsonArray rgb = it.value().toArray();
         if (rgb.size() != 3) {
             continue;

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -88,8 +88,8 @@ public:
         s.setValue("graph.maxcols", ch);
     }
 
-    QString getCurrentTheme() const     { return s.value("theme", "cutter").toString(); }
-    void setColorTheme(QString theme);
+    QString getColorTheme() const     { return s.value("theme", "cutter").toString(); }
+    void setColorTheme(const QString &theme);
 
     /*!
      * \brief Get the value of a config var either from r2 or settings, depending on the key.

--- a/src/dialogs/preferences/AppearanceOptionsWidget.h
+++ b/src/dialogs/preferences/AppearanceOptionsWidget.h
@@ -27,7 +27,7 @@ private:
 
 private slots:
     void updateFontFromConfig();
-    void updateThemeFromConfig();
+    void updateThemeFromConfig(bool qtThemeChanged = true);
 
     void on_fontSelectionButton_clicked();
     void on_themeComboBox_currentIndexChanged(int index);

--- a/src/widgets/ColorSchemePrefWidget.cpp
+++ b/src/widgets/ColorSchemePrefWidget.cpp
@@ -424,8 +424,8 @@ void ColorSchemePrefWidget::apply()
         }
         scheme += curr.optionName + " rgb:" + curr.color.name().remove("#").toLower() + "\n";
     }
-    ColorSchemeFileWorker().save(scheme, Config()->getCurrentTheme());
-    Config()->setColorTheme(Config()->getCurrentTheme());
+    ColorSchemeFileWorker().save(scheme, Config()->getColorTheme());
+    Config()->setColorTheme(Config()->getColorTheme());
 }
 
 void ColorSchemePrefWidget::newColor()
@@ -436,13 +436,15 @@ void ColorSchemePrefWidget::newColor()
 
     ColorOption currCO = ui->preferencesListView->model()->data(ui->preferencesListView->currentIndex(),
                                                                 Qt::UserRole).value<ColorOption>();
-    QColorDialog d;
-    d.setCurrentColor(currCO.color);
-    d.exec();
+    QColorDialog d(currCO.color, this);
+    if (QDialog::Accepted != d.exec())
+        return;
 
     static_cast<ColorSettingsModel *>(ui->preferencesListView->model())->setColor(currCO.optionName,
                                                                                   d.selectedColor());
     ui->preferencesListView->setStandardColors();
+    if (ui->preferencesListView->model()->rowCount())
+        indexChanged(ui->preferencesListView->selectionModel()->selectedIndexes().first());
 }
 
 void ColorSchemePrefWidget::indexChanged(const QModelIndex &ni)
@@ -452,7 +454,7 @@ void ColorSchemePrefWidget::indexChanged(const QModelIndex &ni)
 
 void ColorSchemePrefWidget::updateSchemeFromConfig()
 {
-    isEditable = ColorSchemeFileWorker().isCustomScheme(Config()->getCurrentTheme());
+    isEditable = ColorSchemeFileWorker().isCustomScheme(Config()->getColorTheme());
     static_cast<ColorSettingsModel *>(ui->preferencesListView->model())->updateScheme();
 }
 
@@ -486,7 +488,7 @@ void ColorSettingsModel::setColor(const QString &option, const QColor &color)
 
 QColor ColorSettingsModel::getBackroundColor() const
 {
-    if (!ColorSchemeFileWorker().isCustomScheme(Config()->getCurrentTheme())) {
+    if (!ColorSchemeFileWorker().isCustomScheme(Config()->getColorTheme())) {
         return Config()->getColor(standardBackgroundOptionName);
     }
 
@@ -500,7 +502,7 @@ QColor ColorSettingsModel::getBackroundColor() const
 
 QColor ColorSettingsModel::getTextColor() const
 {
-    if (!ColorSchemeFileWorker().isCustomScheme(Config()->getCurrentTheme())) {
+    if (!ColorSchemeFileWorker().isCustomScheme(Config()->getColorTheme())) {
         return Config()->getColor(standardTextOptionName);
     }
 


### PR DESCRIPTION
Fixes bug with color change
Performed small refactoring of `AppearanceOptionsWidget`, `ColorSchemeFileSaver`

Fixed themes path where the new theme is being stored at.

![image](https://user-images.githubusercontent.com/14978853/49194156-05550480-f393-11e8-8fcf-2dd2633a6ba3.png)
