### PR TITLE
Make graph overview's node color configurable

### DIFF
--- a/src/common/ColorSchemeFileSaver.cpp
+++ b/src/common/ColorSchemeFileSaver.cpp
@@ -23,7 +23,8 @@ static const QStringList cutterSpecificOptions = {
     "gui.navbar.empty",
     "angui.navbar.str",
     "gui.disass_selected",
-    "gui.breakpoint_background"
+    "gui.breakpoint_background",
+    "gui.overview.node"
 };
 
 ColorSchemeFileSaver::ColorSchemeFileSaver(QObject *parent) : QObject (parent)

--- a/src/widgets/ColorSchemePrefWidget.cpp
+++ b/src/widgets/ColorSchemePrefWidget.cpp
@@ -202,6 +202,12 @@ static const QMap<QString, OptionIfo> optionInfoMap = {
     },
     { "graph.current", { "", "graph.current", false } },
     { "graph.traced", { "", "graph.traced", false } },
+    {
+        "gui.overview.node", {
+            QObject::tr("Background color of Graph Overview's node"),
+            QObject::tr("Graph Overview node"), true
+        }
+    },
     { "gui.cflow", { "", "gui.cflow", true } },
     { "gui.dataoffset", { "", "gui.dataoffset", true } },
     {


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**
The color of Graph Overview's node wasn't configurable. Users that wanted to tweak it weren't able to.
This PR solves it by making it configurable via Color Scheme Preferences.

**Test plan (required)**
This is now fixed

![image](https://user-images.githubusercontent.com/20182642/54075972-2a201880-42ae-11e9-942b-dc94c1a137dc.png)


**Closing issues**
closes #1258
