### PR TITLE
Right click -> Select block in hexdump widget

### DIFF
--- a/src/Cutter.pro
+++ b/src/Cutter.pro
@@ -219,7 +219,8 @@ SOURCES += \
     common/ColorSchemeFileSaver.cpp \
     dialogs/EditFunctionDialog.cpp \
     widgets/CutterTreeView.cpp \
-    widgets/ComboQuickFilterView.cpp
+    widgets/ComboQuickFilterView.cpp \
+    dialogs/HexdumpRangeDialog.cpp
 
 HEADERS  += \
     Cutter.h \
@@ -322,7 +323,8 @@ HEADERS  += \
     widgets/ColorSchemePrefWidget.h \
     dialogs/EditFunctionDialog.h \
     widgets/CutterTreeView.h \
-    widgets/ComboQuickFilterView.h
+    widgets/ComboQuickFilterView.h \
+    dialogs/HexdumpRangeDialog.h
 
 FORMS    += \
     dialogs/AboutDialog.ui \
@@ -381,7 +383,8 @@ FORMS    += \
     dialogs/SetFunctionVarTypes.ui \
     widgets/ColorSchemePrefWidget.ui \
     widgets/CutterTreeView.ui \
-    widgets/ComboQuickFilterView.ui
+    widgets/ComboQuickFilterView.ui \
+    dialogs/HexdumpRangeDialog.ui
 
 RESOURCES += \
     resources.qrc \

--- a/src/dialogs/HexdumpRangeDialog.cpp
+++ b/src/dialogs/HexdumpRangeDialog.cpp
@@ -1,0 +1,101 @@
+#include "HexdumpRangeDialog.h"
+#include "ui_HexdumpRangeDialog.h"
+
+HexdumpRangeDialog::HexdumpRangeDialog(QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::HexdumpRangeDialog)
+{
+    ui->setupUi(this);
+    QRegExpValidator *v = new QRegExpValidator(QRegExp("(?:0[xX])?[0-9a-fA-F]+"), this);
+    ui->lengthLineEdit->setValidator(v);
+    ui->startAddressLineEdit->setValidator(v);
+    ui->endAddressLineEdit->setValidator(v);
+
+    //subscribe to a text change slot
+    connect(ui->endAddressLineEdit, &QLineEdit::textEdited, this, &HexdumpRangeDialog::textEdited);
+    connect(ui->lengthLineEdit, &QLineEdit::textEdited, this, &HexdumpRangeDialog::textEdited);
+    connect(ui->endAddressRadioButton, &QRadioButton::clicked, this,
+            &HexdumpRangeDialog::on_radioButtonClicked);
+    connect(ui->lengthRadioButton, &QRadioButton::clicked, this,
+            &HexdumpRangeDialog::on_radioButtonClicked);
+
+}
+
+HexdumpRangeDialog::~HexdumpRangeDialog()
+{
+    delete ui;
+}
+
+QString HexdumpRangeDialog::getStartAddress() const
+{
+    return ui->startAddressLineEdit->text();
+}
+
+QString HexdumpRangeDialog::getEndAddress() const
+{
+    return ui->endAddressLineEdit->text();
+}
+
+QString HexdumpRangeDialog::getLength() const
+{
+    return ui->lengthLineEdit->text();
+}
+
+bool HexdumpRangeDialog::getEndAddressRadioButtonChecked() const
+{
+    return ui->endAddressRadioButton->isChecked();
+}
+
+bool HexdumpRangeDialog::getLengthRadioButtonChecked() const
+{
+    return ui->lengthRadioButton->isChecked();
+}
+
+void HexdumpRangeDialog::setStartAddress(ut64 start)
+{
+    ui->startAddressLineEdit->setText(
+        QString("0x%1").arg(start, 0, 16));
+}
+
+void HexdumpRangeDialog::textEdited()
+{
+    bool warningVisibile = false;
+    QString startAddress = ui->startAddressLineEdit->text();
+    ut64 length = 0;
+    if (sender() == ui->endAddressLineEdit) {
+         length = Core()->math(getEndAddress() + " - " + startAddress);
+
+        ui->lengthLineEdit->setText(
+            QString("0x%1").arg(length, 0, 16));
+    } else if ( sender() == ui->lengthLineEdit) {
+        //we edited the length, so update the end address to be start address + length
+        ut64 endAddress = Core()->math(startAddress + " + " + getLength());
+        ui->endAddressLineEdit->setText(
+            QString("0x%1").arg(endAddress, 0, 16));
+    }
+
+    length = Core()->math(getLength());
+
+    // Warn the user for potentially heavy operation
+    if (length > 0x25000) {
+        warningVisibile = true;
+    }
+
+    ui->selectionWarningLabel->setVisible(warningVisibile);
+
+}
+
+void HexdumpRangeDialog::on_radioButtonClicked(bool checked)
+{
+
+    if (sender() == ui->endAddressRadioButton && checked == true) {
+        ui->lengthLineEdit->setEnabled(false);
+        ui->endAddressLineEdit->setEnabled(true);
+        ui->endAddressLineEdit->setFocus();
+    } else if (sender() == ui->lengthRadioButton && checked == true) {
+        ui->lengthLineEdit->setEnabled(true);
+        ui->endAddressLineEdit->setEnabled(false);
+        ui->lengthLineEdit->setFocus();
+    }
+
+}

