### PR TITLE
Graph scrolling forever

### DIFF
--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -317,12 +317,7 @@ void DisassemblerGraphView::loadCurrentGraph()
 
     if (!func["blocks"].toArray().isEmpty()) {
         computeGraph(entry);
-        viewport()->update();
-
-        if (first_draw) {
-            showBlock(blocks[entry]);
-            first_draw = false;
-        }
+        showBlock(blocks[entry]);
     }
 }
 

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -720,7 +720,6 @@ void DisassemblerGraphView::zoomIn(QPoint mouse)
 {
     current_scale += 0.1;
     auto areaSize = viewport()->size();
-    adjustSize(areaSize.width(), areaSize.height(), mouse);
     viewport()->update();
     emit viewZoomed();
 }
@@ -730,7 +729,6 @@ void DisassemblerGraphView::zoomOut(QPoint mouse)
     current_scale -= 0.1;
     current_scale = std::max(current_scale, 0.3);
     auto areaSize = viewport()->size();
-    adjustSize(areaSize.width(), areaSize.height(), mouse);
     viewport()->update();
     emit viewZoomed();
 }
@@ -739,7 +737,6 @@ void DisassemblerGraphView::zoomReset()
 {
     current_scale = 1.0;
     auto areaSize = viewport()->size();
-    adjustSize(areaSize.width(), areaSize.height());
     viewport()->update();
     emit viewZoomed();
 }

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -522,7 +522,7 @@ void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block)
         }
     }
 
-    qreal render_offset_y = -verticalScrollBar()->value() * current_scale + unscrolled_render_offset_y;
+    qreal render_offset_y = -verticalScrollBar()->value() * current_scale + offset_y;
     qreal render_height = viewport()->size().height();
 
     // Render node text

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -524,20 +524,18 @@ void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block)
         }
     }
 
-    qreal render_offset_y = -verticalScrollBar()->value() * current_scale + offset_y;
     qreal render_height = viewport()->size().height();
 
     // Render node text
     auto x = blockX + (2 * charWidth);
     int y = static_cast<int>(blockY + (2 * charWidth));
+    qreal lineHeightRender = charHeight * current_scale;
     for (auto &line : db.header_text.lines) {
         qreal lineYRender = y * current_scale;
-        qreal lineHeightRender = charHeight * current_scale;
 
         // Check if line does NOT intersects with view area
-        if (-render_offset_y >= lineYRender + lineHeightRender
-                || -render_offset_y + render_height <= lineYRender) {
-            // Skip if it does not intersects
+        if (0 > lineYRender + lineHeightRender
+                || render_height < lineYRender) {
             y += charHeight;
             continue;
         }
@@ -560,12 +558,9 @@ void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block)
         }
         for (auto &line : instr.text.lines) {
             qreal lineYRender = y * current_scale;
-            qreal lineHeightRender = charHeight * current_scale;
 
-            // Check if line does NOT intersects with view area
-            if (-render_offset_y >= lineYRender + lineHeightRender
-                    || -render_offset_y + render_height <= lineYRender) {
-                // Skip if it does not intersects
+            if (0 > lineYRender + lineHeightRender
+                    || render_height < lineYRender) {
                 y += charHeight;
                 continue;
             }

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -386,6 +386,8 @@ void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block)
     qreal blockCharW = charWidth * current_scale;
     int blockCharH = charHeight * current_scale;
 
+    p.save();
+    p.scale(current_scale, current_scale);
 
     p.setPen(Qt::black);
     p.setBrush(Qt::gray);
@@ -587,6 +589,7 @@ void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block)
 
         }
     }
+    p.restore();
 }
 
 GraphView::EdgeConfiguration DisassemblerGraphView::edgeConfiguration(GraphView::GraphBlock &from,
@@ -725,7 +728,6 @@ void DisassemblerGraphView::onSeekChanged(RVA addr)
 void DisassemblerGraphView::zoomIn(QPoint mouse)
 {
     current_scale += 0.1;
-    auto areaSize = viewport()->size();
     viewport()->update();
     emit viewZoomed();
 }
@@ -734,7 +736,6 @@ void DisassemblerGraphView::zoomOut(QPoint mouse)
 {
     current_scale -= 0.1;
     current_scale = std::max(current_scale, 0.3);
-    auto areaSize = viewport()->size();
     viewport()->update();
     emit viewZoomed();
 }
@@ -742,7 +743,6 @@ void DisassemblerGraphView::zoomOut(QPoint mouse)
 void DisassemblerGraphView::zoomReset()
 {
     current_scale = 1.0;
-    auto areaSize = viewport()->size();
     viewport()->update();
     emit viewZoomed();
 }

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -379,15 +379,12 @@ void DisassemblerGraphView::initFont()
 
 void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block)
 {
-    int blockX = block.x * current_scale - offset_x;
-    int blockY = block.y * current_scale - offset_y;
-    int blockW = block.width * current_scale;
-    int blockH = block.height * current_scale;
-    qreal blockCharW = charWidth * current_scale;
-    int blockCharH = charHeight * current_scale;
-
-    p.save();
-    p.scale(current_scale, current_scale);
+    int blockX = block.x - offset_x;
+    int blockY = block.y - offset_y;
+    int blockW = block.width;
+    int blockH = block.height;
+    qreal blockCharW = charWidth;
+    int blockCharH = charHeight;
 
     p.setPen(Qt::black);
     p.setBrush(Qt::gray);
@@ -532,14 +529,14 @@ void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block)
         }
     }
 
-    qreal render_height = viewport()->size().height() * current_scale;
+    qreal render_height = viewport()->size().height();
 
     // Render node text
     auto x = blockX + (2 * blockCharW);
     int y = static_cast<int>(blockY + (2 * blockCharW));
     qreal lineHeightRender = blockCharH;
     for (auto &line : db.header_text.lines) {
-        qreal lineYRender = y * current_scale;
+        qreal lineYRender = y;
 
         // Check if line does NOT intersects with view area
         if (0 > lineYRender + lineHeightRender
@@ -565,7 +562,7 @@ void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block)
             }
         }
         for (auto &line : instr.text.lines) {
-            qreal lineYRender = y * current_scale;
+            qreal lineYRender = y;
 
             if (0 > lineYRender + lineHeightRender
                     || render_height < lineYRender) {
@@ -589,7 +586,6 @@ void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block)
 
         }
     }
-    p.restore();
 }
 
 GraphView::EdgeConfiguration DisassemblerGraphView::edgeConfiguration(GraphView::GraphBlock &from,

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -379,9 +379,11 @@ void DisassemblerGraphView::initFont()
 
 void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block)
 {
+    int blockX = block.x - offset_x;
+    int blockY = block.y - offset_y;
     p.setPen(Qt::black);
     p.setBrush(Qt::gray);
-    p.drawRect(block.x, block.y, block.width, block.height);
+    p.drawRect(blockX, blockY, block.width, block.height);
 
     breakpoints = Core()->getBreakpointsAddresses();
 
@@ -416,7 +418,7 @@ void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block)
     }
 
     // Node's shadow effect
-    p.drawRect(block.x + 2, block.y + 2,
+    p.drawRect(blockX + 2, blockY + 2,
                block.width, block.height);
     p.setPen(QPen(graphNodeColor, 1));
 
@@ -426,12 +428,12 @@ void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block)
         p.setBrush(disassemblyBackgroundColor);
     }
 
