### PR TITLE
Start using "gui.navbar.seek" color instead of "gui.navbar.err" to show seek cursor

### DIFF
--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -199,8 +199,7 @@ void Configuration::loadBaseThemeNative()
     // Custom
     setColor("gui.imports", QColor(50, 140, 255));
     setColor("gui.main", QColor(0, 128, 0));
-    setColor("gui.navbar.err", QColor(255, 0, 0));
-    setColor("gui.navbar.seek", QColor(233, 86, 86));
+    setColor("gui.navbar.seek", QColor(255, 0, 0));
     setColor("gui.navbar.pc", QColor(66, 238, 244));
     setColor("gui.navbar.code", QColor(104, 229, 69));
     setColor("gui.navbar.str", QColor(69, 104, 229));
@@ -268,7 +267,6 @@ void Configuration::loadBaseThemeDark()
     setColor("gui.main", QColor(0, 128, 0));
 
     // GUI: navbar
-    setColor("gui.navbar.err", QColor(233, 86, 86));
     setColor("gui.navbar.seek", QColor(233, 86, 86));
     setColor("gui.navbar.pc", QColor(66, 238, 244));
     setColor("gui.navbar.code", QColor(130, 200, 111));

--- a/src/widgets/SectionsWidget.cpp
+++ b/src/widgets/SectionsWidget.cpp
@@ -333,7 +333,7 @@ AbstractAddrDock::AbstractAddrDock(SectionsModel *model, QWidget *parent) :
     heightDivisor = 1000;
     rectOffset = 100;
     rectWidth = 400;
-    indicatorColor = ConfigColor("gui.navbar.err");
+    indicatorColor = ConfigColor("gui.navbar.seekDebugActions.h");
     textColor = ConfigColor("gui.dataoffset");
 }
 

--- a/src/widgets/SectionsWidget.cpp
+++ b/src/widgets/SectionsWidget.cpp
@@ -333,7 +333,7 @@ AbstractAddrDock::AbstractAddrDock(SectionsModel *model, QWidget *parent) :
     heightDivisor = 1000;
     rectOffset = 100;
     rectWidth = 400;
-    indicatorColor = ConfigColor("gui.navbar.seekDebugActions.h");
+    indicatorColor = ConfigColor("gui.navbar.seek");
     textColor = ConfigColor("gui.dataoffset");
 }
 

--- a/src/widgets/VisualNavbar.cpp
+++ b/src/widgets/VisualNavbar.cpp
@@ -221,7 +221,7 @@ void VisualNavbar::drawPCCursor()
 
 void VisualNavbar::drawSeekCursor()
 {
-    drawCursor(Core()->getOffset(), Config()->getColor("gui.navbar.err"), seekGraphicsItem);
+    drawCursor(Core()->getOffset(), Config()->getColor("gui.navbar.seek"), seekGraphicsItem);
 }
 
 void VisualNavbar::on_seekChanged(RVA addr)


### PR DESCRIPTION
This modification doesn't have change on the GUI but on the code. Now the seek-cursor in Navbar and Sections widgets will use "gui.navbar.seek" color instead of "gui.navbar.err" which doesn't fit