--- a/src/dialogs/HexdumpRangeDialog.cpp
+++ b/src/dialogs/HexdumpRangeDialog.cpp
@@ -60,16 +60,23 @@ void HexdumpRangeDialog::setStartAddress(ut64 start)
 void HexdumpRangeDialog::textEdited()
 {
     bool warningVisibile = false;
-    QString startAddress = ui->startAddressLineEdit->text();
+    ut64 startAddress = Core()->math(ui->startAddressLineEdit->text());
+    ut64 endAddress = 0;
     ut64 length = 0;
     if (sender() == ui->endAddressLineEdit) {
-         length = Core()->math(getEndAddress() + " - " + startAddress);
-
-        ui->lengthLineEdit->setText(
-            QString("0x%1").arg(length, 0, 16));
+        endAddress = Core()->math(getEndAddress());
+        if (endAddress > startAddress) {
+            length = endAddress - startAddress;
+            ui->lengthLineEdit->setText(
+                QString("0x%1").arg(length, 0, 16));
+        }
+        else {
+            ui->lengthLineEdit->setText("Invalid");
+        }
     } else if ( sender() == ui->lengthLineEdit) {
         //we edited the length, so update the end address to be start address + length
-        ut64 endAddress = Core()->math(startAddress + " + " + getLength());
+        length = Core()->math(getLength());
+        endAddress = startAddress + length;
         ui->endAddressLineEdit->setText(
             QString("0x%1").arg(endAddress, 0, 16));
     }

--- a/src/dialogs/HexdumpRangeDialog.h
+++ b/src/dialogs/HexdumpRangeDialog.h
@@ -1,0 +1,38 @@
+#ifndef HEXDUMPRANGEDIALOG_H
+#define HEXDUMPRANGEDIALOG_H
+
+#include "Cutter.h"
+
+#include <QDialog>
+#include <QRegExpValidator>
+
+namespace Ui {
+class HexdumpRangeDialog;
+}
+
+class HexdumpRangeDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit HexdumpRangeDialog(QWidget *parent = nullptr);
+    ~HexdumpRangeDialog();
+    QString getStartAddress() const;
+    QString getEndAddress() const;
+    QString getLength() const;
+    bool    getEndAddressRadioButtonChecked() const;
+    bool    getLengthRadioButtonChecked() const;
+    void    setStartAddress(ut64 start);
+
+public slots:
+    void textEdited();
+
+private:
+    Ui::HexdumpRangeDialog *ui;
+
+private slots:
+    void on_radioButtonClicked(bool checked);
+
+};
+
+#endif // HEXDUMPRANGEDIALOG_H

