### PR TITLE
Replace red syntax highlighting with blueish color

### DIFF
--- a/src/common/Highlighter.cpp
+++ b/src/common/Highlighter.cpp
@@ -11,7 +11,6 @@ Highlighter::Highlighter(QTextDocument *parent) :
     core = Core();
 
     keywordFormat.setForeground(QColor(65, 131, 215));
-    keywordFormat.setFontWeight(QFont::Bold);
 
     for (const QString &pattern : this->core->opcodes) {
         rule.pattern = QRegExp("\\b" + pattern + "\\b");
@@ -21,7 +20,6 @@ Highlighter::Highlighter(QTextDocument *parent) :
     }
 
     regFormat.setForeground(QColor(236, 100, 75));
-    regFormat.setFontWeight(QFont::Bold);
 
     for (const QString &pattern : this->core->regs) {
         rule.pattern = QRegExp("\\b" + pattern + "\\b");

--- a/src/common/SyntaxHighlighter.cpp
+++ b/src/common/SyntaxHighlighter.cpp
@@ -22,8 +22,7 @@ SyntaxHighlighter::SyntaxHighlighter(QTextDocument *parent)
                     << "\\static\\b" << "\\while\\b";
 
     QTextCharFormat keywordFormat;
-    keywordFormat.setForeground(Qt::red);
-    keywordFormat.setFontWeight(QFont::Bold);
+    keywordFormat.setForeground(QColor(80, 200, 215));
 
     for ( const auto &pattern : keywordPatterns ) {
         rule.pattern.setPattern(pattern);


### PR DESCRIPTION
This pr will change the Red color of the Syntax Highlighter to a blue\cyan one. This will fit more into Cutter's color scheme. The red was quite scary

----

**Screenshots:**

Before:

![image](https://user-images.githubusercontent.com/20182642/54083339-afe1a980-432a-11e9-97af-b55df4a22276.png)

![image](https://user-images.githubusercontent.com/20182642/54083332-9d677000-432a-11e9-919c-111c3d92b86b.png)

![image](https://user-images.githubusercontent.com/20182642/54083326-93de0800-432a-11e9-9df8-464d57cda520.png)

------


After:
![image](https://user-images.githubusercontent.com/20182642/54083348-cd167800-432a-11e9-829d-b7b8a577190c.png)


![image](https://user-images.githubusercontent.com/20182642/54083310-64c79680-432a-11e9-8790-0db6904ad4f5.png)

![image](https://user-images.githubusercontent.com/20182642/54083317-73ae4900-432a-11e9-9c06-59358f25a43d.png)


**Closing issues**

<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
