### PR TITLE
Add feature to apply structure offset and fix some issues in EditVariablesDialog

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -571,7 +571,7 @@ void CutterCore::applyStructureOffset(const QString &structureOffset, RVA offset
         offset = getOffset();
     }
 
-    this->cmd("ta " + structureOffset + " @ " + QString::number(offset));
+    this->cmdRaw("ta " + structureOffset + " @ " + QString::number(offset));
     emit instructionChanged(offset);
 }
 

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -565,6 +565,16 @@ void CutterCore::setCurrentBits(int bits, RVA offset)
     emit instructionChanged(offset);
 }
 
+void CutterCore::applyStructureOffset(const QString &structureOffset, RVA offset)
+{
+    if (offset == RVA_INVALID) {
+        offset = getOffset();
+    }
+
+    this->cmd("ta " + structureOffset + " @ " + QString::number(offset));
+    emit instructionChanged(offset);
+}
+
 void CutterCore::seek(ut64 offset)
 {
     // Slower than using the API, but the API is not complete

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -106,6 +106,15 @@ public:
     void setImmediateBase(const QString &r2BaseName, RVA offset = RVA_INVALID);
     void setCurrentBits(int bits, RVA offset = RVA_INVALID);
 
+    /*!
+     * \brief Changes immediate displacement to structure offset
+     * This function makes use of the "ta" command of r2 to apply structure
+     * offset to the immediate displacement used in the given instruction
+     * \param structureOffset The name of struct which will be applied
+     * \param offset The address of the instruction where the struct will be applied
+     */
+    void applyStructureOffset(const QString &structureOffset, RVA offset = RVA_INVALID);
+
     /* Classes */
     QList<QString> getAllAnalClasses(bool sorted);
     QList<AnalMethodDescription> getAnalClassMethods(const QString &cls);

--- a/src/dialogs/EditVariablesDialog.cpp
+++ b/src/dialogs/EditVariablesDialog.cpp
@@ -41,6 +41,9 @@ void EditVariablesDialog::applyFields()
     if (newName != desc.name) {
         Core()->cmdRaw(QString("afvn %1 %2").arg(desc.name).arg(newName));
     }
+
+    // Refresh the views to reflect the changes to vars
+    emit Core()->refreshCodeViews();
 }
 
 void EditVariablesDialog::updateFields()
@@ -63,7 +66,7 @@ void EditVariablesDialog::populateTypesComboBox()
     ui->typeComboBox->addItems(userStructures);
     ui->typeComboBox->insertSeparator(ui->typeComboBox->count());
 
-    primitiveTypesTypeList = Core()->getAllTypes();
+    primitiveTypesTypeList = Core()->getAllPrimitiveTypes();
 
     for (const TypeDescription &thisType : primitiveTypesTypeList) {
         ui->typeComboBox->addItem(thisType.type);

--- a/src/menus/DisassemblyContextMenu.h
+++ b/src/menus/DisassemblyContextMenu.h
@@ -55,6 +55,14 @@ private slots:
     void on_actionSetToData_triggered();
     void on_actionSetToDataEx_triggered();
 
+    /*!
+     * \brief Executed on selecting an offset from the structureOffsetMenu
+     * Uses the applyStructureOffset() function of CutterCore to apply the
+     * structure offset
+     * \param action The action which trigered the event
+     */
+    void on_actionStructureOffsetMenu_triggered(QAction *action);
+
 private:
     QKeySequence getCopySequence() const;
     QKeySequence getCommentSequence() const;
@@ -99,6 +107,8 @@ private:
     QAction actionDeleteComment;
     QAction actionDeleteFlag;
     QAction actionDeleteFunction;
+
+    QMenu *structureOffsetMenu;
 
     QMenu *setBaseMenu;
     QAction actionSetBaseBinary;


### PR DESCRIPTION
This pull request:

1. Adds the feature to apply structure offset from the context menus of disassembly and graph view.
2. Fixes EditVariablesDialog such that the view is refreshed after changes and structs are shown only once in the combo box.

As discussed in #1073 , I have only added the basic functionality. Following are the things on which we can work on in r2 for further improvements:

1. `tas <offset>` currently does not support returning output in json (`tasj`) so I have marked it as a TODO in comments. 
2. I couldn't find a way to undo the applying of structure offset, so maybe that will need to be implemented too. (Sorry if it already exists.)

Closes #1072  , closes #1073 

![structureoffset](https://user-images.githubusercontent.com/26463869/53285249-877f7a00-3784-11e9-8cae-ffe27ddc1d0e.gif)