--- a/src/dialogs/HexdumpRangeDialog.ui
+++ b/src/dialogs/HexdumpRangeDialog.ui
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>HexdumpRangeDialog</class>
+ <widget class="QDialog" name="HexdumpRangeDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>455</width>
+    <height>201</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Select Block</string>
+  </property>
+  <widget class="QDialogButtonBox" name="buttonBox">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>160</y>
+     <width>341</width>
+     <height>32</height>
+    </rect>
+   </property>
+   <property name="orientation">
+    <enum>Qt::Horizontal</enum>
+   </property>
+   <property name="standardButtons">
+    <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+   </property>
+  </widget>
+  <widget class="QWidget" name="gridLayoutWidget">
+   <property name="geometry">
+    <rect>
+     <x>29</x>
+     <y>19</y>
+     <width>401</width>
+     <height>121</height>
+    </rect>
+   </property>
+   <layout class="QGridLayout" name="gridLayout">
+    <item row="2" column="0">
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QRadioButton" name="endAddressRadioButton">
+        <property name="text">
+         <string>End Address:</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">buttonGroup</string>
+        </attribute>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item row="0" column="0">
+     <widget class="QLabel" name="startAddressLabel">
+      <property name="text">
+       <string>Start Address:</string>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="1">
+     <widget class="QLineEdit" name="startAddressLineEdit">
+      <property name="maxLength">
+       <number>18</number>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="1">
+     <widget class="QLineEdit" name="endAddressLineEdit">
+      <property name="maxLength">
+       <number>18</number>
+      </property>
+     </widget>
+    </item>
+    <item row="3" column="1">
+     <widget class="QLineEdit" name="lengthLineEdit">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="maxLength">
+       <number>10</number>
+      </property>
+     </widget>
+    </item>
+    <item row="3" column="0">
+     <widget class="QRadioButton" name="lengthRadioButton">
+      <property name="text">
+       <string>Length:</string>
+      </property>
+      <attribute name="buttonGroup">
+       <string notr="true">buttonGroup</string>
+      </attribute>
+     </widget>
+    </item>
+    <item row="4" column="1">
+     <widget class="QLabel" name="selectionWarningLabel">
+      <property name="enabled">
+       <bool>true</bool>
+      </property>
+      <property name="visible">
+       <bool>false</bool>
+      </property>
+      <property name="text">
+       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#cc0000;&quot;&gt;Big selection might cause with slow operation&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>HexdumpRangeDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>HexdumpRangeDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+ <buttongroups>
+  <buttongroup name="buttonGroup"/>
+ </buttongroups>
+</ui>

--- a/src/dialogs/HexdumpRangeDialog.ui
+++ b/src/dialogs/HexdumpRangeDialog.ui
@@ -106,7 +106,7 @@
        <bool>false</bool>
       </property>
       <property name="text">
-       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#cc0000;&quot;&gt;Big selection might cause with slow operation&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff8585;&quot;&gt;Big selection might cause with slow operation&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
       </property>
      </widget>
     </item>

--- a/src/dialogs/HexdumpRangeDialog.ui
+++ b/src/dialogs/HexdumpRangeDialog.ui
@@ -106,7 +106,7 @@
        <bool>false</bool>
       </property>
       <property name="text">
-       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff8585;&quot;&gt;Big selection might cause with slow operation&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff8585;&quot;&gt;Big selection might cause a delay&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
       </property>
      </widget>
     </item>

--- a/src/widgets/HexdumpWidget.h
+++ b/src/widgets/HexdumpWidget.h
@@ -11,6 +11,7 @@
 #include "Cutter.h"
 #include "CutterDockWidget.h"
 #include "CutterSeekableWidget.h"
+#include "dialogs/HexdumpRangeDialog.h"
 #include "common/Highlighter.h"
 #include "common/HexAsciiHighlighter.h"
 #include "common/HexHighlighter.h"
@@ -44,7 +45,7 @@ public:
 
 public slots:
     void initParsing();
-
+    void on_rangeDialogAccepted();
     void showOffsets(bool show);
 
     void zoomIn(int range = 1);
