### PR TITLE
Set "ayu" the default color theme for dark interface

### DIFF
--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -30,7 +30,6 @@ private:
     void loadInitial();
 
     // Colors
-    bool windowColorIsDark();
     void loadBaseThemeNative();
     void loadBaseThemeDark();
     void loadNativeTheme();
@@ -58,6 +57,7 @@ public:
     void setFont(const QFont &font);
 
     // Colors
+    bool windowColorIsDark();
     void setLastThemeOf(const CutterQtTheme &currQtTheme, const QString& theme);
     QString getLastThemeOf(const CutterQtTheme &currQtTheme) const;
     const QColor getColor(const QString &name) const;

--- a/src/dialogs/WelcomeDialog.cpp
+++ b/src/dialogs/WelcomeDialog.cpp
@@ -54,6 +54,11 @@ void WelcomeDialog::on_themeComboBox_currentIndexChanged(int index)
 {
     Config()->setTheme(index);
 
+    // use "ayu" as the default color theme for dark interface
+    if (Config()->windowColorIsDark()) {
+        Config()->setColorTheme("ayu");
+    }
+
     // make sure that Cutter's logo changes its color according to the selected theme
     ui->logoSvgWidget->load(Config()->getLogoFile());
 }


### PR DESCRIPTION
Currently, when the user chose Dark Theme from the Welcome Window, the color theme was "cutter" which doesn't look good on Dark Themes. As discussed in the past, now the user will get the "ayu" theme to be the default one when using Dark Theme. This only important when the theme is changed using the Welcome Window, upon Cutter's first execution.