### PR TITLE
 Prevent r2 injection when opening a file

### DIFF
--- a/src/Cutter.cpp
+++ b/src/Cutter.cpp
@@ -397,10 +397,14 @@ bool CutterCore::tryFile(QString path, bool rw)
 
 void CutterCore::openFile(QString path, RVA mapaddr)
 {
-    if (mapaddr != RVA_INVALID) {
-        cmd("o " + path + QString(" %1").arg(mapaddr));
-    } else {
-        cmd("o " + path);
+    CORE_LOCK();
+    RVA addr = mapaddr != RVA_INVALID ? mapaddr : 0;
+    ut64 baddr = Core()->getFileInfo().object()["bin"].toObject()["baddr"].toVariant().toULongLong();
+    if(r_core_file_open(core_, path.toUtf8().constData(), R_PERM_RX, addr)){
+        r_core_bin_load(core_, path.toUtf8().constData(), baddr);
+    }
+    else{
+        eprintf("Cannot open file\n");
     }
 }
 

--- a/src/Cutter.cpp
+++ b/src/Cutter.cpp
@@ -395,6 +395,12 @@ bool CutterCore::tryFile(QString path, bool rw)
     return true;
 }
 
+/*!
+ * \brief Opens a file using r2 API
+ * \param path Path to file
+ * \param mapaddr Map Address
+ * \return bool
+ */
 bool CutterCore::openFile(QString path, RVA mapaddr)
 {
     CORE_LOCK();
@@ -402,8 +408,7 @@ bool CutterCore::openFile(QString path, RVA mapaddr)
     ut64 baddr = Core()->getFileInfo().object()["bin"].toObject()["baddr"].toVariant().toULongLong();
     if (r_core_file_open(core_, path.toUtf8().constData(), R_PERM_RX, addr)) {
         r_core_bin_load(core_, path.toUtf8().constData(), baddr);
-    }
-    else{
+    } else {
         return false;
     }
     return true;

--- a/src/Cutter.cpp
+++ b/src/Cutter.cpp
@@ -395,17 +395,18 @@ bool CutterCore::tryFile(QString path, bool rw)
     return true;
 }
 
-void CutterCore::openFile(QString path, RVA mapaddr)
+bool CutterCore::openFile(QString path, RVA mapaddr)
 {
     CORE_LOCK();
     RVA addr = mapaddr != RVA_INVALID ? mapaddr : 0;
     ut64 baddr = Core()->getFileInfo().object()["bin"].toObject()["baddr"].toVariant().toULongLong();
-    if(r_core_file_open(core_, path.toUtf8().constData(), R_PERM_RX, addr)){
+    if (r_core_file_open(core_, path.toUtf8().constData(), R_PERM_RX, addr)) {
         r_core_bin_load(core_, path.toUtf8().constData(), baddr);
     }
     else{
-        eprintf("Cannot open file\n");
+        return false;
     }
+    return true;
 }
 
 void CutterCore::renameFunction(const QString &oldName, const QString &newName)

--- a/src/Cutter.h
+++ b/src/Cutter.h
@@ -449,7 +449,7 @@ public:
     bool loadFile(QString path, ut64 baddr = 0LL, ut64 mapaddr = 0LL, int perms = R_PERM_R,
                   int va = 0, bool loadbin = false, const QString &forceBinPlugin = QString());
     bool tryFile(QString path, bool rw);
-    void openFile(QString path, RVA mapaddr);
+    bool openFile(QString path, RVA mapaddr);
     void loadScript(const QString &scriptname);
     QJsonArray getOpenedFiles();
 

--- a/src/dialogs/OpenFileDialog.cpp
+++ b/src/dialogs/OpenFileDialog.cpp
@@ -35,6 +35,7 @@ void OpenFileDialog::on_buttonBox_accepted()
     if(filePath.contains(';') || filePath.contains('|')){
         QMessageBox msgBox(this);
         msgBox.setText(tr("File name contains invalid characters"));
+        msgBox.setWindowTitle("Invalid filename");
         msgBox.exec();
         return;     // keep the dialog open
     }

--- a/src/dialogs/OpenFileDialog.cpp
+++ b/src/dialogs/OpenFileDialog.cpp
@@ -30,7 +30,10 @@ void OpenFileDialog::on_buttonBox_accepted()
         mapAddress = Core()->math(mapAddressStr);
     }
 
-    Core()->openFile(filePath, mapAddress);
+    if (!Core()->openFile(filePath, mapAddress)) {
+        QMessageBox::critical(this, tr("Open file"), tr("Failed to open file"));
+        return;
+    }
     close();
 }
 

--- a/src/dialogs/OpenFileDialog.cpp
+++ b/src/dialogs/OpenFileDialog.cpp
@@ -29,7 +29,16 @@ void OpenFileDialog::on_buttonBox_accepted()
     if (!mapAddressStr.isEmpty()) {
         mapAddress = Core()->math(mapAddressStr);
     }
+
+    if(filePath.contains(';') || filePath.contains('|')){
+        QMessageBox msgBox(this);
+        msgBox.setText(tr("File name contains invalid characters"));
+        msgBox.exec();
+        return;
+    }
+
     Core()->openFile(filePath, mapAddress);
+    close();
 }
 
 void OpenFileDialog::on_buttonBox_rejected()

--- a/src/dialogs/OpenFileDialog.cpp
+++ b/src/dialogs/OpenFileDialog.cpp
@@ -30,11 +30,13 @@ void OpenFileDialog::on_buttonBox_accepted()
         mapAddress = Core()->math(mapAddressStr);
     }
 
+    // check for invalid characters to prevent r2 injection
+
     if(filePath.contains(';') || filePath.contains('|')){
         QMessageBox msgBox(this);
         msgBox.setText(tr("File name contains invalid characters"));
         msgBox.exec();
-        return;
+        return;     // keep the dialog open
     }
 
     Core()->openFile(filePath, mapAddress);

--- a/src/dialogs/OpenFileDialog.cpp
+++ b/src/dialogs/OpenFileDialog.cpp
@@ -30,16 +30,6 @@ void OpenFileDialog::on_buttonBox_accepted()
         mapAddress = Core()->math(mapAddressStr);
     }
 
-    // check for invalid characters to prevent r2 injection
-
-    if(filePath.contains(';') || filePath.contains('|')){
-        QMessageBox msgBox(this);
-        msgBox.setText(tr("File name contains invalid characters"));
-        msgBox.setWindowTitle("Invalid filename");
-        msgBox.exec();
-        return;     // keep the dialog open
-    }
-
     Core()->openFile(filePath, mapAddress);
     close();
 }

--- a/src/dialogs/OpenFileDialog.ui
+++ b/src/dialogs/OpenFileDialog.ui
@@ -48,7 +48,7 @@
      <x>10</x>
      <y>20</y>
      <width>241</width>
-     <height>27</height>
+     <height>29</height>
     </rect>
    </property>
    <layout class="QHBoxLayout" name="horizontalLayout">
@@ -124,22 +124,6 @@
  </widget>
  <resources/>
  <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>OpenFileDialog</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
   <connection>
    <sender>buttonBox</sender>
    <signal>rejected()</signal>


### PR DESCRIPTION
When opening a file from File->Open menu the file name is passed to cmd() without validation which can lead to execution of various commands. I have added some code to prevent the above behaviour.