### PR TITLE
remove confusing keyowrds from SyntaxHighlighter

### DIFF
--- a/src/common/SyntaxHighlighter.cpp
+++ b/src/common/SyntaxHighlighter.cpp
@@ -20,8 +20,6 @@ SyntaxHighlighter::SyntaxHighlighter(QTextDocument *parent)
                     << "\\bdefault\\b" << "\\bgoto\\b" << "\\bsizeof\\b"
                     << "\\bvolatile\\b" << "\\bdo\\b" << "\\bif\\b"
                     << "\\static\\b" << "\\while\\b";
-    //Special words
-    keywordPatterns << "\\bloc_*\\b" << "\\bsym.*\\b";
 
     QTextCharFormat keywordFormat;
     keywordFormat.setForeground(Qt::red);


### PR DESCRIPTION
the removed regex patterns will color in red everything that matches them. This PR will ignore these special keywords. We need a proper syntax highlighter, see: https://github.com/radareorg/cutter/issues/1170

closes #1205