### PR TITLE
Implement highlight in Types dialog

### DIFF
--- a/src/dialogs/LoadNewTypesDialog.cpp
+++ b/src/dialogs/LoadNewTypesDialog.cpp
@@ -3,6 +3,7 @@
 
 #include "Cutter.h"
 #include "common/Configuration.h"
+#include "common/SyntaxHighlighter.h"
 #include "widgets/TypesWidget.h"
 
 #include <QFileDialog>
@@ -14,6 +15,8 @@ LoadNewTypesDialog::LoadNewTypesDialog(QWidget *parent) :
 {
     ui->setupUi(this);
     ui->plainTextEdit->setPlainText("");
+    syntaxHighLighter = new SyntaxHighlighter(ui->plainTextEdit->document());
+
     ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
 }
 

--- a/src/dialogs/LoadNewTypesDialog.h
+++ b/src/dialogs/LoadNewTypesDialog.h
@@ -7,6 +7,7 @@
 namespace Ui {
 class LoadNewTypesDialog;
 }
+class SyntaxHighlighter;
 
 class LoadNewTypesDialog : public QDialog
 {
@@ -38,6 +39,7 @@ private slots:
 
 private:
     std::unique_ptr<Ui::LoadNewTypesDialog> ui;
+    SyntaxHighlighter *syntaxHighLighter;
 
 signals:
     /*!


### PR DESCRIPTION
This tiny pull request implements Code Highlighting in Types Dialog.
Close #1159 


![image](https://user-images.githubusercontent.com/20182642/52638160-faae0400-2ed9-11e9-864a-7a288e5e4035.png)
