### PR TITLE
Add a separator for disassembly context menu 

### DIFF
--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -65,6 +65,7 @@ DisassemblyContextMenu::DisassemblyContextMenu(QWidget *parent)
                SLOT(on_actionAnalyzeFunction_triggered()));
     addAction(&actionAnalyzeFunction);
 
+    addSeparator();
 
     addSetBaseMenu();
 


### PR DESCRIPTION
Added a separator for the Disassembly context menu in order to make the list more easy to navigate.

**Test plan (required)**

![image](https://user-images.githubusercontent.com/20182642/49380735-f8317000-f71a-11e8-8d20-9cc33d0710d1.png)

**Closing issues**

Closes #975