### PR TITLE
Translations deployment for MAC & Linux has fixed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,10 @@ script:
 
 after_success:
   - export CUTTER_VERSION=$(python ../scripts/get_version.py)
+  - lrelease ../src/Cutter.pro
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      mkdir -p Cutter.app/Contents/Resources/translations &&
+      cp ../src/translations/*.qm Cutter.app/Contents/Resources/translations/ &&
       macdeployqt Cutter.app -executable=Cutter.app/Contents/MacOS/Cutter -libpath="../Frameworks" &&
       macdeployqt Cutter.app -executable=Cutter.app/Contents/MacOS/Cutter -libpath="../Frameworks" &&
       "$TRAVIS_BUILD_DIR/scripts/appbundle_embed_python.sh" "$PYTHON_FRAMEWORK_DIR/Python.framework" Cutter.app Cutter.app/Contents/MacOS/Cutter &&
@@ -98,6 +101,8 @@ after_success:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       make INSTALL_ROOT=appdir install &&
       cp -r /usr/share/radare2 appdir/usr/share/ &&
+      mkdir -p appdir/usr/bin/translations &&
+      cp ../src/translations/*.qm appdir/usr/bin/translations/ &&
       "$TRAVIS_BUILD_DIR/scripts/appimage_embed_python.sh" "$CUSTOM_PYTHON_PREFIX" appdir &&
       wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" &&
       chmod a+x linuxdeployqt*.AppImage &&

--- a/src/CutterApplication.cpp
+++ b/src/CutterApplication.cpp
@@ -248,13 +248,23 @@ bool CutterApplication::loadTranslations()
                 + QStringLiteral("translations");
             const QString &translationsPath(QLibraryInfo::location(QLibraryInfo::TranslationsPath));
 
-            // const QString &cutterDirectPath = cutterTranslationPath + QDir::separator() + QString("cutter_%1.qm").arg(langPrefix);
+            const QStringList &cutterTrPaths = {
+                cutterTranslationPath,
+                translationsPath,
+#ifdef Q_OS_MAC
+                QStringLiteral("%1/../Resources/translations").arg(QCoreApplication::applicationDirPath()),
+#endif // Q_OS_MAC
+            };
 
-            if (t->load(it, QLatin1String("cutter"), QLatin1String("_"), cutterTranslationPath) ||
-                t->load(it, QLatin1String("cutter"), QLatin1String("_"), translationsPath)) {
-                installTranslator(t);
+            bool cutterTrLoaded = false;
+            for (const auto &trPath : cutterTrPaths) {
+                if (t->load(it, QLatin1String("cutter"), QLatin1String("_"), trPath)) {
+                    installTranslator(t);
+                    cutterTrLoaded = true;
+                    break;
+                }
             }
-            else {
+            if (!cutterTrLoaded) {
                 qWarning() << "Cannot load Cutter's translation for " << language;
                 delete t;
             }

--- a/src/CutterApplication.cpp
+++ b/src/CutterApplication.cpp
@@ -231,9 +231,9 @@ void CutterApplication::loadPlugins()
 bool CutterApplication::loadTranslations()
 {
     const QString &language = Config()->getCurrLocale().bcp47Name();
-    if (language == QStringLiteral("en") || language.startsWith(QStringLiteral("en-")))
+    if (language == QStringLiteral("en") || language.startsWith(QStringLiteral("en-"))) {
         return true;
-
+    }
     const auto &allLocales = QLocale::matchingLocales(QLocale::AnyLanguage, QLocale::AnyScript,
         QLocale::AnyCountry);
 
@@ -268,13 +268,15 @@ bool CutterApplication::loadTranslations()
                 }
             }
             
-            if (trCutter)
+            if (trCutter) {
                 delete trCutter;
-            if (trQt)
+            }
+            if (trQt) {
                 delete trQt;
-            if (trQtBase)
+            }
+            if (trQtBase) {
                 delete trQtBase;
-
+            }
             return true;
         }
     }

--- a/src/CutterApplication.h
+++ b/src/CutterApplication.h
@@ -27,6 +27,10 @@ protected:
     bool event(QEvent *e);
 
 private:
+    /*!
+     * \brief Load and translations depending on Language settings
+     * \return true on success
+     */
     bool loadTranslations();
 
 private:

