### PR TITLE
Fix progress bar alignment in Async Task Dialog

### DIFF
--- a/src/dialogs/AsyncTaskDialog.ui
+++ b/src/dialogs/AsyncTaskDialog.ui
@@ -26,6 +26,9 @@
      <property name="maximum">
       <number>0</number>
      </property>
+     <property name="textVisible">
+      <bool>false</bool>
+     </property>
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>


### PR DESCRIPTION
Fix this problem where the alignment of the progress bar is wrong:
![image](https://user-images.githubusercontent.com/20182642/52636686-fed82280-2ed5-11e9-9645-e577e58e1d54.png)
