### PR TITLE
Closing #929 | Color functions at offset 0x00 in the Imports widget

### DIFF
--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -156,6 +156,8 @@ void Configuration::loadDefaultTheme()
     setColor("gui.navbar.sym", QColor(229, 150, 69));
     setColor("gui.navbar.empty", QColor(100, 100, 100));
     setColor("gui.breakpoint_background", QColor(233, 143, 143));
+    setColor("gui.item_invalid", QColor(155, 155, 155));
+    setColor("gui.item_unsafe", QColor(255, 129, 123));
 }
 
 void Configuration::loadBaseDark()
@@ -189,6 +191,8 @@ void Configuration::loadBaseDark()
     setColor("gui.dataoffset", QColor(255, 255, 255));
     // Custom
     setColor("gui.imports", QColor(50, 140, 255));
+    setColor("gui.item_invalid", QColor(155, 155, 155));
+    setColor("gui.item_unsafe", QColor(255, 129, 123));
     setColor("gui.main", QColor(0, 128, 0));
 
     // GUI: navbar

--- a/src/widgets/ImportsWidget.cpp
+++ b/src/widgets/ImportsWidget.cpp
@@ -31,8 +31,12 @@ QVariant ImportsModel::data(const QModelIndex &index, int role) const
     switch (role) {
     case Qt::ForegroundRole:
         if (index.column() < ImportsModel::ColumnCount) {
+            // Red color for unsafe functions
             if (banned.match(import.name).hasMatch())
                 return QColor(255, 129, 123);
+            // Grey color for symbols at offset 0 which can only be filled at runtime
+            if (import.plt == 0)
+                return QColor(155, 155, 155);
         }
         break;
     case Qt::DisplayRole:

--- a/src/widgets/ImportsWidget.cpp
+++ b/src/widgets/ImportsWidget.cpp
@@ -33,10 +33,10 @@ QVariant ImportsModel::data(const QModelIndex &index, int role) const
         if (index.column() < ImportsModel::ColumnCount) {
             // Red color for unsafe functions
             if (banned.match(import.name).hasMatch())
-                return QColor(255, 129, 123);
+                return Config()->getColor("gui.item_unsafe");
             // Grey color for symbols at offset 0 which can only be filled at runtime
             if (import.plt == 0)
-                return QColor(155, 155, 155);
+                return Config()->getColor("gui.item_invalid");
         }
         break;
     case Qt::DisplayRole:


### PR DESCRIPTION
Color function at offset 0 in Grey at the Imports widget. The addresses for these functions would only be filled at runtime.

![image](https://user-images.githubusercontent.com/20182642/49701491-beb6a400-fbf5-11e8-8d20-86bec1ae6230.png)



![image](https://user-images.githubusercontent.com/20182642/49701486-ae062e00-fbf5-11e8-9b51-79c63629a9ea.png)



**Closing issues**

Closes #929 