### PR TITLE
Enforce LTR layout

### DIFF
--- a/src/CutterApplication.cpp
+++ b/src/CutterApplication.cpp
@@ -30,6 +30,7 @@ CutterApplication::CutterApplication(int &argc, char **argv) : QApplication(argc
     setApplicationVersion(CUTTER_VERSION_FULL);
     setWindowIcon(QIcon(":/img/cutter.svg"));
     setAttribute(Qt::AA_DontShowIconsInMenus);
+    setLayoutDirection(Qt::LeftToRight);
 
     // WARN!!! Put initialization code below this line. Code above this line is mandatory to be run First
     // Load translations


### PR DESCRIPTION
This PR enforces Left-To-Right layout in Cutter and ignore the Locale system of the operation system.

**Before changes:**

![image](https://user-images.githubusercontent.com/20182642/51077442-9ff17480-16af-11e9-94cc-ab422701dc91.png)

--

![image](https://user-images.githubusercontent.com/20182642/51077425-628ce700-16af-11e9-8164-f26d91bf34c8.png)

--

![image](https://user-images.githubusercontent.com/20182642/51077426-6c164f00-16af-11e9-8c98-76fa70362713.png)


--




**Closing issues**

closes #1098
