### PR TITLE
Added 'asm.xrefs' option in preferences dialog

### DIFF
--- a/src/dialogs/preferences/AsmOptionsWidget.cpp
+++ b/src/dialogs/preferences/AsmOptionsWidget.cpp
@@ -35,6 +35,7 @@ void AsmOptionsWidget::updateAsmOptionsFromVars()
     qhelpers::setCheckedWithoutSignals(ui->esilCheckBox, Config()->getConfigBool("asm.esil"));
     qhelpers::setCheckedWithoutSignals(ui->pseudoCheckBox, Config()->getConfigBool("asm.pseudo"));
     qhelpers::setCheckedWithoutSignals(ui->offsetCheckBox, Config()->getConfigBool("asm.offset"));
+    qhelpers::setCheckedWithoutSignals(ui->xrefCheckBox, Config()->getConfigBool("asm.xrefs"));
     qhelpers::setCheckedWithoutSignals(ui->describeCheckBox, Config()->getConfigBool("asm.describe"));
     qhelpers::setCheckedWithoutSignals(ui->stackpointerCheckBox, Config()->getConfigBool("asm.stackptr"));
     qhelpers::setCheckedWithoutSignals(ui->slowCheckBox, Config()->getConfigBool("asm.slow"));
@@ -131,6 +132,12 @@ void AsmOptionsWidget::on_pseudoCheckBox_toggled(bool checked)
 void AsmOptionsWidget::on_offsetCheckBox_toggled(bool checked)
 {
     Config()->setConfig("asm.offset", checked);
+    triggerAsmOptionsChanged();
+}
+
+void AsmOptionsWidget::on_xrefCheckBox_toggled(bool checked)
+{
+    Config()->setConfig("asm.xrefs", checked);
     triggerAsmOptionsChanged();
 }
 

--- a/src/dialogs/preferences/AsmOptionsWidget.h
+++ b/src/dialogs/preferences/AsmOptionsWidget.h
@@ -35,6 +35,7 @@ private slots:
     void on_esilCheckBox_toggled(bool checked);
     void on_pseudoCheckBox_toggled(bool checked);
     void on_offsetCheckBox_toggled(bool checked);
+    void on_xrefCheckBox_toggled(bool checked);
     void on_describeCheckBox_toggled(bool checked);
     void on_stackpointerCheckBox_toggled(bool checked);
     void on_slowCheckBox_toggled(bool checked);

--- a/src/dialogs/preferences/AsmOptionsWidget.ui
+++ b/src/dialogs/preferences/AsmOptionsWidget.ui
@@ -46,6 +46,13 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="xrefCheckBox">
+         <property name="text">
+          <string>Show xrefs (asm.xrefs)</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QCheckBox" name="describeCheckBox">
          <property name="text">
           <string>Show opcode description (asm.describe)</string>


### PR DESCRIPTION
I did not realize it was missing until https://github.com/radareorg/cutter/issues/1148