--- a/src/CutterApplication.h
+++ b/src/CutterApplication.h
@@ -27,6 +27,9 @@ protected:
     bool event(QEvent *e);
 
 private:
+    bool loadTranslations();
+
+private:
     bool m_FileAlreadyDropped;
     MainWindow *mainWindow;
 };

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -7,6 +7,10 @@ int main(int argc, char *argv[])
     qRegisterMetaType<QList<StringDescription>>();
     qRegisterMetaType<QList<FunctionDescription>>();
 
+    // Application info setup, required to be set before any instance of QSettings will be instantiated
+    QCoreApplication::setOrganizationName("Cutter");
+    QCoreApplication::setApplicationName("Cutter");
+
     CutterApplication a(argc, argv);
 
     int ret = a.exec();

--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -55,12 +55,13 @@ static const QHash<QString, QVariant> asmOptions = {
 Configuration::Configuration() : QObject()
 {
     mPtr = this;
-    if (!s.isWritable())
+    if (!s.isWritable()) {
         QMessageBox::critical(nullptr,
             tr("Critical!"),
             tr("!!! Settings are not writable! Make sure you have a write access to \"%1\"")
                 .arg(s.fileName())
         );
+    }
     loadInitial();
 }
 
@@ -468,12 +469,14 @@ QStringList Configuration::getAvailableTranslations()
     QSet<QString> fileNamesSet;
     for (const auto &trDir : trDirs) {
         QDir dir(trDir);
-        if (!dir.exists())
+        if (!dir.exists()) {
             continue;
+        }
         const QStringList &currTrFileNames = dir.entryList(QStringList("cutter_*.qm"), QDir::Files,
             QDir::Name);
-        for (const auto &trFile : currTrFileNames)
+        for (const auto &trFile : currTrFileNames) {
             fileNamesSet << trFile;
+        }
     }
 
     QStringList fileNames = fileNamesSet.toList();

--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -54,6 +54,12 @@ static const QHash<QString, QVariant> asmOptions = {
 Configuration::Configuration() : QObject()
 {
     mPtr = this;
+    if (!s.isWritable())
+        QMessageBox::critical(nullptr,
+            tr("Critical!"),
+            tr("!!! Settings are not writable! Make sure you have a write access to \"%1\"")
+                .arg(s.fileName())
+        );
     loadInitial();
 }
 
@@ -74,7 +80,7 @@ void Configuration::loadInitial()
 QString Configuration::getDirProjects()
 {
     auto projectsDir = s.value("dir.projects").toString();
-    if (projectsDir == "") {
+    if (projectsDir.isEmpty()) {
         projectsDir = Core()->getConfig("dir.projects");
         setDirProjects(projectsDir);
     }
@@ -126,7 +132,7 @@ QLocale Configuration::getCurrLocale() const
 
 /*!
  * \brief sets Cutter's locale
- * \param l - a QLocale object describes the locate to confugre
+ * \param l - a QLocale object describes the locate to configure
  */
 void Configuration::setLocale(const QLocale &l)
 {
@@ -136,18 +142,20 @@ void Configuration::setLocale(const QLocale &l)
 /*!
  * \brief set Cutter's interface language by a given locale name
  * \param language - a string represents the name of a locale language
+ * \return true on success
  */
-void Configuration::setLocaleByName(const QString &language)
+bool Configuration::setLocaleByName(const QString &language)
 {
-    auto allLocales = QLocale::matchingLocales(QLocale::AnyLanguage, QLocale::AnyScript,
+    const auto &allLocales = QLocale::matchingLocales(QLocale::AnyLanguage, QLocale::AnyScript,
                                                QLocale::AnyCountry);
 
     for (auto &it : allLocales) {
         if (QString::compare(it.nativeLanguageName(), language, Qt::CaseInsensitive) == 0) {
             setLocale(it);
-            break;
+            return true;
         }
     }
+    return false;
 }
 
 bool Configuration::windowColorIsDark()

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -108,6 +108,7 @@ public:
     void setConfig(const QString &key, const QVariant &value);
     bool isFirstExecution();
 
+    QStringList getTranslationsDirectories() const;
 
 signals:
     void fontsUpdated();

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -50,7 +50,7 @@ public:
     // Languages
     QLocale getCurrLocale() const;
     void setLocale(const QLocale &l);
-    void setLocaleByName(const QString &language);
+    bool setLocaleByName(const QString &language);
     QStringList getAvailableTranslations();
 
     // Fonts

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -107,7 +107,11 @@ public:
      */
     void setConfig(const QString &key, const QVariant &value);
     bool isFirstExecution();
-
+    
+    /*!
+     * \brief Get list of available translation directories (depends on configuration and OS)
+     * \return list of directories
+     */
     QStringList getTranslationsDirectories() const;
 
 signals:

--- a/src/dialogs/WelcomeDialog.cpp
+++ b/src/dialogs/WelcomeDialog.cpp
@@ -16,6 +16,7 @@ WelcomeDialog::WelcomeDialog(QWidget *parent) :
     ui(new Ui::WelcomeDialog)
 {
     ui->setupUi(this);
+    setWindowFlag(Qt::WindowContextHelpButtonHint, false);
     ui->logoSvgWidget->load(Config()->getLogoFile());
     ui->versionLabel->setText("<font color='#a4a9b2'>" + tr("Version ") + CUTTER_VERSION_FULL + "</font>");
     ui->themeComboBox->setCurrentIndex(Config()->getTheme());

--- a/src/dialogs/preferences/AppearanceOptionsWidget.cpp
+++ b/src/dialogs/preferences/AppearanceOptionsWidget.cpp
@@ -185,12 +185,12 @@ void AppearanceOptionsWidget::on_deleteButton_clicked()
 void AppearanceOptionsWidget::onLanguageComboBoxCurrentIndexChanged(int index)
 {
     QString language = ui->languageComboBox->itemText(index).toLower();
-    Config()->setLocaleByName(language);
+    if (Config()->setLocaleByName(language)) {
+        QMessageBox::information(this,
+            tr("Language settings"),
+            tr("Language will be changed after next application start."));
+        return;
+    }
 
-    QMessageBox mb;
-    mb.setWindowTitle(tr("Language settings"));
-    mb.setText(tr("Language will be changed after next application start."));
-    mb.setIcon(QMessageBox::Information);
-    mb.setStandardButtons(QMessageBox::Ok);
-    mb.exec();
+    qWarning() << tr("Cannot set language, not found in available ones");
 }

--- a/src/dialogs/preferences/PreferencesDialog.cpp
+++ b/src/dialogs/preferences/PreferencesDialog.cpp
@@ -20,6 +20,7 @@ PreferencesDialog::PreferencesDialog(QWidget *parent)
 {
     setAttribute(Qt::WA_DeleteOnClose);
     ui->setupUi(this);
+    setWindowFlag(Qt::WindowContextHelpButtonHint, false);
 
     QList<PreferenceCategory> prefs {
 


### PR DESCRIPTION
* Refactored translations logic
* Now we have few translations locations and looks for translations files there
* Organization and an Application name initialization moved to the early beginning to avoid usage of uninitialized `QSettings`
* More verbose error handling if We cannot switch Language or cannot write anything to the `QSettings`
* Removed help `?` button from Welcome and Preferences dialogs

**Test plan (required)**

* Linux:
    * download deployed `AppImage`
    * run it, open any executable and then open Preferences dialog
    * open `Appearance` section and check that there are some translations (except English) are available to choose:
![image](https://user-images.githubusercontent.com/14978853/51434256-9054cb80-1c6d-11e9-861a-6e4b07161a3e.png)
    * select any language you like, then close Preferences dialog and close Cutter
    * reopen Cutter AppImage and open preferences, check that Language settings was stored ok. There are not full translations for all the Languages, but you may notice that `Italiano` and `Russian` are translated well:
![image](https://user-images.githubusercontent.com/14978853/51434271-f6d9e980-1c6d-11e9-8eab-a1f1cdf3d283.png)

* MAC:
    * download `.dmg` file and install new version of Cutter from it
    * run it, open any executable and then open Preferences dialog
    * open `Appearance` section and check that there are some translations (except English) are available to choose:
    <img width="442" alt="screen shot 2019-01-20 at 04 25 28" src="https://user-images.githubusercontent.com/14978853/51434316-0ad21b00-1c6f-11e9-8e12-27ba9ba86e35.png">

    * select any language you like, then close Preferences dialog and close Cutter
    * reopen Cutter AppImage and open preferences, check that Language settings was stored ok. 
