### PR TITLE
Added support for automatically saving and opening recent folder

### DIFF
--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -95,6 +95,18 @@ void Configuration::setDirProjects(const QString &dir)
     s.setValue("dir.projects", QDir::toNativeSeparators(dir));
 }
 
+QString Configuration::getRecentFolder()
+{
+    QString recentFolder = s.value("dir.recentFolder", QDir::homePath()).toString();
+
+    return QDir::toNativeSeparators(recentFolder);
+}
+
+void Configuration::setRecentFolder(const QString &dir)
+{
+    s.setValue("dir.recentFolder", QDir::toNativeSeparators(dir));
+}
+
 /**
  * @brief Configuration::setFilesTabLastClicked
  * Set the new file dialog last clicked tab

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -72,6 +72,9 @@ public:
     QString getDirProjects();
     void setDirProjects(const QString &dir);
 
+    QString getRecentFolder();
+    void setRecentFolder(const QString &dir);
+
     void setNewFileLastClicked(int lastClicked);
     int getNewFileLastClicked();
 

--- a/src/dialogs/NewFileDialog.cpp
+++ b/src/dialogs/NewFileDialog.cpp
@@ -84,7 +84,6 @@ void NewFileDialog::on_loadFileButton_clicked()
 
 void NewFileDialog::on_selectFileButton_clicked()
 {
-    QSettings settings;
     QString currentDir = Config()->getRecentFolder();
     const QString &fileName = QDir::toNativeSeparators(QFileDialog::getOpenFileName(this, tr("Select file"), currentDir));
 

--- a/src/dialogs/NewFileDialog.cpp
+++ b/src/dialogs/NewFileDialog.cpp
@@ -85,13 +85,13 @@ void NewFileDialog::on_loadFileButton_clicked()
 void NewFileDialog::on_selectFileButton_clicked()
 {
     QSettings settings;
-    QString currentDir = settings.value("recentFolder", QDir::homePath()).toString();
+    QString currentDir = Config()->getRecentFolder();
     const QString &fileName = QDir::toNativeSeparators(QFileDialog::getOpenFileName(this, tr("Select file"), currentDir));
 
     if (!fileName.isEmpty()) {
         ui->newFileEdit->setText(fileName);
         ui->loadFileButton->setFocus();
-        settings.setValue("recentFolder", QDir::toNativeSeparators(QFileInfo(fileName).absolutePath()));
+        Config()->setRecentFolder(QFileInfo(fileName).absolutePath());
     }
 }
 

--- a/src/dialogs/NewFileDialog.cpp
+++ b/src/dialogs/NewFileDialog.cpp
@@ -84,11 +84,14 @@ void NewFileDialog::on_loadFileButton_clicked()
 
 void NewFileDialog::on_selectFileButton_clicked()
 {
-    const QString &fileName = QDir::toNativeSeparators(QFileDialog::getOpenFileName(this, tr("Select file"), QDir::homePath()));
+    QSettings settings;
+    QString currentDir = settings.value("recentFolder", QDir::homePath()).toString();
+    const QString &fileName = QDir::toNativeSeparators(QFileDialog::getOpenFileName(this, tr("Select file"), currentDir));
 
     if (!fileName.isEmpty()) {
         ui->newFileEdit->setText(fileName);
         ui->loadFileButton->setFocus();
+        settings.setValue("recentFolder", QDir::toNativeSeparators(QFileInfo(fileName).absolutePath()));
     }
 }
 

--- a/src/dialogs/OpenFileDialog.cpp
+++ b/src/dialogs/OpenFileDialog.cpp
@@ -1,8 +1,9 @@
 #include "OpenFileDialog.h"
 #include "ui_OpenFileDialog.h"
 
+#include "common/Configuration.h"
+
 #include <QFileDialog>
-#include <QSettings>
 
 OpenFileDialog::OpenFileDialog(QWidget *parent):
     QDialog(parent),
@@ -15,13 +16,12 @@ OpenFileDialog::~OpenFileDialog() {}
 
 void OpenFileDialog::on_selectFileButton_clicked()
 {
-    QSettings settings;
-    QString currentDir = settings.value("recentFolder", QDir::homePath()).toString();
+    QString currentDir = Config()->getRecentFolder();
     QString fileName = QFileDialog::getOpenFileName(this, tr("Select file"), currentDir);
 
     if (!fileName.isEmpty()) {
         ui->filenameLineEdit->setText(fileName);
-        settings.setValue("recentFolder", QDir::toNativeSeparators(QFileInfo(fileName).absolutePath()));
+        Config()->setRecentFolder(QFileInfo(fileName).absolutePath());
     }
 }
 

--- a/src/dialogs/OpenFileDialog.cpp
+++ b/src/dialogs/OpenFileDialog.cpp
@@ -2,6 +2,7 @@
 #include "ui_OpenFileDialog.h"
 
 #include <QFileDialog>
+#include <QSettings>
 
 OpenFileDialog::OpenFileDialog(QWidget *parent):
     QDialog(parent),
@@ -14,10 +15,13 @@ OpenFileDialog::~OpenFileDialog() {}
 
 void OpenFileDialog::on_selectFileButton_clicked()
 {
-    QString fileName = QFileDialog::getOpenFileName(this, tr("Select file"), QDir::homePath());
+    QSettings settings;
+    QString currentDir = settings.value("recentFolder", QDir::homePath()).toString();
+    QString fileName = QFileDialog::getOpenFileName(this, tr("Select file"), currentDir);
 
     if (!fileName.isEmpty()) {
         ui->filenameLineEdit->setText(fileName);
+        settings.setValue("recentFolder", QDir::toNativeSeparators(QFileInfo(fileName).absolutePath()));
     }
 }
 


### PR DESCRIPTION
This pull request closes issue #1147 
**Before:** Each time opening a file would take you to the home directory
**After:** Now each time you try to open a file, you will land on the directory from where you opened the previous file (or to the default home directory in case this is your first time opening a file)
