### PR TITLE
Disable "aan" from advanced options

### DIFF
--- a/src/dialogs/InitialOptionsDialog.ui
+++ b/src/dialogs/InitialOptionsDialog.ui
@@ -343,7 +343,7 @@
                      <string>Autorename functions based on context (aan)</string>
                     </property>
                     <property name="checked">
-                     <bool>true</bool>
+                     <bool>false</bool>
                     </property>
                    </widget>
                   </item>


### PR DESCRIPTION
Removing "aan" from the default set of commands running by "aaa" is something that needs to be changed in the rradare2 code. For now, this PR disable "aan" from default "Advanced Analysis" feature of Cutter.

![image](https://user-images.githubusercontent.com/20182642/52693370-4068dc00-2f6f-11e9-948b-6f2bd5bb15de.png)
