### PR TITLE
Replace R_FREE() with r_mem_free()

### DIFF
--- a/src/common/ColorSchemeFileSaver.cpp
+++ b/src/common/ColorSchemeFileSaver.cpp
@@ -30,7 +30,7 @@ ColorSchemeFileSaver::ColorSchemeFileSaver(QObject *parent) : QObject (parent)
 {
     char* szThemes = r_str_home(R2_HOME_THEMES);
     customR2ThemesLocationPath = szThemes;
-    R_FREE(szThemes);
+    r_mem_free(szThemes);
     if (!QDir(customR2ThemesLocationPath).exists()) {
         QDir().mkpath(customR2ThemesLocationPath);
     }


### PR DESCRIPTION
Calling `R_FREE()` leads to heap corruption under debugging.