### PR TITLE
Fix graph header resizing

### DIFF
--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -123,7 +123,7 @@ DisassemblerGraphView::DisassemblerGraphView(QWidget *parent)
     header->setReadOnly(true);
     header->setLineWrapMode(QTextEdit::NoWrap);
 
-    layout()->setContentsMargins(0,0,0,0);
+    layout()->setContentsMargins(0, 0, 0, 0);
     layout()->setAlignment(Qt::AlignTop);
     layout()->addWidget(header);
 

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -123,6 +123,7 @@ DisassemblerGraphView::DisassemblerGraphView(QWidget *parent)
     header->setReadOnly(true);
     header->setLineWrapMode(QTextEdit::NoWrap);
 
+    // Add header as widget to layout so it stretches to the layout width
     layout()->setContentsMargins(0, 0, 0, 0);
     layout()->setAlignment(Qt::AlignTop);
     layout()->addWidget(header);

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -123,9 +123,9 @@ DisassemblerGraphView::DisassemblerGraphView(QWidget *parent)
     header->setReadOnly(true);
     header->setLineWrapMode(QTextEdit::NoWrap);
 
-    this->layout()->setContentsMargins(0,0,0,0);
-    this->layout()->setAlignment(Qt::AlignTop);
-    this->layout()->addWidget(header);
+    layout()->setContentsMargins(0,0,0,0);
+    layout()->setAlignment(Qt::AlignTop);
+    layout()->addWidget(header);
 
     highlighter = new SyntaxHighlighter(header->document());
 }

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -118,10 +118,15 @@ DisassemblerGraphView::DisassemblerGraphView(QWidget *parent)
 
     connect(mMenu, SIGNAL(copy()), this, SLOT(copySelection()));
 
-    header = new QTextEdit(viewport());
+    header = new QTextEdit();
     header->setFixedHeight(30);
     header->setReadOnly(true);
     header->setLineWrapMode(QTextEdit::NoWrap);
+
+    this->layout()->setContentsMargins(0,0,0,0);
+    this->layout()->setAlignment(Qt::AlignTop);
+    this->layout()->addWidget(header);
+
     highlighter = new SyntaxHighlighter(header->document());
 }
 

--- a/src/widgets/GraphWidget.cpp
+++ b/src/widgets/GraphWidget.cpp
@@ -26,7 +26,6 @@ GraphWidget::GraphWidget(MainWindow *main, OverviewWidget *overview, QAction *ac
         toggleOverview(visibility);
         if (visibility) {
             Core()->setMemoryWidgetPriority(CutterCore::MemoryWidgetType::Graph);
-            this->graphView->header->setFixedWidth(width());
         }
     });
 
@@ -40,7 +39,6 @@ GraphWidget::GraphWidget(MainWindow *main, OverviewWidget *overview, QAction *ac
         if (type == CutterCore::MemoryWidgetType::Graph && !emptyGraph) {
             this->raise();
             this->graphView->setFocus();
-            this->graphView->header->setFixedWidth(width());
         }
     });
 }


### PR DESCRIPTION
Added header as widget to graph view layout so it now stretches to parent size.
Closes #1093 