@@ -102,6 +103,9 @@ private:
 
     int bufferLines = 0;
     int cols = 0;
+    ut64 requestedSelectionStartAddress=0;
+    ut64 requestedSelectionEndAddress=0;
+    HexdumpRangeDialog  rangeDialog;
     QAction syncAction;
     CutterSeekableWidget *seekable;
 
@@ -136,6 +140,8 @@ private slots:
 
     void on_actionFormatHex_triggered();
     void on_actionFormatOctal_triggered();
+
+    void on_actionSelect_Block_triggered();
 
     void fontsUpdated();
     void colorsUpdatedSlot();

--- a/src/widgets/HexdumpWidget.ui
+++ b/src/widgets/HexdumpWidget.ui
@@ -64,43 +64,6 @@
          <property name="spacing">
           <number>0</number>
          </property>
-         <item row="1" column="2">
-          <widget class="QTextEdit" name="hexHexText">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="acceptDrops">
-            <bool>false</bool>
-           </property>
-           <property name="frameShape">
-            <enum>QFrame::NoFrame</enum>
-           </property>
-           <property name="lineWidth">
-            <number>0</number>
-           </property>
-           <property name="verticalScrollBarPolicy">
-            <enum>Qt::ScrollBarAlwaysOff</enum>
-           </property>
-           <property name="horizontalScrollBarPolicy">
-            <enum>Qt::ScrollBarAlwaysOff</enum>
-           </property>
-           <property name="sizeAdjustPolicy">
-            <enum>QAbstractScrollArea::AdjustToContents</enum>
-           </property>
-           <property name="lineWrapMode">
-            <enum>QTextEdit::NoWrap</enum>
-           </property>
-           <property name="cursorWidth">
-            <number>3</number>
-           </property>
-           <property name="textInteractionFlags">
-            <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-           </property>
-          </widget>
-         </item>
          <item row="1" column="3">
           <widget class="Line" name="line_2">
            <property name="orientation">
@@ -219,6 +182,34 @@
           <widget class="Line" name="line">
            <property name="orientation">
             <enum>Qt::Vertical</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="2">
+          <widget class="QTextEdit" name="hexHexText">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="acceptDrops">
+            <bool>false</bool>
+           </property>
+           <property name="frameShape">
+            <enum>QFrame::NoFrame</enum>
+           </property>
+           <property name="lineWidth">
+            <number>0</number>
+           </property>
+           <property name="verticalScrollBarPolicy">
+            <enum>Qt::ScrollBarAlwaysOff</enum>
+           </property>
+           <property name="horizontalScrollBarPolicy">
+            <enum>Qt::ScrollBarAlwaysOff</enum>
+           </property>
+           <property name="sizeAdjustPolicy">
+            <enum>QAbstractScrollArea::AdjustToContents</enum>
            </property>
           </widget>
          </item>
@@ -910,6 +901,11 @@
    </property>
    <property name="toolTip">
     <string>4 bytes</string>
+   </property>
+  </action>
+  <action name="actionSelect_Block">
+   <property name="text">
+    <string>Select Block...</string>
    </property>
   </action>
  </widget>

--- a/src/widgets/HexdumpWidget.ui
+++ b/src/widgets/HexdumpWidget.ui
@@ -211,6 +211,9 @@
            <property name="sizeAdjustPolicy">
             <enum>QAbstractScrollArea::AdjustToContents</enum>
            </property>
+           <property name="textInteractionFlags">
+            <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+           </property>
           </widget>
          </item>
         </layout>


### PR DESCRIPTION
This code was mainly created by @jamieb122 in #770 -- good job!
Sadly he became busy so I'm sending a PR with a modified and improved version of the PR.

<img src="https://user-images.githubusercontent.com/20182642/50157622-9a845280-02da-11e9-97bc-09f8e0bdbeaf.gif" width="70%" height="70%">

Extra modifications:
 - Accept only hexadecimal characters
 - Make sure Length is not a negative number
 - Warn the user before performing heavy operation

**Closing issues**

Closes #761 