### PR TITLE
Fix SIGSEGV on Sections widget

### DIFF
--- a/src/widgets/SectionsWidget.cpp
+++ b/src/widgets/SectionsWidget.cpp
@@ -152,7 +152,7 @@ void SectionsWidget::initSectionsTable()
 {
     sectionsTable = new CutterTreeView;
     sectionsModel = new SectionsModel(&sections, this);
-    auto proxyModel = new SectionsProxyModel(sectionsModel, this);
+    proxyModel = new SectionsProxyModel(sectionsModel, this);
 
     sectionsTable->setModel(proxyModel);
     sectionsTable->setIndentation(10);


### PR DESCRIPTION
An argument declared the wrong way caused Cutter to SIGSEGV.
![image](https://user-images.githubusercontent.com/20182642/50047175-0be4bb00-00b9-11e9-9a4f-a4f35234be2c.png)

This PR should fix it

