### PR TITLE
Fixed AboutDialog leaking

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -913,6 +913,7 @@ void MainWindow::on_actionTabs_triggered()
 void MainWindow::on_actionAbout_triggered()
 {
     AboutDialog *a = new AboutDialog(this);
+    a->setAttribute(Qt::WA_DeleteOnClose);
     a->open();
 }
 

--- a/src/dialogs/NewFileDialog.cpp
+++ b/src/dialogs/NewFileDialog.cpp
@@ -165,6 +165,7 @@ void NewFileDialog::on_projectsListWidget_itemDoubleClicked(QListWidgetItem *ite
 void NewFileDialog::on_aboutButton_clicked()
 {
     AboutDialog *a = new AboutDialog(this);
+    a->setAttribute(Qt::WA_DeleteOnClose);
     a->open();
 }
 

--- a/src/dialogs/WelcomeDialog.cpp
+++ b/src/dialogs/WelcomeDialog.cpp
@@ -81,6 +81,7 @@ void WelcomeDialog::onLanguageComboBox_currentIndexChanged(int index)
 void WelcomeDialog::on_checkUpdateButton_clicked()
 {
     AboutDialog *a = new AboutDialog(this);
+    a->setAttribute(Qt::WA_DeleteOnClose);
     a->open();
 }
 


### PR DESCRIPTION
Fixed `AboutDialog` leaking on several places, because the dialog wasn't deleted after close automatically.

**Test plan (required)**

- open and close `AboutDialog` in the `WelcomeDialog` (requires settings reset), `NewFileDialog`, `MainWindow` under memory analyzer or profiler to check is `AboutDialog` will be deleted after close

