### PR TITLE
Fixed infinite recursion in OverviewView

### DIFF
--- a/src/widgets/OverviewView.cpp
+++ b/src/widgets/OverviewView.cpp
@@ -88,7 +88,7 @@ void OverviewView::mousePressEvent(QMouseEvent *event)
     rangeRect = QRectF(x, y, w, h);
     viewport()->update();
     emit mouseMoved();
-    mousePressEvent(event);
+    GraphView::mousePressEvent(event);
 }
 
 void OverviewView::mouseReleaseEvent(QMouseEvent *event)


### PR DESCRIPTION
It was calling itself at the end of the function
instead of calling the parent's mousePressEvent
function.