-    p.drawRect(block.x, block.y,
+    p.drawRect(blockX, blockY,
                block.width, block.height);
 
     // Draw different background for selected instruction
     if (selected_instruction != RVA_INVALID) {
-        int y = static_cast<int>(block.y + (2 * charWidth) + (db.header_text.lines.size() * charHeight));
+        int y = static_cast<int>(blockY + (2 * charWidth) + (db.header_text.lines.size() * charHeight));
         for (const Instr &instr : db.instrs) {
             if (instr.addr > selected_instruction) {
                 break;
@@ -440,11 +442,11 @@ void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block)
             //auto traceCount = dbgfunctions->GetTraceRecordHitCount(instr.addr);
             auto traceCount = 0;
             if (selected && traceCount) {
-                p.fillRect(QRect(static_cast<int>(block.x + charWidth), y,
+                p.fillRect(QRect(static_cast<int>(blockX + charWidth), y,
                                  static_cast<int>(block.width - (10 + 2 * charWidth)),
                                  int(instr.text.lines.size()) * charHeight), disassemblyTracedSelectionColor);
             } else if (selected) {
-                p.fillRect(QRect(static_cast<int>(block.x + charWidth), y,
+                p.fillRect(QRect(static_cast<int>(blockX + charWidth), y,
                                  static_cast<int>(block.width - (10 + 2 * charWidth)),
                                  int(instr.text.lines.size()) * charHeight), disassemblySelectionColor);
             } else if (traceCount) {
@@ -458,7 +460,7 @@ void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block)
                 if (disassemblyTracedColor.blue() > 160)
                     colorDiff *= -1;
 
-                p.fillRect(QRect(static_cast<int>(block.x + charWidth), y,
+                p.fillRect(QRect(static_cast<int>(blockX + charWidth), y,
                                  static_cast<int>(block.width - (10 + 2 * charWidth)),
                                  int(instr.text.lines.size()) * charHeight),
                            QColor(disassemblyTracedColor.red(),
@@ -471,7 +473,7 @@ void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block)
 
     // highlight selected tokens
     if (highlight_token != nullptr) {
-        int y = static_cast<int>(block.y + (2 * charWidth) + (db.header_text.lines.size() * charHeight));
+        int y = static_cast<int>(blockY + (2 * charWidth) + (db.header_text.lines.size() * charHeight));
         int tokenWidth = mFontMetrics->width(highlight_token->content);
 
         for (const Instr &instr : db.instrs) {
@@ -497,7 +499,7 @@ void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block)
 
                 QColor selectionColor = ConfigColor("highlightWord");
 
-                p.fillRect(QRect(static_cast<int>(block.x + charWidth * 3 + widthBefore), y, highlightWidth,
+                p.fillRect(QRect(static_cast<int>(blockX + charWidth * 3 + widthBefore), y, highlightWidth,
                                  charHeight), selectionColor);
             }
 
@@ -507,14 +509,14 @@ void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block)
 
     // highlight program counter
     if (PCInBlock) {
-        int y = static_cast<int>(block.y + (2 * charWidth) + (db.header_text.lines.size() * charHeight));
+        int y = static_cast<int>(blockY + (2 * charWidth) + (db.header_text.lines.size() * charHeight));
         for (const Instr &instr : db.instrs) {
             if (instr.addr > PCAddr) {
                 break;
             }
             auto PC = instr.addr == PCAddr;
             if (PC) {
-                p.fillRect(QRect(static_cast<int>(block.x + charWidth), y,
+                p.fillRect(QRect(static_cast<int>(blockX + charWidth), y,
                                  static_cast<int>(block.width - (10 + 2 * charWidth)),
                                  int(instr.text.lines.size()) * charHeight), PCSelectionColor);
             }
@@ -526,8 +528,8 @@ void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block)
     qreal render_height = viewport()->size().height();
 
     // Render node text
-    auto x = block.x + (2 * charWidth);
-    int y = static_cast<int>(block.y + (2 * charWidth));
+    auto x = blockX + (2 * charWidth);
+    int y = static_cast<int>(blockY + (2 * charWidth));
     for (auto &line : db.header_text.lines) {
         qreal lineYRender = y * current_scale;
         qreal lineHeightRender = charHeight * current_scale;
@@ -547,11 +549,11 @@ void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block)
 
     for (const Instr &instr : db.instrs) {
         if (Core()->isBreakpoint(breakpoints, instr.addr)) {
-            p.fillRect(QRect(static_cast<int>(block.x + charWidth), y,
+            p.fillRect(QRect(static_cast<int>(blockX + charWidth), y,
                              static_cast<int>(block.width - (10 + 2 * charWidth)),
                              int(instr.text.lines.size()) * charHeight), ConfigColor("gui.breakpoint_background"));
             if (instr.addr == selected_instruction) {
-                p.fillRect(QRect(static_cast<int>(block.x + charWidth), y,
+                p.fillRect(QRect(static_cast<int>(blockX + charWidth), y,
                                  static_cast<int>(block.width - (10 + 2 * charWidth)),
                                  int(instr.text.lines.size()) * charHeight), disassemblySelectionColor);
             }

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -382,14 +382,10 @@ void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block)
 {
     int blockX = block.x - offset_x;
     int blockY = block.y - offset_y;
-    int blockW = block.width;
-    int blockH = block.height;
-    qreal blockCharW = charWidth;
-    int blockCharH = charHeight;
 
     p.setPen(Qt::black);
     p.setBrush(Qt::gray);
-    p.drawRect(blockX, blockY, blockW, blockH);
+    p.drawRect(blockX, blockY, block.width, block.height);
 
     breakpoints = Core()->getBreakpointsAddresses();
 
@@ -425,7 +421,7 @@ void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block)
 
     // Node's shadow effect
     p.drawRect(blockX + 2, blockY + 2,
-               blockW, blockH);
+               block.width, block.height);
     p.setPen(QPen(graphNodeColor, 1));
 
     if (block_selected) {
@@ -435,11 +431,11 @@ void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block)
     }
 
     p.drawRect(blockX, blockY,
-               blockW, blockH);
+               block.width, block.height);
 
     // Draw different background for selected instruction
     if (selected_instruction != RVA_INVALID) {
-        int y = static_cast<int>(blockY + (2 * blockCharW) + (db.header_text.lines.size() * blockCharH));
+        int y = static_cast<int>(blockY + (2 * charWidth) + (db.header_text.lines.size() * charHeight));
         for (const Instr &instr : db.instrs) {
             if (instr.addr > selected_instruction) {
                 break;
@@ -448,13 +444,13 @@ void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block)
             //auto traceCount = dbgfunctions->GetTraceRecordHitCount(instr.addr);
             auto traceCount = 0;
             if (selected && traceCount) {
-                p.fillRect(QRect(static_cast<int>(blockX + blockCharW), y,
-                                 static_cast<int>(blockW - (10 + 2 * blockCharW)),
-                                 int(instr.text.lines.size()) * blockCharH), disassemblyTracedSelectionColor);
+                p.fillRect(QRect(static_cast<int>(blockX + charWidth), y,
+                                 static_cast<int>(block.width - (10 + 2 * charWidth)),
+                                 int(instr.text.lines.size()) * charHeight), disassemblyTracedSelectionColor);
             } else if (selected) {
-                p.fillRect(QRect(static_cast<int>(blockX + blockCharW), y,
-                                 static_cast<int>(blockW - (10 + 2 * blockCharW)),
-                                 int(instr.text.lines.size()) * blockCharH), disassemblySelectionColor);
+                p.fillRect(QRect(static_cast<int>(blockX + charWidth), y,
+                                 static_cast<int>(block.width - (10 + 2 * charWidth)),
+                                 int(instr.text.lines.size()) * charHeight), disassemblySelectionColor);
             } else if (traceCount) {
                 // Color depending on how often a sequence of code is executed
                 int exponent = 1;
@@ -466,20 +462,20 @@ void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block)
                 if (disassemblyTracedColor.blue() > 160)
                     colorDiff *= -1;
 
-                p.fillRect(QRect(static_cast<int>(blockX + blockCharW), y,
-                                 static_cast<int>(blockW - (10 + 2 * blockCharW)),
-                                 int(instr.text.lines.size()) * blockCharH),
+                p.fillRect(QRect(static_cast<int>(blockX + charWidth), y,
+                                 static_cast<int>(block.width - (10 + 2 * charWidth)),
+                                 int(instr.text.lines.size()) * charHeight),
                            QColor(disassemblyTracedColor.red(),
                                   disassemblyTracedColor.green(),
                                   std::max(0, std::min(256, disassemblyTracedColor.blue() + colorDiff))));
             }
-            y += int(instr.text.lines.size()) * blockCharH;
+            y += int(instr.text.lines.size()) * charHeight;
         }
     }
 
     // highlight selected tokens
     if (highlight_token != nullptr) {
-        int y = static_cast<int>(blockY + (2 * blockCharW) + (db.header_text.lines.size() * blockCharH));
+        int y = static_cast<int>(blockY + (2 * charWidth) + (db.header_text.lines.size() * charHeight));
         int tokenWidth = mFontMetrics->width(highlight_token->content);
 
         for (const Instr &instr : db.instrs) {
@@ -494,72 +490,72 @@ void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block)
                 }
 
                 int widthBefore = mFontMetrics->width(instr.plainText.left(pos));
-                if (blockCharW * 3 + widthBefore > blockW - (10 + 2 * blockCharW)) {
+                if (charWidth * 3 + widthBefore > block.width - (10 + 2 * charWidth)) {
                     continue;
                 }
 
                 int highlightWidth = tokenWidth;
-                if (blockCharW * 3 + widthBefore + tokenWidth >= blockW - (10 + 2 * blockCharW)) {
-                    highlightWidth = static_cast<int>(blockW - widthBefore - (10 + 4 * blockCharW));
+                if (charWidth * 3 + widthBefore + tokenWidth >= block.width - (10 + 2 * charWidth)) {
+                    highlightWidth = static_cast<int>(block.width - widthBefore - (10 + 4 * charWidth));
                 }
 
                 QColor selectionColor = ConfigColor("highlightWord");
 
-                p.fillRect(QRect(static_cast<int>(blockX + blockCharW * 3 + widthBefore), y, highlightWidth,
-                                 blockCharH), selectionColor);
+                p.fillRect(QRect(static_cast<int>(blockX + charWidth * 3 + widthBefore), y, highlightWidth,
+                                 charHeight), selectionColor);
             }
 
-            y += int(instr.text.lines.size()) * blockCharH;
+            y += int(instr.text.lines.size()) * charHeight;
         }
     }
 
     // highlight program counter
     if (PCInBlock) {
-        int y = static_cast<int>(blockY + (2 * blockCharW) + (db.header_text.lines.size() * blockCharH));
+        int y = static_cast<int>(blockY + (2 * charWidth) + (db.header_text.lines.size() * charHeight));
         for (const Instr &instr : db.instrs) {
             if (instr.addr > PCAddr) {
                 break;
             }
             auto PC = instr.addr == PCAddr;
             if (PC) {
-                p.fillRect(QRect(static_cast<int>(blockX + blockCharW), y,
-                                 static_cast<int>(blockW - (10 + 2 * blockCharW)),
-                                 int(instr.text.lines.size()) * blockCharH), PCSelectionColor);
+                p.fillRect(QRect(static_cast<int>(blockX + charWidth), y,
+                                 static_cast<int>(block.width - (10 + 2 * charWidth)),
+                                 int(instr.text.lines.size()) * charHeight), PCSelectionColor);
             }
-            y += int(instr.text.lines.size()) * blockCharH;
+            y += int(instr.text.lines.size()) * charHeight;
         }
     }
 
     qreal render_height = viewport()->size().height();
 
     // Render node text
-    auto x = blockX + (2 * blockCharW);
-    int y = static_cast<int>(blockY + (2 * blockCharW));
-    qreal lineHeightRender = blockCharH;
+    auto x = blockX + (2 * charWidth);
+    int y = static_cast<int>(blockY + (2 * charWidth));
+    qreal lineHeightRender = charHeight;
     for (auto &line : db.header_text.lines) {
         qreal lineYRender = y;
 
         // Check if line does NOT intersects with view area
         if (0 > lineYRender + lineHeightRender
                 || render_height < lineYRender) {
-            y += blockCharH;
+            y += charHeight;
             continue;
         }
 
-        RichTextPainter::paintRichText(&p, static_cast<int>(x), y, blockW, blockCharH, 0, line,
+        RichTextPainter::paintRichText(&p, static_cast<int>(x), y, block.width, charHeight, 0, line,
                                        mFontMetrics);
-        y += blockCharH;
+        y += charHeight;
     }
 
     for (const Instr &instr : db.instrs) {
         if (Core()->isBreakpoint(breakpoints, instr.addr)) {
-            p.fillRect(QRect(static_cast<int>(blockX + blockCharW), y,
-                             static_cast<int>(blockW - (10 + 2 * blockCharW)),
-                             int(instr.text.lines.size()) * blockCharH), ConfigColor("gui.breakpoint_background"));
+            p.fillRect(QRect(static_cast<int>(blockX + charWidth), y,
+                             static_cast<int>(block.width - (10 + 2 * charWidth)),
+                             int(instr.text.lines.size()) * charHeight), ConfigColor("gui.breakpoint_background"));
             if (instr.addr == selected_instruction) {
-                p.fillRect(QRect(static_cast<int>(blockX + blockCharW), y,
-                                 static_cast<int>(blockW - (10 + 2 * blockCharW)),
-                                 int(instr.text.lines.size()) * blockCharH), disassemblySelectionColor);
+                p.fillRect(QRect(static_cast<int>(blockX + charWidth), y,
+                                 static_cast<int>(block.width - (10 + 2 * charWidth)),
+                                 int(instr.text.lines.size()) * charHeight), disassemblySelectionColor);
             }
         }
         for (auto &line : instr.text.lines) {
@@ -567,23 +563,23 @@ void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block)
 
             if (0 > lineYRender + lineHeightRender
                     || render_height < lineYRender) {
-                y += blockCharH;
+                y += charHeight;
                 continue;
             }
 
-            int rectSize = qRound(blockCharW);
+            int rectSize = qRound(charWidth);
             if (rectSize % 2) {
                 rectSize++;
             }
-            // Assume blockCharW <= blockCharH
+            // Assume charWidth <= charHeight
             // TODO: Breakpoint/Cip stuff
-            QRectF bpRect(x - rectSize / 3.0, y + (blockCharH - rectSize) / 2.0, rectSize, rectSize);
+            QRectF bpRect(x - rectSize / 3.0, y + (charHeight - rectSize) / 2.0, rectSize, rectSize);
             Q_UNUSED(bpRect);
 
-            RichTextPainter::paintRichText(&p, static_cast<int>(x + blockCharW), y,
-                                           static_cast<int>(blockW - blockCharW), blockCharH, 0, line,
+            RichTextPainter::paintRichText(&p, static_cast<int>(x + charWidth), y,
+                                           static_cast<int>(block.width - charWidth), charHeight, 0, line,
                                            mFontMetrics);
-            y += blockCharH;
+            y += charHeight;
 
         }
     }
@@ -706,7 +702,7 @@ void DisassemblerGraphView::onSeekChanged(RVA addr)
     if (db) {
         // This is a local address! We animated to it.
         transition_dont_seek = true;
-        showBlock(&blocks[db->entry], true);
+        showBlock(&blocks[db->entry]);
         prepareHeader();
     } else {
         refreshView();
@@ -714,7 +710,7 @@ void DisassemblerGraphView::onSeekChanged(RVA addr)
         if (db) {
             // This is a local address! We animated to it.
             transition_dont_seek = true;
-            showBlock(&blocks[db->entry], true);
+            showBlock(&blocks[db->entry]);
             prepareHeader();
         } else {
             header->hide();

--- a/src/widgets/DisassemblerGraphView.h
+++ b/src/widgets/DisassemblerGraphView.h
@@ -158,7 +158,6 @@ private slots:
     void on_actionExportGraph_triggered();
 
 private:
-    bool first_draw = true;
     bool transition_dont_seek = false;
 
     Token *highlight_token;

--- a/src/widgets/GraphView.cpp
+++ b/src/widgets/GraphView.cpp
@@ -395,8 +395,8 @@ void GraphView::paintEvent(QPaintEvent *event)
 
     p.setRenderHint(QPainter::Antialiasing);
 
-    int render_width = viewport()->size().width();
-    int render_height = viewport()->size().height();
+    int render_width = viewport()->width();
+    int render_height = viewport()->height();
 
     QRect viewportRect(viewport()->rect().topLeft(), viewport()->rect().bottomRight() - QPoint(1, 1));
     p.setBrush(backgroundColor);

--- a/src/widgets/GraphView.cpp
+++ b/src/widgets/GraphView.cpp
@@ -9,7 +9,6 @@
 GraphView::GraphView(QWidget *parent)
     : QAbstractScrollArea(parent)
 {
-    QSize areaSize = viewport()->size();
 }
 
 GraphView::~GraphView()
@@ -112,8 +111,6 @@ bool GraphView::event(QEvent *event)
 // This calculates the full graph starting at block entry.
 void GraphView::computeGraph(ut64 entry)
 {
-    QSize areaSize = viewport()->size();
-
     // Populate incoming lists
     for (auto &blockIt : blocks) {
         GraphBlock &block = blockIt.second;
@@ -370,14 +367,12 @@ void GraphView::computeGraph(ut64 entry)
     ready = true;
 
     viewport()->update();
-    areaSize = viewport()->size();
 }
 
 QPolygonF GraphView::recalculatePolygon(QPolygonF polygon)
 {
     QPolygonF ret;
     for (int i = 0; i < polygon.size(); i++) {
-        //ret << QPointF(polygon[i].x() * current_scale - offset_x, polygon[i].y() * current_scale - offset_y);
         ret << QPointF(polygon[i].x() - offset_x, polygon[i].y() - offset_y);
     }
     return ret;
@@ -698,12 +693,12 @@ void GraphView::centerY()
     offset_y /= current_scale;
 }
 
-void GraphView::showBlock(GraphBlock &block, bool animated)
+void GraphView::showBlock(GraphBlock &block)
 {
-    showBlock(&block, animated);
+    showBlock(&block);
 }
 
-void GraphView::showBlock(GraphBlock *block, bool animated)
+void GraphView::showBlock(GraphBlock *block)
 {
     if (width * current_scale <= viewport()->width()) {
         centerX();
@@ -782,13 +777,13 @@ void GraphView::mousePressEvent(QMouseEvent *event)
             QPointF start = edge.polyline.first();
             QPointF end = edge.polyline.last();
             if (checkPointClicked(start, x, y)) {
-                showBlock(edge.dest, true);
+                showBlock(edge.dest);
                 // TODO: Callback to child
                 return;
                 break;
             }
             if (checkPointClicked(end, x, y, true)) {
-                showBlock(block, true);
+                showBlock(block);
                 // TODO: Callback to child
                 return;
                 break;

--- a/src/widgets/GraphView.cpp
+++ b/src/widgets/GraphView.cpp
@@ -420,14 +420,14 @@ void GraphView::paintEvent(QPaintEvent *event)
         // Always draw edges
         // TODO: Only draw edges if they are actually visible ...
         // Draw edges
+        p.save();
+        p.scale(current_scale, current_scale);
         for (GraphEdge &edge : block.edges) {
             QPolygonF polyline = recalculatePolygon(edge.polyline);
             QPolygonF arrow_start = recalculatePolygon(edge.arrow_start);
             QPolygonF arrow_end = recalculatePolygon(edge.arrow_end);
             EdgeConfiguration ec = edgeConfiguration(block, edge.dest);
             QPen pen(edge.color);
-//            if(blockSelected)
-//                pen.setStyle(Qt::DashLine);
             pen.setWidth(pen.width());
             p.setPen(pen);
             p.setBrush(edge.color);
@@ -441,6 +441,7 @@ void GraphView::paintEvent(QPaintEvent *event)
                 p.drawConvexPolygon(arrow_end);
             }
         }
+        p.restore();
     }
 
     emit refreshBlock();

--- a/src/widgets/GraphView.cpp
+++ b/src/widgets/GraphView.cpp
@@ -427,7 +427,7 @@ void GraphView::paintEvent(QPaintEvent *event)
             QPolygonF arrow_end = recalculatePolygon(edge.arrow_end);
             EdgeConfiguration ec = edgeConfiguration(block, edge.dest);
             QPen pen(edge.color);
-            pen.setWidth(pen.width());
+            pen.setWidth(pen.width() / ec.width_scale);
             p.setPen(pen);
             p.setBrush(edge.color);
             p.drawPolyline(polyline);

--- a/src/widgets/GraphView.cpp
+++ b/src/widgets/GraphView.cpp
@@ -687,6 +687,22 @@ int GraphView::findVertEdgeIndex(EdgesVector &edges, int col, int min_row, int m
     return i;
 }
 
+void GraphView::center()
+{
+    centerX();
+    centerY();
+}
+
+void GraphView::centerX()
+{
+    offset_x = -((viewport()->width() - width * current_scale) / 2);
+}
+
+void GraphView::centerY()
+{
+    offset_y = -((viewport()->height() - height * current_scale) / 2);
+}
+
 void GraphView::showBlock(GraphBlock &block, bool animated)
 {
     showBlock(&block, animated);
@@ -694,13 +710,17 @@ void GraphView::showBlock(GraphBlock &block, bool animated)
 
 void GraphView::showBlock(GraphBlock *block, bool animated)
 {
-    int render_width = viewport()->size().width() / current_scale;
-
-    offset_x = block->x - ((render_width - block->width) / 2);
-    // Show block middle of X
-    int show_block_offset_y = 30;
-    offset_y = block->y + show_block_offset_y;
-
+    if (width * current_scale <= viewport()->width()) {
+        centerX();
+    } else {
+        int render_width = viewport()->width() / current_scale;
+        offset_x = block->x - ((render_width - block->width) / 2);
+    }
+    if (height * current_scale <= viewport()->height()) {
+        centerY();
+    } else {
+        offset_y = block->y - 30;
+    }
     blockTransitionedTo(block);
     viewport()->update();
 }
@@ -847,8 +867,8 @@ void GraphView::mouseReleaseEvent(QMouseEvent *event)
 void GraphView::wheelEvent(QWheelEvent *event)
 {
     const QPoint delta = -event->angleDelta();
-    offset_x += delta.x();
-    offset_y += delta.y();
+    offset_x += delta.x() * current_scale;
+    offset_y += delta.y() * current_scale;
     viewport()->update();
     event->accept();
 }

--- a/src/widgets/GraphView.cpp
+++ b/src/widgets/GraphView.cpp
@@ -696,10 +696,10 @@ void GraphView::showBlock(GraphBlock *block, bool animated)
 {
     int render_width = viewport()->size().width() / current_scale;
 
-    offset_x = block->x + ((render_width - block->width) / 2);
+    offset_x = block->x - ((render_width - block->width) / 2);
     // Show block middle of X
     int show_block_offset_y = 30;
-    offset_y = block->y - show_block_offset_y;
+    offset_y = block->y + show_block_offset_y;
 
     blockTransitionedTo(block);
     viewport()->update();

--- a/src/widgets/GraphView.cpp
+++ b/src/widgets/GraphView.cpp
@@ -10,7 +10,6 @@ GraphView::GraphView(QWidget *parent)
     : QAbstractScrollArea(parent)
 {
     QSize areaSize = viewport()->size();
-    adjustSize(areaSize.width(), areaSize.height());
 }
 
 GraphView::~GraphView()
@@ -97,10 +96,6 @@ GraphView::EdgeConfiguration GraphView::edgeConfiguration(GraphView::GraphBlock 
     qWarning() << "Edge configuration not overridden!";
     EdgeConfiguration ec;
     return ec;
-}
-
-void GraphView::adjustSize(int new_width, int new_height, QPoint mouse)
-{
 }
 
 bool GraphView::event(QEvent *event)
@@ -376,7 +371,6 @@ void GraphView::computeGraph(ut64 entry)
 
     viewport()->update();
     areaSize = viewport()->size();
-    adjustSize(areaSize.width(), areaSize.height());
 }
 
 QPolygonF GraphView::recalculatePolygon(QPolygonF polygon)
@@ -757,11 +751,6 @@ bool GraphView::checkPointClicked(QPointF &point, int x, int y, bool above_y)
     return false;
 }
 
-void GraphView::resizeEvent(QResizeEvent *event)
-{
-    adjustSize(event->size().width(), event->size().height());
-}
-
 // Mouse events
 void GraphView::mousePressEvent(QMouseEvent *event)
 {
@@ -821,10 +810,11 @@ void GraphView::mousePressEvent(QMouseEvent *event)
 void GraphView::mouseMoveEvent(QMouseEvent *event)
 {
     if (scroll_mode) {
-        offset_x = scroll_base_x - event->x();
-        offset_y = scroll_base_y - event->y();
+        offset_x += scroll_base_x - event->x();
+        offset_y += scroll_base_y - event->y();
         scroll_base_x = event->x();
         scroll_base_y = event->y();
+        viewport()->update();
     }
 }
 

--- a/src/widgets/GraphView.cpp
+++ b/src/widgets/GraphView.cpp
@@ -383,7 +383,7 @@ QPolygonF GraphView::recalculatePolygon(QPolygonF polygon)
 {
     QPolygonF ret;
     for (int i = 0; i < polygon.size(); i++) {
-        ret << QPointF(polygon[i].x() - offset_x, polygon[i].y() - offset_y);
+        ret << QPointF(polygon[i].x() * current_scale - offset_x, polygon[i].y() * current_scale - offset_y);
     }
     return ret;
 }
@@ -403,7 +403,7 @@ void GraphView::paintEvent(QPaintEvent *event)
     p.drawRect(viewportRect);
     p.setBrush(Qt::black);
 
-    p.scale(current_scale, current_scale);
+    //p.scale(current_scale, current_scale);
 
     for (auto &blockIt : blocks) {
         GraphBlock &block = blockIt.second;
@@ -434,7 +434,7 @@ void GraphView::paintEvent(QPaintEvent *event)
             QPen pen(edge.color);
 //            if(blockSelected)
 //                pen.setStyle(Qt::DashLine);
-            pen.setWidth(pen.width() / ec.width_scale);
+            pen.setWidth(pen.width());
             p.setPen(pen);
             p.setBrush(edge.color);
             p.drawPolyline(polyline);

--- a/src/widgets/GraphView.cpp
+++ b/src/widgets/GraphView.cpp
@@ -377,7 +377,8 @@ QPolygonF GraphView::recalculatePolygon(QPolygonF polygon)
 {
     QPolygonF ret;
     for (int i = 0; i < polygon.size(); i++) {
-        ret << QPointF(polygon[i].x() * current_scale - offset_x, polygon[i].y() * current_scale - offset_y);
+        //ret << QPointF(polygon[i].x() * current_scale - offset_x, polygon[i].y() * current_scale - offset_y);
+        ret << QPointF(polygon[i].x() - offset_x, polygon[i].y() - offset_y);
     }
     return ret;
 }
@@ -397,7 +398,7 @@ void GraphView::paintEvent(QPaintEvent *event)
     p.drawRect(viewportRect);
     p.setBrush(Qt::black);
 
-    //p.scale(current_scale, current_scale);
+    p.scale(current_scale, current_scale);
 
     for (auto &blockIt : blocks) {
         GraphBlock &block = blockIt.second;
@@ -408,10 +409,10 @@ void GraphView::paintEvent(QPaintEvent *event)
         qreal blockHeight = block.height * current_scale;
 
         // Check if block is visible by checking if block intersects with view area
-        if (offset_x < blockX + blockWidth
-                && blockX < offset_x + render_width
-                && offset_y < blockY + blockHeight
-                && blockY < offset_y + render_height) {
+        if (offset_x * current_scale < blockX + blockWidth
+                && blockX < offset_x * current_scale + render_width
+                && offset_y * current_scale < blockY + blockHeight
+                && blockY < offset_y * current_scale + render_height) {
             drawBlock(p, block);
         }
 
@@ -420,8 +421,6 @@ void GraphView::paintEvent(QPaintEvent *event)
         // Always draw edges
         // TODO: Only draw edges if they are actually visible ...
         // Draw edges
-        p.save();
-        p.scale(current_scale, current_scale);
         for (GraphEdge &edge : block.edges) {
             QPolygonF polyline = recalculatePolygon(edge.polyline);
             QPolygonF arrow_start = recalculatePolygon(edge.arrow_start);
@@ -441,7 +440,6 @@ void GraphView::paintEvent(QPaintEvent *event)
                 p.drawConvexPolygon(arrow_end);
             }
         }
-        p.restore();
     }
 
     emit refreshBlock();
@@ -691,11 +689,13 @@ void GraphView::center()
 void GraphView::centerX()
 {
     offset_x = -((viewport()->width() - width * current_scale) / 2);
+    offset_x /= current_scale;
 }
 
 void GraphView::centerY()
 {
     offset_y = -((viewport()->height() - height * current_scale) / 2);
+    offset_y /= current_scale;
 }
 
 void GraphView::showBlock(GraphBlock &block, bool animated)

--- a/src/widgets/GraphView.h
+++ b/src/widgets/GraphView.h
@@ -141,6 +141,9 @@ protected:
     void mouseReleaseEvent(QMouseEvent *event) override;
     void mouseDoubleClickEvent(QMouseEvent *event) override;
 
+    void center();
+    void centerX();
+    void centerY();
     int width = 0;
     int height = 0;
 private:

--- a/src/widgets/GraphView.h
+++ b/src/widgets/GraphView.h
@@ -177,6 +177,7 @@ private:
     int findVertEdgeIndex(EdgesVector &edges, int col, int min_row, int max_row);
     GraphEdge routeEdge(EdgesVector &horiz_edges, EdgesVector &vert_edges, Matrix<bool> &edge_valid,
                         GraphBlock &start, GraphBlock &end, QColor color);
+    QPolygonF recalculatePolygon(QPolygonF polygon);
 };
 
 #endif // GRAPHVIEW_H

--- a/src/widgets/GraphView.h
+++ b/src/widgets/GraphView.h
@@ -95,9 +95,8 @@ public:
     ~GraphView() override;
     void paintEvent(QPaintEvent *event) override;
 
-    // Show a block centered. Animates to it if animated=true
-    void showBlock(GraphBlock &block, bool animated = false);
-    void showBlock(GraphBlock *block, bool animated = false);
+    void showBlock(GraphBlock &block);
+    void showBlock(GraphBlock *block);
 
     // Zoom data
     qreal current_scale = 1.0;

--- a/src/widgets/GraphView.h
+++ b/src/widgets/GraphView.h
@@ -102,8 +102,8 @@ public:
     // Zoom data
     qreal current_scale = 1.0;
 
-    int unscrolled_render_offset_x = 0;
-    int unscrolled_render_offset_y = 0;
+    int offset_x = 0;
+    int offset_y = 0;
 
 protected:
     std::unordered_map<ut64, GraphBlock> blocks;

--- a/src/widgets/GraphView.h
+++ b/src/widgets/GraphView.h
@@ -130,11 +130,8 @@ protected:
     virtual void wheelEvent(QWheelEvent *event) override;
     virtual EdgeConfiguration edgeConfiguration(GraphView::GraphBlock &from, GraphView::GraphBlock *to);
 
-    void adjustSize(int new_width, int new_height, QPoint mouse = QPoint(0, 0));
-
     bool event(QEvent *event) override;
 
-    void resizeEvent(QResizeEvent *event) override;
     // Mouse events
     void mousePressEvent(QMouseEvent *event) override;
     void mouseMoveEvent(QMouseEvent *event) override;

--- a/src/widgets/GraphWidget.cpp
+++ b/src/widgets/GraphWidget.cpp
@@ -49,29 +49,29 @@ GraphWidget::~GraphWidget() {}
 
 void GraphWidget::toggleOverview(bool visibility)
 {
-    //if (!overviewWidget) {
-    //    return;
-    //}
-    //if (visibility) {
-    //    connect(graphView, SIGNAL(refreshBlock()), this, SLOT(adjustOverview()));
-    //    connect(graphView, SIGNAL(viewZoomed()), this, SLOT(adjustOverview()));
-    //    connect(graphView->horizontalScrollBar(), SIGNAL(valueChanged(int)), this, SLOT(adjustOverview()));
-    //    connect(graphView->verticalScrollBar(), SIGNAL(valueChanged(int)), this, SLOT(adjustOverview()));
-    //    connect(overviewWidget->graphView, SIGNAL(refreshBlock()), this, SLOT(adjustOffset()));
-    //    connect(overviewWidget->graphView, SIGNAL(mouseMoved()), this, SLOT(adjustGraph()));
-    //    connect(overviewWidget, &QDockWidget::dockLocationChanged, this, &GraphWidget::adjustOverview);
-    //    connect(overviewWidget, &OverviewWidget::resized, this, &GraphWidget::adjustOverview);
-    //} else {
-    //    disconnect(graphView, SIGNAL(refreshBlock()), this, SLOT(adjustOverview()));
-    //    disconnect(graphView, SIGNAL(viewZoomed()), this, SLOT(adjustOverview()));
-    //    disconnect(graphView->horizontalScrollBar(), SIGNAL(valueChanged(int)), this, SLOT(adjustOverview()));
-    //    disconnect(graphView->verticalScrollBar(), SIGNAL(valueChanged(int)), this, SLOT(adjustOverview()));
-    //    disconnect(overviewWidget->graphView, SIGNAL(refreshBlock()), this, SLOT(adjustOffset()));
-    //    disconnect(overviewWidget->graphView, SIGNAL(mouseMoved()), this, SLOT(adjustGraph()));
-    //    disconnect(overviewWidget, &QDockWidget::dockLocationChanged, this, &GraphWidget::adjustOverview);
-    //    disconnect(overviewWidget, &OverviewWidget::resized, this, &GraphWidget::adjustOverview);
-    //    disableOverviewRect();
-    //}
+    if (!overviewWidget) {
+        return;
+    }
+    if (visibility) {
+        connect(graphView, SIGNAL(refreshBlock()), this, SLOT(adjustOverview()));
+        connect(graphView, SIGNAL(viewZoomed()), this, SLOT(adjustOverview()));
+        connect(graphView->horizontalScrollBar(), SIGNAL(valueChanged(int)), this, SLOT(adjustOverview()));
+        connect(graphView->verticalScrollBar(), SIGNAL(valueChanged(int)), this, SLOT(adjustOverview()));
+        connect(overviewWidget->graphView, SIGNAL(refreshBlock()), this, SLOT(adjustOffset()));
+        connect(overviewWidget->graphView, SIGNAL(mouseMoved()), this, SLOT(adjustGraph()));
+        connect(overviewWidget, &QDockWidget::dockLocationChanged, this, &GraphWidget::adjustOverview);
+        connect(overviewWidget, &OverviewWidget::resized, this, &GraphWidget::adjustOverview);
+    } else {
+        disconnect(graphView, SIGNAL(refreshBlock()), this, SLOT(adjustOverview()));
+        disconnect(graphView, SIGNAL(viewZoomed()), this, SLOT(adjustOverview()));
+        disconnect(graphView->horizontalScrollBar(), SIGNAL(valueChanged(int)), this, SLOT(adjustOverview()));
+        disconnect(graphView->verticalScrollBar(), SIGNAL(valueChanged(int)), this, SLOT(adjustOverview()));
+        disconnect(overviewWidget->graphView, SIGNAL(refreshBlock()), this, SLOT(adjustOffset()));
+        disconnect(overviewWidget->graphView, SIGNAL(mouseMoved()), this, SLOT(adjustGraph()));
+        disconnect(overviewWidget, &QDockWidget::dockLocationChanged, this, &GraphWidget::adjustOverview);
+        disconnect(overviewWidget, &OverviewWidget::resized, this, &GraphWidget::adjustOverview);
+        disableOverviewRect();
+    }
 }
 
 void GraphWidget::disableOverviewRect()
@@ -85,45 +85,22 @@ void GraphWidget::disableOverviewRect()
 
 void GraphWidget::adjustOverview()
 {
-    //if (!overviewWidget) {
-    //    return;
-    //}
-    //overviewWidget->graphView->h_offset = 0;
-    //overviewWidget->graphView->v_offset = 0;
-    //bool scrollXVisible = graphView->horizontalScrollBar()->isVisible();
-    //bool scrollYVisible = graphView->verticalScrollBar()->isVisible();
-    //if (!scrollXVisible && !scrollYVisible) {
-    //    disableOverviewRect();
-    //    return;
-    //}
-    //qreal x = 0;
-    //qreal y = 0;
-    //qreal w = graphView->viewport()->width();
-    //qreal h = graphView->viewport()->height();
-    //qreal curScale = overviewWidget->graphView->current_scale;
-    //qreal baseScale = graphView->current_scale;
+    if (!overviewWidget) {
+        return;
+    }
+    qreal curScale = overviewWidget->graphView->current_scale;
+    qreal baseScale = graphView->current_scale;
+    qreal w = graphView->viewport()->width() * curScale / baseScale;
+    qreal h = graphView->viewport()->height() * curScale / baseScale;
+    int graph_offset_x = graphView->offset_x;
+    int graph_offset_y = graphView->offset_y;
+    int overview_offset_x = overviewWidget->graphView->offset_x;
+    int overview_offset_y = overviewWidget->graphView->offset_y;
+    int rangeRectX = graph_offset_x * curScale - overview_offset_x;
+    int rangeRectY = graph_offset_y * curScale - overview_offset_y;
 
-    //w *= curScale / baseScale;
-    //h *= curScale / baseScale;
-    //if (scrollXVisible) {
-    //    x = graphView->horizontalScrollBar()->value();
-    //    x *= curScale;
-    //} else {
-    //    x = (overviewWidget->graphView->viewport()->width() - w) / 2;
-    //    overviewWidget->graphView->h_offset = x;
-    //}
-
-    //if (scrollYVisible) {
-    //    y = graphView->verticalScrollBar()->value();
-    //    y *= curScale;
-    //} else {
-    //    y = (overviewWidget->graphView->viewport()->height() - h) / 2;
-    //    overviewWidget->graphView->v_offset = y;
-    //}
-
-    //overviewWidget->graphView->rangeRect = QRectF(x + overviewWidget->graphView->unscrolled_render_offset_x,
-    //        y + overviewWidget->graphView->unscrolled_render_offset_y, w, h);
-    //overviewWidget->graphView->viewport()->update();
+    overviewWidget->graphView->rangeRect = QRectF(rangeRectX, rangeRectY, w, h);
+    overviewWidget->graphView->viewport()->update();
 }
 
 void GraphWidget::adjustGraph()

--- a/src/widgets/GraphWidget.cpp
+++ b/src/widgets/GraphWidget.cpp
@@ -90,8 +90,8 @@ void GraphWidget::adjustOverview()
     int graph_offset_y = graphView->offset_y;
     int overview_offset_x = overviewWidget->graphView->offset_x;
     int overview_offset_y = overviewWidget->graphView->offset_y;
-    int rangeRectX = graph_offset_x * curScale - overview_offset_x;
-    int rangeRectY = graph_offset_y * curScale - overview_offset_y;
+    int rangeRectX = graph_offset_x * curScale - overview_offset_x * curScale;
+    int rangeRectY = graph_offset_y * curScale - overview_offset_y * curScale;
 
     overviewWidget->graphView->rangeRect = QRectF(rangeRectX, rangeRectY, w, h);
     overviewWidget->graphView->viewport()->update();
@@ -108,7 +108,7 @@ void GraphWidget::adjustGraph()
     int recty = overviewWidget->graphView->rangeRect.y();
     int overview_offset_x = overviewWidget->graphView->offset_x;
     int overview_offset_y = overviewWidget->graphView->offset_y;
-    graphView->offset_x = (rectx + overview_offset_x) / curScale;
-    graphView->offset_y = (recty + overview_offset_y) / curScale;
+    graphView->offset_x = rectx /curScale + overview_offset_x;
+    graphView->offset_y = recty /curScale + overview_offset_y;
     graphView->viewport()->update();
 }

--- a/src/widgets/GraphWidget.cpp
+++ b/src/widgets/GraphWidget.cpp
@@ -49,29 +49,29 @@ GraphWidget::~GraphWidget() {}
 
 void GraphWidget::toggleOverview(bool visibility)
 {
-    if (!overviewWidget) {
-        return;
-    }
-    if (visibility) {
-        connect(graphView, SIGNAL(refreshBlock()), this, SLOT(adjustOverview()));
-        connect(graphView, SIGNAL(viewZoomed()), this, SLOT(adjustOverview()));
-        connect(graphView->horizontalScrollBar(), SIGNAL(valueChanged(int)), this, SLOT(adjustOverview()));
-        connect(graphView->verticalScrollBar(), SIGNAL(valueChanged(int)), this, SLOT(adjustOverview()));
-        connect(overviewWidget->graphView, SIGNAL(refreshBlock()), this, SLOT(adjustOffset()));
-        connect(overviewWidget->graphView, SIGNAL(mouseMoved()), this, SLOT(adjustGraph()));
-        connect(overviewWidget, &QDockWidget::dockLocationChanged, this, &GraphWidget::adjustOverview);
-        connect(overviewWidget, &OverviewWidget::resized, this, &GraphWidget::adjustOverview);
-    } else {
-        disconnect(graphView, SIGNAL(refreshBlock()), this, SLOT(adjustOverview()));
-        disconnect(graphView, SIGNAL(viewZoomed()), this, SLOT(adjustOverview()));
-        disconnect(graphView->horizontalScrollBar(), SIGNAL(valueChanged(int)), this, SLOT(adjustOverview()));
-        disconnect(graphView->verticalScrollBar(), SIGNAL(valueChanged(int)), this, SLOT(adjustOverview()));
-        disconnect(overviewWidget->graphView, SIGNAL(refreshBlock()), this, SLOT(adjustOffset()));
-        disconnect(overviewWidget->graphView, SIGNAL(mouseMoved()), this, SLOT(adjustGraph()));
-        disconnect(overviewWidget, &QDockWidget::dockLocationChanged, this, &GraphWidget::adjustOverview);
-        disconnect(overviewWidget, &OverviewWidget::resized, this, &GraphWidget::adjustOverview);
-        disableOverviewRect();
-    }
+    //if (!overviewWidget) {
+    //    return;
+    //}
+    //if (visibility) {
+    //    connect(graphView, SIGNAL(refreshBlock()), this, SLOT(adjustOverview()));
+    //    connect(graphView, SIGNAL(viewZoomed()), this, SLOT(adjustOverview()));
+    //    connect(graphView->horizontalScrollBar(), SIGNAL(valueChanged(int)), this, SLOT(adjustOverview()));
+    //    connect(graphView->verticalScrollBar(), SIGNAL(valueChanged(int)), this, SLOT(adjustOverview()));
+    //    connect(overviewWidget->graphView, SIGNAL(refreshBlock()), this, SLOT(adjustOffset()));
+    //    connect(overviewWidget->graphView, SIGNAL(mouseMoved()), this, SLOT(adjustGraph()));
+    //    connect(overviewWidget, &QDockWidget::dockLocationChanged, this, &GraphWidget::adjustOverview);
+    //    connect(overviewWidget, &OverviewWidget::resized, this, &GraphWidget::adjustOverview);
+    //} else {
+    //    disconnect(graphView, SIGNAL(refreshBlock()), this, SLOT(adjustOverview()));
+    //    disconnect(graphView, SIGNAL(viewZoomed()), this, SLOT(adjustOverview()));
+    //    disconnect(graphView->horizontalScrollBar(), SIGNAL(valueChanged(int)), this, SLOT(adjustOverview()));
+    //    disconnect(graphView->verticalScrollBar(), SIGNAL(valueChanged(int)), this, SLOT(adjustOverview()));
+    //    disconnect(overviewWidget->graphView, SIGNAL(refreshBlock()), this, SLOT(adjustOffset()));
+    //    disconnect(overviewWidget->graphView, SIGNAL(mouseMoved()), this, SLOT(adjustGraph()));
+    //    disconnect(overviewWidget, &QDockWidget::dockLocationChanged, this, &GraphWidget::adjustOverview);
+    //    disconnect(overviewWidget, &OverviewWidget::resized, this, &GraphWidget::adjustOverview);
+    //    disableOverviewRect();
+    //}
 }
 
 void GraphWidget::disableOverviewRect()
@@ -85,69 +85,69 @@ void GraphWidget::disableOverviewRect()
 
 void GraphWidget::adjustOverview()
 {
-    if (!overviewWidget) {
-        return;
-    }
-    overviewWidget->graphView->h_offset = 0;
-    overviewWidget->graphView->v_offset = 0;
-    bool scrollXVisible = graphView->horizontalScrollBar()->isVisible();
-    bool scrollYVisible = graphView->verticalScrollBar()->isVisible();
-    if (!scrollXVisible && !scrollYVisible) {
-        disableOverviewRect();
-        return;
-    }
-    qreal x = 0;
-    qreal y = 0;
-    qreal w = graphView->viewport()->width();
-    qreal h = graphView->viewport()->height();
-    qreal curScale = overviewWidget->graphView->current_scale;
-    qreal baseScale = graphView->current_scale;
+    //if (!overviewWidget) {
+    //    return;
+    //}
+    //overviewWidget->graphView->h_offset = 0;
+    //overviewWidget->graphView->v_offset = 0;
+    //bool scrollXVisible = graphView->horizontalScrollBar()->isVisible();
+    //bool scrollYVisible = graphView->verticalScrollBar()->isVisible();
+    //if (!scrollXVisible && !scrollYVisible) {
+    //    disableOverviewRect();
+    //    return;
+    //}
+    //qreal x = 0;
+    //qreal y = 0;
+    //qreal w = graphView->viewport()->width();
+    //qreal h = graphView->viewport()->height();
+    //qreal curScale = overviewWidget->graphView->current_scale;
+    //qreal baseScale = graphView->current_scale;
 
-    w *= curScale / baseScale;
-    h *= curScale / baseScale;
-    if (scrollXVisible) {
-        x = graphView->horizontalScrollBar()->value();
-        x *= curScale;
-    } else {
-        x = (overviewWidget->graphView->viewport()->width() - w) / 2;
-        overviewWidget->graphView->h_offset = x;
-    }
+    //w *= curScale / baseScale;
+    //h *= curScale / baseScale;
+    //if (scrollXVisible) {
+    //    x = graphView->horizontalScrollBar()->value();
+    //    x *= curScale;
+    //} else {
+    //    x = (overviewWidget->graphView->viewport()->width() - w) / 2;
+    //    overviewWidget->graphView->h_offset = x;
+    //}
 
-    if (scrollYVisible) {
-        y = graphView->verticalScrollBar()->value();
-        y *= curScale;
-    } else {
-        y = (overviewWidget->graphView->viewport()->height() - h) / 2;
-        overviewWidget->graphView->v_offset = y;
-    }
+    //if (scrollYVisible) {
+    //    y = graphView->verticalScrollBar()->value();
+    //    y *= curScale;
+    //} else {
+    //    y = (overviewWidget->graphView->viewport()->height() - h) / 2;
+    //    overviewWidget->graphView->v_offset = y;
+    //}
 
-    overviewWidget->graphView->rangeRect = QRectF(x + overviewWidget->graphView->unscrolled_render_offset_x,
-            y + overviewWidget->graphView->unscrolled_render_offset_y, w, h);
-    overviewWidget->graphView->viewport()->update();
+    //overviewWidget->graphView->rangeRect = QRectF(x + overviewWidget->graphView->unscrolled_render_offset_x,
+    //        y + overviewWidget->graphView->unscrolled_render_offset_y, w, h);
+    //overviewWidget->graphView->viewport()->update();
 }
 
 void GraphWidget::adjustGraph()
 {
-    if (!overviewWidget) {
-        return;
-    }
-    int x1 = overviewWidget->graphView->horizontalScrollBar()->value();
-    int y1 = overviewWidget->graphView->verticalScrollBar()->value();
-    qreal x2 = (overviewWidget->graphView->rangeRect.x() - (qreal)overviewWidget->graphView->unscrolled_render_offset_x) / overviewWidget->graphView->current_scale;
-    qreal y2 = (overviewWidget->graphView->rangeRect.y() - (qreal)overviewWidget->graphView->unscrolled_render_offset_y) / overviewWidget->graphView->current_scale;
+    //if (!overviewWidget) {
+    //    return;
+    //}
+    //int x1 = overviewWidget->graphView->horizontalScrollBar()->value();
+    //int y1 = overviewWidget->graphView->verticalScrollBar()->value();
+    //qreal x2 = (overviewWidget->graphView->rangeRect.x() - (qreal)overviewWidget->graphView->unscrolled_render_offset_x) / overviewWidget->graphView->current_scale;
+    //qreal y2 = (overviewWidget->graphView->rangeRect.y() - (qreal)overviewWidget->graphView->unscrolled_render_offset_y) / overviewWidget->graphView->current_scale;
 
-    graphView->horizontalScrollBar()->setValue(x1 + x2);
-    graphView->verticalScrollBar()->setValue(y1 + y2);
+    //graphView->horizontalScrollBar()->setValue(x1 + x2);
+    //graphView->verticalScrollBar()->setValue(y1 + y2);
 }
 
 void GraphWidget::adjustOffset()
 {
-    bool scrollXVisible = graphView->horizontalScrollBar()->isVisible();
-    bool scrollYVisible = graphView->verticalScrollBar()->isVisible();
-    if (!scrollXVisible) {
-        overviewWidget->graphView->unscrolled_render_offset_x = 0;
-    }
-    if (!scrollYVisible) {
-        overviewWidget->graphView->unscrolled_render_offset_y = 0;
-    }
+    //bool scrollXVisible = graphView->horizontalScrollBar()->isVisible();
+    //bool scrollYVisible = graphView->verticalScrollBar()->isVisible();
+    //if (!scrollXVisible) {
+    //    overviewWidget->graphView->unscrolled_render_offset_x = 0;
+    //}
+    //if (!scrollYVisible) {
+    //    overviewWidget->graphView->unscrolled_render_offset_y = 0;
+    //}
 }

--- a/src/widgets/GraphWidget.cpp
+++ b/src/widgets/GraphWidget.cpp
@@ -55,18 +55,12 @@ void GraphWidget::toggleOverview(bool visibility)
     if (visibility) {
         connect(graphView, SIGNAL(refreshBlock()), this, SLOT(adjustOverview()));
         connect(graphView, SIGNAL(viewZoomed()), this, SLOT(adjustOverview()));
-        connect(graphView->horizontalScrollBar(), SIGNAL(valueChanged(int)), this, SLOT(adjustOverview()));
-        connect(graphView->verticalScrollBar(), SIGNAL(valueChanged(int)), this, SLOT(adjustOverview()));
-        connect(overviewWidget->graphView, SIGNAL(refreshBlock()), this, SLOT(adjustOffset()));
         connect(overviewWidget->graphView, SIGNAL(mouseMoved()), this, SLOT(adjustGraph()));
         connect(overviewWidget, &QDockWidget::dockLocationChanged, this, &GraphWidget::adjustOverview);
         connect(overviewWidget, &OverviewWidget::resized, this, &GraphWidget::adjustOverview);
     } else {
         disconnect(graphView, SIGNAL(refreshBlock()), this, SLOT(adjustOverview()));
         disconnect(graphView, SIGNAL(viewZoomed()), this, SLOT(adjustOverview()));
-        disconnect(graphView->horizontalScrollBar(), SIGNAL(valueChanged(int)), this, SLOT(adjustOverview()));
-        disconnect(graphView->verticalScrollBar(), SIGNAL(valueChanged(int)), this, SLOT(adjustOverview()));
-        disconnect(overviewWidget->graphView, SIGNAL(refreshBlock()), this, SLOT(adjustOffset()));
         disconnect(overviewWidget->graphView, SIGNAL(mouseMoved()), this, SLOT(adjustGraph()));
         disconnect(overviewWidget, &QDockWidget::dockLocationChanged, this, &GraphWidget::adjustOverview);
         disconnect(overviewWidget, &OverviewWidget::resized, this, &GraphWidget::adjustOverview);
@@ -105,26 +99,16 @@ void GraphWidget::adjustOverview()
 
 void GraphWidget::adjustGraph()
 {
-    //if (!overviewWidget) {
-    //    return;
-    //}
-    //int x1 = overviewWidget->graphView->horizontalScrollBar()->value();
-    //int y1 = overviewWidget->graphView->verticalScrollBar()->value();
-    //qreal x2 = (overviewWidget->graphView->rangeRect.x() - (qreal)overviewWidget->graphView->unscrolled_render_offset_x) / overviewWidget->graphView->current_scale;
-    //qreal y2 = (overviewWidget->graphView->rangeRect.y() - (qreal)overviewWidget->graphView->unscrolled_render_offset_y) / overviewWidget->graphView->current_scale;
-
-    //graphView->horizontalScrollBar()->setValue(x1 + x2);
-    //graphView->verticalScrollBar()->setValue(y1 + y2);
-}
-
-void GraphWidget::adjustOffset()
-{
-    //bool scrollXVisible = graphView->horizontalScrollBar()->isVisible();
-    //bool scrollYVisible = graphView->verticalScrollBar()->isVisible();
-    //if (!scrollXVisible) {
-    //    overviewWidget->graphView->unscrolled_render_offset_x = 0;
-    //}
-    //if (!scrollYVisible) {
-    //    overviewWidget->graphView->unscrolled_render_offset_y = 0;
-    //}
+    if (!overviewWidget) {
+        return;
+    }
+    qreal curScale = overviewWidget->graphView->current_scale;
+    qreal baseScale = graphView->current_scale;
+    int rectx = overviewWidget->graphView->rangeRect.x();
+    int recty = overviewWidget->graphView->rangeRect.y();
+    int overview_offset_x = overviewWidget->graphView->offset_x;
+    int overview_offset_y = overviewWidget->graphView->offset_y;
+    graphView->offset_x = (rectx + overview_offset_x) / curScale;
+    graphView->offset_y = (recty + overview_offset_y) / curScale;
+    graphView->viewport()->update();
 }

--- a/src/widgets/GraphWidget.cpp
+++ b/src/widgets/GraphWidget.cpp
@@ -27,6 +27,9 @@ GraphWidget::GraphWidget(MainWindow *main, OverviewWidget *overview, QAction *ac
         if (visibility) {
             Core()->setMemoryWidgetPriority(CutterCore::MemoryWidgetType::Graph);
             this->graphView->header->setFixedWidth(width());
+            eprintf("viewport X is %d\n", this->graphView->viewport()->width());
+            eprintf("viewport Y is %d\n", this->graphView->viewport()->height());
+            this->graphView->refreshView();
         }
     });
 

--- a/src/widgets/GraphWidget.h
+++ b/src/widgets/GraphWidget.h
@@ -23,7 +23,6 @@ private:
 private slots:
     void adjustOverview();
     void adjustGraph();
-    void adjustOffset();
 };
 
 #endif // GRAPHWIDGET_H

--- a/src/widgets/OverviewView.cpp
+++ b/src/widgets/OverviewView.cpp
@@ -52,19 +52,21 @@ void OverviewView::refreshView()
 
 void OverviewView::drawBlock(QPainter &p, GraphView::GraphBlock &block)
 {
-    int blockX = block.x - offset_x;
-    int blockY = block.y - offset_y;
+    int blockX = block.x * current_scale - offset_x;
+    int blockY = block.y * current_scale - offset_y;
+    int blockW = block.width * current_scale;
+    int blockH = block.height * current_scale;
 
     p.setPen(Qt::black);
     p.setBrush(Qt::gray);
-    p.drawRect(blockX, blockY, block.width, block.height);
+    p.drawRect(blockX, blockY, blockW, blockH);
     p.setBrush(QColor(0, 0, 0, 100));
     p.drawRect(blockX + 2, blockY + 2,
-               block.width, block.height);
+               blockW, blockH);
     p.setPen(QPen(graphNodeColor, 1));
     p.setBrush(disassemblyBackgroundColor);
     p.drawRect(blockX, blockY,
-               block.width, block.height);
+               blockW, blockH);
 }
 
 void OverviewView::paintEvent(QPaintEvent *event)

--- a/src/widgets/OverviewView.cpp
+++ b/src/widgets/OverviewView.cpp
@@ -28,17 +28,17 @@ OverviewView::~OverviewView()
 
 void OverviewView::adjustScale()
 {
-    if (horizontalScrollBar()->maximum() > 0) {
-        current_scale = (qreal)viewport()->width() / (qreal)(horizontalScrollBar()->maximum() + horizontalScrollBar()->pageStep());
-    }
-    if (verticalScrollBar()->maximum() > 0) {
-        qreal h_scale = (qreal)viewport()->height() / (qreal)(verticalScrollBar()->maximum() + verticalScrollBar()->pageStep());
-        if (current_scale > h_scale) {
-            current_scale = h_scale;
-        }
-    }
-    adjustSize(viewport()->size().width(), viewport()->size().height());
-    viewport()->update();
+    //if (horizontalScrollBar()->maximum() > 0) {
+    //    current_scale = (qreal)viewport()->width() / (qreal)(horizontalScrollBar()->maximum() + horizontalScrollBar()->pageStep());
+    //}
+    //if (verticalScrollBar()->maximum() > 0) {
+    //    qreal h_scale = (qreal)viewport()->height() / (qreal)(verticalScrollBar()->maximum() + verticalScrollBar()->pageStep());
+    //    if (current_scale > h_scale) {
+    //        current_scale = h_scale;
+    //    }
+    //}
+    //adjustSize(viewport()->size().width(), viewport()->size().height());
+    //viewport()->update();
 }
 
 void OverviewView::refreshView()
@@ -107,36 +107,36 @@ void OverviewView::mouseReleaseEvent(QMouseEvent *event)
 
 void OverviewView::mouseMoveEvent(QMouseEvent *event)
 {
-    if (!mouseActive) {
-        return;
-    }
-    qreal x = event->localPos().x() - initialDiff.x();
-    qreal y = event->localPos().y() - initialDiff.y();
-    qreal w = rangeRect.width();
-    qreal h = rangeRect.height();
-    qreal real_width = width * current_scale;
-    qreal real_height = height * current_scale;
-    qreal max_right = unscrolled_render_offset_x + real_width;
-    qreal max_bottom = unscrolled_render_offset_y + real_height;
-    qreal rect_right = x + w;
-    qreal rect_bottom = y + h;
-    if (rect_right >= max_right) {
-        x = unscrolled_render_offset_x + real_width - w;
-    }
-    if (rect_bottom >= max_bottom) {
-        y = unscrolled_render_offset_y + real_height - h;
-    }
-    if (x <= unscrolled_render_offset_x) {
-        x = unscrolled_render_offset_x;
-    }
-    if (y <= unscrolled_render_offset_y) {
-        y = unscrolled_render_offset_y;
-    }
-    x += h_offset;
-    y += v_offset;
-    rangeRect = QRectF(x, y, w, h);
-    viewport()->update();
-    emit mouseMoved();
+//    if (!mouseActive) {
+//        return;
+//    }
+//    qreal x = event->localPos().x() - initialDiff.x();
+//    qreal y = event->localPos().y() - initialDiff.y();
+//    qreal w = rangeRect.width();
+//    qreal h = rangeRect.height();
+//    qreal real_width = width * current_scale;
+//    qreal real_height = height * current_scale;
+//    qreal max_right = unscrolled_render_offset_x + real_width;
+//    qreal max_bottom = unscrolled_render_offset_y + real_height;
+//    qreal rect_right = x + w;
+//    qreal rect_bottom = y + h;
+//    if (rect_right >= max_right) {
+//        x = unscrolled_render_offset_x + real_width - w;
+//    }
+//    if (rect_bottom >= max_bottom) {
+//        y = unscrolled_render_offset_y + real_height - h;
+//    }
+//    if (x <= unscrolled_render_offset_x) {
+//        x = unscrolled_render_offset_x;
+//    }
+//    if (y <= unscrolled_render_offset_y) {
+//        y = unscrolled_render_offset_y;
+//    }
+//    x += h_offset;
+//    y += v_offset;
+//    rangeRect = QRectF(x, y, w, h);
+//    viewport()->update();
+//    emit mouseMoved();
 }
 
 GraphView::EdgeConfiguration OverviewView::edgeConfiguration(GraphView::GraphBlock &from,

--- a/src/widgets/OverviewView.cpp
+++ b/src/widgets/OverviewView.cpp
@@ -97,8 +97,8 @@ void OverviewView::mousePressEvent(QMouseEvent *event)
     }
     qreal w = rangeRect.width();
     qreal h = rangeRect.height();
-    qreal x = event->localPos().x() - w/2 + h_offset;
-    qreal y = event->localPos().y() - h/2 + v_offset;
+    qreal x = event->localPos().x() - w/2;
+    qreal y = event->localPos().y() - h/2;
     rangeRect = QRectF(x, y, w, h);
     viewport()->update();
     emit mouseMoved();
@@ -138,8 +138,6 @@ void OverviewView::mouseMoveEvent(QMouseEvent *event)
 //    if (y <= unscrolled_render_offset_y) {
 //        y = unscrolled_render_offset_y;
 //    }
-//    x += h_offset;
-//    y += v_offset;
 //    rangeRect = QRectF(x, y, w, h);
 //    viewport()->update();
 //    emit mouseMoved();

--- a/src/widgets/OverviewView.cpp
+++ b/src/widgets/OverviewView.cpp
@@ -28,38 +28,42 @@ OverviewView::~OverviewView()
 
 void OverviewView::adjustScale()
 {
-    //if (horizontalScrollBar()->maximum() > 0) {
-    //    current_scale = (qreal)viewport()->width() / (qreal)(horizontalScrollBar()->maximum() + horizontalScrollBar()->pageStep());
-    //}
-    //if (verticalScrollBar()->maximum() > 0) {
-    //    qreal h_scale = (qreal)viewport()->height() / (qreal)(verticalScrollBar()->maximum() + verticalScrollBar()->pageStep());
-    //    if (current_scale > h_scale) {
-    //        current_scale = h_scale;
-    //    }
-    //}
-    //adjustSize(viewport()->size().width(), viewport()->size().height());
-    //viewport()->update();
+    current_scale = (qreal)viewport()->width() / width;
+    qreal h_scale = (qreal)viewport()->height() / height;
+    if (current_scale > h_scale) {
+        current_scale = h_scale;
+    }
+    center();
+    viewport()->update();
+}
+
+void OverviewView::center()
+{
+    offset_x = -((viewport()->width() - width * current_scale) / 2);
+    offset_y = -((viewport()->height() - height * current_scale) / 2);
 }
 
 void OverviewView::refreshView()
 {
     current_scale = 1.0;
     viewport()->update();
-    adjustSize(viewport()->size().width(), viewport()->size().height());
     adjustScale();
 }
 
 void OverviewView::drawBlock(QPainter &p, GraphView::GraphBlock &block)
 {
+    int blockX = block.x - offset_x;
+    int blockY = block.y - offset_y;
+
     p.setPen(Qt::black);
     p.setBrush(Qt::gray);
-    p.drawRect(block.x, block.y, block.width, block.height);
+    p.drawRect(blockX, blockY, block.width, block.height);
     p.setBrush(QColor(0, 0, 0, 100));
-    p.drawRect(block.x + 2, block.y + 2,
+    p.drawRect(blockX + 2, blockY + 2,
                block.width, block.height);
     p.setPen(QPen(graphNodeColor, 1));
     p.setBrush(disassemblyBackgroundColor);
-    p.drawRect(block.x, block.y,
+    p.drawRect(blockX, blockY,
                block.width, block.height);
 }
 

--- a/src/widgets/OverviewView.cpp
+++ b/src/widgets/OverviewView.cpp
@@ -145,6 +145,11 @@ void OverviewView::mouseMoveEvent(QMouseEvent *event)
 //    emit mouseMoved();
 }
 
+void OverviewView::wheelEvent(QWheelEvent *event)
+{
+    event->ignore();
+}
+
 GraphView::EdgeConfiguration OverviewView::edgeConfiguration(GraphView::GraphBlock &from,
                                                                       GraphView::GraphBlock *to)
 {

--- a/src/widgets/OverviewView.cpp
+++ b/src/widgets/OverviewView.cpp
@@ -48,19 +48,17 @@ void OverviewView::drawBlock(QPainter &p, GraphView::GraphBlock &block)
 {
     int blockX = block.x - offset_x;
     int blockY = block.y - offset_y;
-    int blockW = block.width;
-    int blockH = block.height;
 
     p.setPen(Qt::black);
     p.setBrush(Qt::gray);
-    p.drawRect(blockX, blockY, blockW, blockH);
+    p.drawRect(blockX, blockY, block.width, block.height);
     p.setBrush(QColor(0, 0, 0, 100));
     p.drawRect(blockX + 2, blockY + 2,
-               blockW, blockH);
+               block.width, block.height);
     p.setPen(QPen(graphNodeColor, 1));
     p.setBrush(disassemblyBackgroundColor);
     p.drawRect(blockX, blockY,
-               blockW, blockH);
+               block.width, block.height);
 }
 
 void OverviewView::paintEvent(QPaintEvent *event)

--- a/src/widgets/OverviewView.cpp
+++ b/src/widgets/OverviewView.cpp
@@ -97,8 +97,8 @@ void OverviewView::mousePressEvent(QMouseEvent *event)
     }
     qreal w = rangeRect.width();
     qreal h = rangeRect.height();
-    qreal x = event->localPos().x() - w/2;
-    qreal y = event->localPos().y() - h/2;
+    qreal x = event->localPos().x() - w / 2;
+    qreal y = event->localPos().y() - h / 2;
     rangeRect = QRectF(x, y, w, h);
     viewport()->update();
     emit mouseMoved();
@@ -113,34 +113,14 @@ void OverviewView::mouseReleaseEvent(QMouseEvent *event)
 
 void OverviewView::mouseMoveEvent(QMouseEvent *event)
 {
-//    if (!mouseActive) {
-//        return;
-//    }
-//    qreal x = event->localPos().x() - initialDiff.x();
-//    qreal y = event->localPos().y() - initialDiff.y();
-//    qreal w = rangeRect.width();
-//    qreal h = rangeRect.height();
-//    qreal real_width = width * current_scale;
-//    qreal real_height = height * current_scale;
-//    qreal max_right = unscrolled_render_offset_x + real_width;
-//    qreal max_bottom = unscrolled_render_offset_y + real_height;
-//    qreal rect_right = x + w;
-//    qreal rect_bottom = y + h;
-//    if (rect_right >= max_right) {
-//        x = unscrolled_render_offset_x + real_width - w;
-//    }
-//    if (rect_bottom >= max_bottom) {
-//        y = unscrolled_render_offset_y + real_height - h;
-//    }
-//    if (x <= unscrolled_render_offset_x) {
-//        x = unscrolled_render_offset_x;
-//    }
-//    if (y <= unscrolled_render_offset_y) {
-//        y = unscrolled_render_offset_y;
-//    }
-//    rangeRect = QRectF(x, y, w, h);
-//    viewport()->update();
-//    emit mouseMoved();
+    if (!mouseActive) {
+        return;
+    }
+    qreal x = event->localPos().x() - initialDiff.x();
+    qreal y = event->localPos().y() - initialDiff.y();
+    rangeRect = QRectF(x, y, rangeRect.width(), rangeRect.height());
+    viewport()->update();
+    emit mouseMoved();
 }
 
 void OverviewView::wheelEvent(QWheelEvent *event)

--- a/src/widgets/OverviewView.cpp
+++ b/src/widgets/OverviewView.cpp
@@ -37,12 +37,6 @@ void OverviewView::adjustScale()
     viewport()->update();
 }
 
-void OverviewView::center()
-{
-    offset_x = -((viewport()->width() - width * current_scale) / 2);
-    offset_y = -((viewport()->height() - height * current_scale) / 2);
-}
-
 void OverviewView::refreshView()
 {
     current_scale = 1.0;
@@ -52,10 +46,10 @@ void OverviewView::refreshView()
 
 void OverviewView::drawBlock(QPainter &p, GraphView::GraphBlock &block)
 {
-    int blockX = block.x * current_scale - offset_x;
-    int blockY = block.y * current_scale - offset_y;
-    int blockW = block.width * current_scale;
-    int blockH = block.height * current_scale;
+    int blockX = block.x - offset_x;
+    int blockY = block.y - offset_y;
+    int blockW = block.width;
+    int blockH = block.height;
 
     p.setPen(Qt::black);
     p.setBrush(Qt::gray);

--- a/src/widgets/OverviewView.h
+++ b/src/widgets/OverviewView.h
@@ -103,11 +103,6 @@ private:
     void adjustScale();
 
     /*
-     * \brief centerize the position
-     */
-    void center();
-
-    /*
      * \brief if the mouse is in the rect in Overview.
      */
     bool mouseContainsRect(QMouseEvent *event);

--- a/src/widgets/OverviewView.h
+++ b/src/widgets/OverviewView.h
@@ -67,6 +67,10 @@ protected:
      * \brief mouseMoveEvent to move the rect.
      */
     void mouseMoveEvent(QMouseEvent *event) override;
+    /*
+     * \brief override this to prevent scrolling
+     */
+    void wheelEvent(QWheelEvent *event) override;
 
 private:
     /*

--- a/src/widgets/OverviewView.h
+++ b/src/widgets/OverviewView.h
@@ -27,13 +27,6 @@ public:
     QRectF rangeRect;
 
     /*
-     * \brief offset for the rect which is put when either of the scrollbar of
-     * Graph is not visible.
-     */
-    qreal h_offset = 0;
-    qreal v_offset = 0;
-
-    /*
      * \brief Graph access this function to set minimum set of the data
      * @param baseWidth width of Graph when it computed the blocks
      * @param baseHeigh height of Graph when it computed the blocks

--- a/src/widgets/OverviewView.h
+++ b/src/widgets/OverviewView.h
@@ -106,6 +106,11 @@ private:
     void adjustScale();
 
     /*
+     * \brief centerize the position
+     */
+    void center();
+
+    /*
      * \brief if the mouse is in the rect in Overview.
      */
     bool mouseContainsRect(QMouseEvent *event);


### PR DESCRIPTION
Graph now scrolls forever and Overview also applies for it.

even when only a node is shown on the screen, you can move the node.

Also refactoring a lot of Graph and Overview code.

![gifrecord_2019-02-14_202137](https://user-images.githubusercontent.com/29271244/52783925-cdf31b80-3096-11e9-80c9-4554a55408c1.gif)
![gifrecord_2019-02-14_201737](https://user-images.githubusercontent.com/29271244/52783938-d8151a00-3096-11e9-8d61-c10a18eec53d.gif)