### PR TITLE
Make Plugin window bigger for readability (fix #1032)

### DIFF
--- a/src/dialogs/R2PluginsDialog.ui
+++ b/src/dialogs/R2PluginsDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>506</width>
-    <height>310</height>
+    <width>618</width>
+    <height>642</height>
    </rect>
   </property>
   <property name="windowTitle">


### PR DESCRIPTION
Now the Plugin dialog is bigger and includes more information. This will increase reability

![image](https://user-images.githubusercontent.com/20182642/50496559-1bf18880-0a31-11e9-8ec1-044a569ad56b.png)


**Closing issues**

Closing #1032 
