### PR TITLE
docker/Dockerfile: Add check for image building

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,6 +31,9 @@ RUN git clone --recurse-submodules https://github.com/radareorg/cutter.git && \
 WORKDIR /opt/cutter
 RUN bash build.sh
 
+# Check it afterwards
+RUN bash -c 'if [[ ! -x "/opt/cutter/build/Cutter" ]]; then exit -1; fi'
+
 # Add r2 user
 RUN useradd r2
 


### PR DESCRIPTION
This adds a check for the `Cutter` binary in the docker build process to avoid issues as seen in #1001.

After merging this commit, a build should be automatically triggered and a working images will be produced as confirmed by building the image using `--no-cache` with the current git state.