### PR TITLE
Set Analysis configuration before executing Analysis commands

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -378,10 +378,6 @@ void MainWindow::openProject(const QString &project_name)
 void MainWindow::finalizeOpen()
 {
     core->getOpcodes();
-
-    // Override any incorrect setting saved in the project
-    core->setSettings();
-
     core->updateSeek();
     core->message(tr(" > Populating UI"));
     refreshAll();

--- a/src/dialogs/InitialOptionsDialog.cpp
+++ b/src/dialogs/InitialOptionsDialog.cpp
@@ -178,6 +178,16 @@ QList<QString> InitialOptionsDialog::getSelectedAdvancedAnalCmds()
 {
     QList<QString> advanced = QList<QString>();
     if (ui->analSlider->value() == 3) {
+        // Enable analysis configurations before executing analysis commands
+        if (ui->jmptbl->isChecked()) {
+            advanced << "e! anal.jmptbl";
+        }
+        if (ui->pushret->isChecked()) {
+            advanced << "e! anal.pushret";
+        }
+        if (ui->hasnext->isChecked()) {
+            advanced << "e! anal.hasnext";
+        }
         if (ui->aa_symbols->isChecked()) {
             advanced << "aa";
         }
@@ -207,15 +217,6 @@ QList<QString> InitialOptionsDialog::getSelectedAdvancedAnalCmds()
         }
         if (ui->aap_preludes->isChecked()) {
             advanced << "aap";
-        }
-        if (ui->jmptbl->isChecked()) {
-            advanced << "e! anal.jmptbl";
-        }
-        if (ui->pushret->isChecked()) {
-            advanced << "e! anal.pushret";
-        }
-        if (ui->hasnext->isChecked()) {
-            advanced << "e! anal.hasnext";
         }
     }
     return advanced;


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

This PR holds two changes:
 - Set Analysis configuration before executing Analysis commands. This is the expected way, where the analysis is affected by the analysis settings configured by the user.
 - Remove (probably) unnecessary commands that reset the configurations which were set by the user

**Test plan (required)**

First, enable "anal.hasnext" via the Advanced Analysis window

![image](https://user-images.githubusercontent.com/20182642/50589420-342d3180-0e8f-11e9-997d-fe6fedc580e9.png)


Check console for the settings:
![image](https://user-images.githubusercontent.com/20182642/50589541-c2091c80-0e8f-11e9-93f7-e838e3381dde.png)

_before the fix, the number of functions detected by cutter was ~50% less_


**Closing issues**

closes #1047
