### PR TITLE
Update templates to hide instructions from final post

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,7 +10,8 @@ about: Create a report to help us improve
 * File format:
 
 **Describe the bug**
-A clear and concise description of what the bug is.
+
+<!-- A clear and concise description of what the bug is. -->
 
 **To Reproduce**
 Steps to reproduce the behavior:
@@ -20,10 +21,15 @@ Steps to reproduce the behavior:
 4. See error
 
 **Expected behavior**
-A clear and concise description of what you expected to happen.
+
+<!-- A clear and concise description of what you expected to happen. -->
+
 
 **Screenshots**
-If applicable, add screenshots to help explain your problem.
+
+<!-- If applicable, add screenshots to help explain your problem. -->
+
 
 **Additional context**
-Add any other context about the problem here.
+
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,6 +14,7 @@ about: Create a report to help us improve
 <!-- A clear and concise description of what the bug is. -->
 
 **To Reproduce**
+
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -5,14 +5,18 @@ about: Suggest an idea for this project
 ---
 
 **Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
 
 **Describe the solution you'd like**
-A clear and concise description of what you want to happen.
-For UI requests, don't hesitate to post some draws.
+
+<!-- A clear and concise description of what you want to happen.
+For UI requests, don't hesitate to post some draws. -->
 
 **Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
 
 **Additional context**
-Add any other context or screenshots about the feature request here.
+
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,17 @@
-*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*
+<!-- *Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.* 
 
 Please provide enough information so that others can review your pull request:
 
-Explain the **details** for making this change. What existing problem does the pull request solve?
+Explain the **details** for making this change. What existing problem does the pull request solve? -->
+
 
 **Test plan (required)**
 
-Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
+<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
 
-**Code formatting**
-
-Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html
+<!-- **Code formatting**
+Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->
 
 **Closing issues**
 
-Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
+<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->


### PR DESCRIPTION
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:

Explain the **details** for making this change. What existing problem does the pull request solve?

some users will keep the Template Instructions in their PR instead of deleting them. This PR will help avoid this by commenting the instructions. When editing and writing PR\ISSUE the users will see the instructions but when posting or previewing their issue\pr the instruction wouldn't be there so it help us maintainers to focus on the important words and sentences in the PR\ISSUE.

**Test plan (required)**

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

Open a new PR or ISSUE and see this work

**Code formatting**

Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html

no code formatting is required in this pr

**Closing issues**

Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

no issue is closed in this pr