### PR TITLE
Fixed memory leak and refactored code

### DIFF
--- a/src/Cutter.cpp
+++ b/src/Cutter.cpp
@@ -2271,11 +2271,22 @@ QString CutterCore::addTypes(const char *str)
     char *error_msg = nullptr;
     char *parsed = r_parse_c_string(core_->anal, str, &error_msg);
 
-    if (!parsed && error_msg) {
-        return QString(error_msg);
+    if (!parsed) {
+         QString ret;
+         if (error_msg) {
+             ret = error_msg;
+             r_mem_free(error_msg);
+         }
+         return ret;
     }
 
     sdb_query_lines(core_->anal->sdb_types, parsed);
+    r_mem_free(parsed);
+
+    if (error_msg) {
+        r_mem_free(error_msg);
+    }
+
     return QString();
 }
 

--- a/src/dialogs/LoadNewTypesDialog.cpp
+++ b/src/dialogs/LoadNewTypesDialog.cpp
@@ -28,11 +28,7 @@ void LoadNewTypesDialog::on_selectFileButton_clicked()
     Config()->setRecentFolder(QFileInfo(filename).absolutePath());
     QFile file(filename);
     if (!file.open(QIODevice::ReadOnly)) {
-        QMessageBox popup(this);
-        popup.setWindowTitle(tr("Error"));
-        popup.setText(file.errorString());
-        popup.setStandardButtons(QMessageBox::Ok);
-        popup.exec();
+        QMessageBox::critical(this, tr("Error"), file.errorString());
         on_selectFileButton_clicked();
         return;
     }

--- a/src/widgets/TypesWidget.cpp
+++ b/src/widgets/TypesWidget.cpp
@@ -245,11 +245,7 @@ void TypesWidget::on_actionExport_Types_triggered()
     Config()->setRecentFolder(QFileInfo(filename).absolutePath());
     QFile file(filename);
     if (!file.open(QIODevice::WriteOnly)) {
-        QMessageBox popup(this);
-        popup.setWindowTitle(tr("Error"));
-        popup.setText(file.errorString());
-        popup.setStandardButtons(QMessageBox::Ok);
-        popup.exec();
+        QMessageBox::critical(this, tr("Error"), file.errorString());
         on_actionExport_Types_triggered();
         return;
     }
@@ -260,24 +256,26 @@ void TypesWidget::on_actionExport_Types_triggered()
 
 void TypesWidget::on_actionLoad_New_Types_triggered()
 {
-    LoadNewTypesDialog *dialog = new LoadNewTypesDialog(this);
-    connect(dialog, SIGNAL(newTypesLoaded()), this, SLOT(refreshTypes()));
-    dialog->setWindowTitle(tr("Load New Types"));
-    dialog->exec();
+    LoadNewTypesDialog dialog(this);
+    connect(&dialog, SIGNAL(newTypesLoaded()), this, SLOT(refreshTypes()));
+    dialog.setWindowTitle(tr("Load New Types"));
+    dialog.exec();
 }
 
 void TypesWidget::on_actionDelete_Type_triggered()
 {
     QModelIndex proxyIndex = ui->typesTreeView->currentIndex();
+    if (!proxyIndex.isValid()) {
+        return;
+    }
     QModelIndex index = types_proxy_model->mapToSource(proxyIndex);
+    if (!index.isValid()) {
+        return;
+    }
 
     TypeDescription exp = index.data(TypesModel::TypeDescriptionRole).value<TypeDescription>();
-    QMessageBox popup(this);
-    popup.setIcon(QMessageBox::Question);
-    popup.setText(tr("Are you sure you want to delete \"%1\"?").arg(exp.type));
-    popup.setStandardButtons(QMessageBox::No | QMessageBox::Yes);
-    popup.setDefaultButton(QMessageBox::Yes);
-    if (popup.exec() == QMessageBox::Yes) {
+    QMessageBox::StandardButton reply = QMessageBox::question(this, tr("Cutter"), tr("Are you sure you want to delete \"%1\"?").arg(exp.type));
+    if (reply == QMessageBox::Yes) {
         types_model->removeRow(index.row());
     }
 }


### PR DESCRIPTION
Made the following changes as requested by @a1ext :

1. Fixed memory leak in addTypes()
2. Shortened code for QMessageBox where possible.
3. Checked for validity of index while deleting.
4. Changed LoadNewTypesDialog to be allocated on the stack.