### PR TITLE
Fix a resizing issue

### DIFF
--- a/src/widgets/OverviewWidget.cpp
+++ b/src/widgets/OverviewWidget.cpp
@@ -24,6 +24,12 @@ OverviewWidget::OverviewWidget(MainWindow *main, QAction *action) :
 
 OverviewWidget::~OverviewWidget() {}
 
+void OverviewWidget::resizeEvent(QResizeEvent *event)
+{
+    graphView->refreshView();
+    QDockWidget::resizeEvent(event);
+}
+
 void OverviewWidget::updateContents()
 {
     if (!refreshDeferrer->attemptRefresh(nullptr)) {

--- a/src/widgets/OverviewWidget.h
+++ b/src/widgets/OverviewWidget.h
@@ -17,6 +17,10 @@ public:
 
 private:
     RefreshDeferrer *refreshDeferrer;
+    /**
+     * @brief this takes care of scaling the overview when the widget is resized
+     */
+    void resizeEvent(QResizeEvent *event) override;
 
 private slots:
     /**


### PR DESCRIPTION
Tied with https://github.com/radareorg/cutter/pull/1120

Small bug fix, like when you resize the overview dock then it shows scrollbar instead of handling scaling the view.

Now no scrollbar shown.