### PR TITLE
Fix arch and bits in Hexdump Widget

### DIFF
--- a/src/widgets/HexdumpWidget.cpp
+++ b/src/widgets/HexdumpWidget.cpp
@@ -386,6 +386,8 @@ void HexdumpWidget::refresh(RVA addr)
     ui->hexOffsetText->verticalScrollBar()->setValue(ui->hexHexText->verticalScrollBar()->value());
     ui->hexASCIIText->verticalScrollBar()->setValue(ui->hexHexText->verticalScrollBar()->value());
 
+    selectHexPreview();
+
     connectScroll(false);
 }
 


### PR DESCRIPTION
Closes #1059 
Before: Default architecture in the Hexdump Widget was different than the one selected in the Initial Options Dialog.
After: Same architecture in Hexdump Widget and Initial Options Dialog.