### PR TITLE
Fix out of bounds crash in Theme selector

### DIFF
--- a/src/widgets/ColorSchemePrefWidget.cpp
+++ b/src/widgets/ColorSchemePrefWidget.cpp
@@ -462,11 +462,13 @@ ColorSettingsModel::ColorSettingsModel(QObject *parent) : QAbstractListModel (pa
 
 QVariant ColorSettingsModel::data(const QModelIndex &index, int role) const
 {
-    if (!index.isValid())
+    if (!index.isValid()) {
       return QVariant();
+    }
     
-    if (index.row() < 0 || index.row() >= m_data.size())
+    if (index.row() < 0 || index.row() >= m_data.size()) {
       return QVariant();
+    }
     
     if (role == Qt::DisplayRole) {
         return QVariant::fromValue(m_data.at(index.row()).displayingText);

--- a/src/widgets/ColorSchemePrefWidget.cpp
+++ b/src/widgets/ColorSchemePrefWidget.cpp
@@ -462,6 +462,12 @@ ColorSettingsModel::ColorSettingsModel(QObject *parent) : QAbstractListModel (pa
 
 QVariant ColorSettingsModel::data(const QModelIndex &index, int role) const
 {
+    if (!index.isValid())
+      return QVariant();
+    
+    if (index.row() < 0 || index.row() >= m_data.size())
+      return QVariant();
+    
     if (role == Qt::DisplayRole) {
         return QVariant::fromValue(m_data.at(index.row()).displayingText);
     }


### PR DESCRIPTION
There was an index-out-of-bounds access to an array which is now fixed by checking that index is valid andinside the excpected range.

