### PR TITLE
Fix CutterSeekable isSynchronized() and signal on de-syncing

### DIFF
--- a/src/common/CutterSeekable.cpp
+++ b/src/common/CutterSeekable.cpp
@@ -16,17 +16,15 @@ CutterSeekable::~CutterSeekable() {}
 void CutterSeekable::onCoreSeekChanged(RVA addr)
 {
     if (synchronized && widgetOffset != addr) {
-        synchronized = false;
-        seek(addr);
-        synchronized = true;
+        updateSeek(addr, true);
     }
 }
 
-void CutterSeekable::seek(RVA addr)
+void CutterSeekable::updateSeek(RVA addr, bool localOnly)
 {
     previousOffset = widgetOffset;
     widgetOffset = addr;
-    if (synchronized) {
+    if (synchronized && !localOnly) {
         Core()->seek(addr);
     }
 
@@ -51,6 +49,7 @@ RVA CutterSeekable::getOffset()
 void CutterSeekable::toggleSynchronization()
 {
     synchronized = !synchronized;
+    onCoreSeekChanged(Core()->getOffset());
 }
 
 bool CutterSeekable::isSynchronized()

--- a/src/common/CutterSeekable.h
+++ b/src/common/CutterSeekable.h
@@ -20,7 +20,7 @@ public:
      * In any case, CutterSeekable::seekableSeekChanged is emitted.
      * @param addr the location to seek at.
      */
-    void seek(RVA addr);
+    void seek(RVA addr) { updateSeek(addr, false); }
 
     /**
      * @brief toggleSyncWithCore toggles
@@ -73,6 +73,12 @@ private:
      * synchronized with core or not.
      */
     bool synchronized = true;
+
+    /**
+     * @brief internal method for changing the seek
+     * @param localOnly whether the seek should be updated globally if synchronized
+     */
+    void updateSeek(RVA addr, bool localOnly);
 
 signals:
     void seekableSeekChanged(RVA addr);


### PR DESCRIPTION
Also fixes incorrect "(unsynced)" in the graph widget's title.