### PR TITLE
Force context menu to show shortcuts fix. Closes #1154

### DIFF
--- a/src/CutterApplication.cpp
+++ b/src/CutterApplication.cpp
@@ -293,10 +293,10 @@ bool CutterApplication::loadTranslations()
 }
 
 
-#if QT_VERSION_CHECK(5, 10, 0) < QT_VERSION
 void CutterProxyStyle::polish(QWidget *widget)
 {
     QProxyStyle::polish(widget);
+#if QT_VERSION_CHECK(5, 10, 0) < QT_VERSION
     // HACK: This is the only way I've found to force Qt (5.10 and newer) to
     //       display shortcuts in context menus on all platforms. It's ugly,
     //       but it gets the job done.
@@ -306,6 +306,6 @@ void CutterProxyStyle::polish(QWidget *widget)
             action->setShortcutVisibleInContextMenu(true);
         }
     }
+#endif // QT_VERSION_CHECK(5, 10, 0) < QT_VERSION
 }
 
-#endif // QT_VERSION_CHECK(5, 10, 0) < QT_VERSION

--- a/src/CutterApplication.h
+++ b/src/CutterApplication.h
@@ -40,7 +40,6 @@ private:
 };
 
 
-#if QT_VERSION_CHECK(5, 10, 0) < QT_VERSION
 /*!
  * \brief CutterProxyStyle is used to force shortcuts displaying in context menu
  */
@@ -53,7 +52,5 @@ public:
      */
     void polish(QWidget *widget) override;
 };
-
-#endif // QT_VERSION_CHECK(5, 10, 0) < QT_VERSION
 
 #endif // CUTTERAPPLICATION_H

--- a/src/CutterApplication.h
+++ b/src/CutterApplication.h
@@ -4,6 +4,7 @@
 #include <QEvent>
 #include <QApplication>
 #include <QList>
+#include <QProxyStyle>
 
 #include "MainWindow.h"
 
@@ -37,5 +38,22 @@ private:
     bool m_FileAlreadyDropped;
     MainWindow *mainWindow;
 };
+
+
+#if QT_VERSION_CHECK(5, 10, 0) < QT_VERSION
+/*!
+ * \brief CutterProxyStyle is used to force shortcuts displaying in context menu
+ */
+class CutterProxyStyle : public QProxyStyle
+{
+    Q_OBJECT
+public:
+    /*!
+     * \brief it is enough to get notification about QMenu polishing to force shortcut displaying
+     */
+    void polish(QWidget *widget) override;
+};
+
+#endif // QT_VERSION_CHECK(5, 10, 0) < QT_VERSION
 
 #endif // CUTTERAPPLICATION_H


### PR DESCRIPTION
This fix forces context menu to display corresponding shortcut with help of `QAction::setShortcutVisibleInContextMenu`

**Test plan (required)**

- open any binary in Cutter, check that context menu has shortcuts:
![image](https://user-images.githubusercontent.com/14978853/52236830-fb8ed680-28d8-11e9-9163-854938b38c57.png)
- change Cutter Theme configuration, repeat the first point. 
- it would be good to check that this fix works on all platforms we support

Closes #1154 
