### PR TITLE
Fixed .travis.yml due to new linuxdeployqt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,7 +106,7 @@ after_success:
       LD_LIBRARY_PATH=$CUSTOM_PYTHON_PREFIX/lib ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage -no-strip -exclude-libs=libnss3.so,libnssutil3.so -ignore-glob=usr/lib/python3.6/** -verbose=2 &&
       find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq &&
       export APPIMAGE_FILE="Cutter-v$CUTTER_VERSION-x64.Linux.AppImage" &&
-      mv Cutter-x86_64.AppImage "$APPIMAGE_FILE" &&
+      mv Cutter-*-x86_64.AppImage "$APPIMAGE_FILE" &&
       export FILE_TO_UPLOAD="$APPIMAGE_FILE"
     ; fi
 


### PR DESCRIPTION
The new version of linuxdeployqt (AppImage)
seems to change the name of the created
AppImage.