### PR TITLE
Overview optimization

### DIFF
--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -336,19 +336,19 @@ void MainWindow::setOverviewData()
 
 void MainWindow::overviewCacheOn()
 {
-    eprintf("hey hey hye\n");
+    if (!overviewDock || overviewDock->userClosed) {
+        return;
+    }
+    if (core->isGraphEmpty()) {
+        enableOverviewMenu(false);
+        overviewDock->hide();
+        return;
+    }
     overviewDock->graphView->useCache = true;
     adjustOverview();
 }
 
 void MainWindow::overviewCacheOff()
-{
-    eprintf("what what what\n");
-    overviewDock->graphView->useCache = false;
-    adjustOverview();
-}
-
-void MainWindow::adjustOverview()
 {
     if (!overviewDock || overviewDock->userClosed) {
         return;
@@ -358,7 +358,13 @@ void MainWindow::adjustOverview()
         overviewDock->hide();
         return;
     }
+    overviewDock->graphView->useCache = false;
     setOverviewData();
+    adjustOverview();
+}
+
+void MainWindow::adjustOverview()
+{
     qreal curScale = overviewDock->graphView->current_scale;
     qreal baseScale = targetGraphDock->graphView->current_scale;
     qreal w = targetGraphDock->graphView->viewport()->width() * curScale / baseScale;

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -200,7 +200,7 @@ void MainWindow::initUI()
     connect(ui->actionOverview, &QAction::toggled, [this](bool checked) {
         if (checked) {
             overviewDock->userClosed = false;
-            adjustOverview();
+            overviewCacheOff();
         }
     });
     sectionsDock = new SectionsWidget(this, ui->actionSections);
@@ -298,33 +298,33 @@ void MainWindow::toggleOverview(bool visibility, GraphWidget *targetGraph)
         return;
     }
     targetGraphDock = targetGraph;
-    connect(targetGraphDock->graphView, SIGNAL(refreshBlock()), this, SLOT(adjustOverview()));
-    connect(targetGraphDock->graphView, SIGNAL(viewRefreshed()), this, SLOT(adjustOverview()));
-    connect(targetGraphDock->graphView, SIGNAL(viewZoomed()), this, SLOT(adjustOverview()));
+    connect(targetGraphDock->graphView, SIGNAL(refreshBlock()), this, SLOT(overviewCacheOn()));
+    connect(targetGraphDock->graphView, SIGNAL(viewRefreshed()), this, SLOT(overviewCacheOff()));
+    connect(targetGraphDock->graphView, SIGNAL(viewZoomed()), this, SLOT(overviewCacheOff()));
     connect(targetGraphDock, &GraphWidget::graphClose, [this]() {
         disconnectOverview();
         enableOverviewMenu(false);
         overviewDock->hide();
     });
     connect(overviewDock->graphView, SIGNAL(mouseMoved()), this, SLOT(adjustGraph()));
-    connect(overviewDock, &QDockWidget::dockLocationChanged, this, &MainWindow::adjustOverview);
+    connect(overviewDock, &QDockWidget::dockLocationChanged, this, &MainWindow::overviewCacheOff);
     connect(overviewDock, &OverviewWidget::graphClose, [this]() {
         ui->actionOverview->setChecked(false);
         if (!core->isGraphEmpty()) {
             overviewDock->userClosed = true;
         }
     });
-    connect(overviewDock, SIGNAL(resized()), this, SLOT(adjustOverview()));
+    connect(overviewDock, SIGNAL(resized()), this, SLOT(overviewCacheOff()));
 }
 
 void MainWindow::disconnectOverview()
 {
-    disconnect(targetGraphDock->graphView, SIGNAL(refreshBlock()), this, SLOT(adjustOverview()));
-    disconnect(targetGraphDock->graphView, SIGNAL(viewRefreshed()), this, SLOT(adjustOverview()));
-    disconnect(targetGraphDock->graphView, SIGNAL(viewZoomed()), this, SLOT(adjustOverview()));
+    disconnect(targetGraphDock->graphView, SIGNAL(refreshBlock()), this, SLOT(overviewCacheOn()));
+    disconnect(targetGraphDock->graphView, SIGNAL(viewRefreshed()), this, SLOT(overviewCacheOff()));
+    disconnect(targetGraphDock->graphView, SIGNAL(viewZoomed()), this, SLOT(overviewCacheOff()));
     disconnect(overviewDock->graphView, SIGNAL(mouseMoved()), this, SLOT(adjustGraph()));
-    disconnect(overviewDock, &QDockWidget::dockLocationChanged, this, &MainWindow::adjustOverview);
-    disconnect(overviewDock, SIGNAL(resized()), this, SLOT(adjustOverview()));
+    disconnect(overviewDock, &QDockWidget::dockLocationChanged, this, &MainWindow::overviewCacheOff);
+    disconnect(overviewDock, SIGNAL(resized()), this, SLOT(overviewCacheOff()));
     disconnect(overviewDock, &QDockWidget::visibilityChanged, this, nullptr);
 }
 
@@ -332,6 +332,20 @@ void MainWindow::setOverviewData()
 {
     overviewDock->graphView->setData(targetGraphDock->graphView->getWidth(),
             targetGraphDock->graphView->getHeight(), targetGraphDock->graphView->getBlocks());
+}
+
+void MainWindow::overviewCacheOn()
+{
+    eprintf("hey hey hye\n");
+    overviewDock->graphView->useCache = true;
+    adjustOverview();
+}
+
+void MainWindow::overviewCacheOff()
+{
+    eprintf("what what what\n");
+    overviewDock->graphView->useCache = false;
+    adjustOverview();
 }
 
 void MainWindow::adjustOverview()

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -201,6 +201,9 @@ void MainWindow::initUI()
         if (checked) {
             overviewDock->userClosed = false;
             overviewCacheOff();
+            if (targetGraphDock) {
+                toggleOverview(true, targetGraphDock);
+            }
         }
     });
     sectionsDock = new SectionsWidget(this, ui->actionSections);

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -334,14 +334,22 @@ void MainWindow::setOverviewData()
             targetGraphDock->graphView->getHeight(), targetGraphDock->graphView->getBlocks());
 }
 
-void MainWindow::overviewCacheOn()
+bool MainWindow::isOverviewActive()
 {
     if (!overviewDock || overviewDock->userClosed) {
-        return;
+        return false;
     }
     if (core->isGraphEmpty()) {
         enableOverviewMenu(false);
         overviewDock->hide();
+        return false;
+    }
+    return true;
+}
+
+void MainWindow::overviewCacheOn()
+{
+    if (!isOverviewActive()) {
         return;
     }
     overviewDock->graphView->useCache = true;
@@ -350,12 +358,7 @@ void MainWindow::overviewCacheOn()
 
 void MainWindow::overviewCacheOff()
 {
-    if (!overviewDock || overviewDock->userClosed) {
-        return;
-    }
-    if (core->isGraphEmpty()) {
-        enableOverviewMenu(false);
-        overviewDock->hide();
+    if (!isOverviewActive()) {
         return;
     }
     overviewDock->graphView->useCache = false;

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -273,6 +273,8 @@ private:
 
     void updateDockActionsChecked();
     void setOverviewData();
+
+    bool isOverviewActive();
 };
 
 #endif // MAINWINDOW_H

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -191,6 +191,7 @@ private slots:
 
     void disconnectOverview();
     void updateOverview();
+    void forceUpdateOverview();
     void updateOverviewAddr();
     void drawOverview();
     void adjustGraph();

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -138,6 +138,8 @@ public slots:
 
     void toggleOverview(bool visibility, GraphWidget *targetGraph);
     void disconnectOverview();
+    void overviewCacheOn();
+    void overviewCacheOff();
     void adjustOverview();
     void adjustGraph();
 

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -137,12 +137,6 @@ public slots:
     void openNewFileFailed();
 
     void toggleOverview(bool visibility, GraphWidget *targetGraph);
-    void disconnectOverview();
-    void overviewCacheOn();
-    void overviewCacheOff();
-    void adjustOverview();
-    void adjustGraph();
-
 private slots:
     void on_actionAbout_triggered();
     void on_actionIssue_triggered();
@@ -194,6 +188,12 @@ private slots:
     bool eventFilter(QObject *object, QEvent *event) override;
     void changeDebugView();
     void changeDefinedView();
+
+    void disconnectOverview();
+    void updateOverview();
+    void updateOverviewAddr();
+    void drawOverview();
+    void adjustGraph();
 
 private:
     CutterCore *core;
@@ -273,7 +273,6 @@ private:
 
     void updateDockActionsChecked();
     void setOverviewData();
-
     bool isOverviewActive();
 };
 

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -182,6 +182,7 @@ void DisassemblerGraphView::loadCurrentGraph()
     QJsonArray functions;
     RAnalFunction *fcn = Core()->functionAt(seekable->getOffset());
     if (fcn) {
+        currentFcnAddr = fcn->addr;
         QJsonDocument functionsDoc = Core()->cmdj("agJ " + RAddressString(fcn->addr));
         functions = functionsDoc.array();
     }
@@ -211,14 +212,8 @@ void DisassemblerGraphView::loadCurrentGraph()
     // Refresh global "empty graph" variable so other widget know there is nothing to show here
     Core()->setGraphEmpty(emptyGraph);
 
-    Analysis anal;
-    anal.ready = true;
-
     QJsonValue funcRef = functions.first();
     QJsonObject func = funcRef.toObject();
-    Function f;
-    f.ready = true;
-    f.entry = func["offset"].toVariant().toULongLong();
 
     windowTitle = tr("Graph");
     QString funcName = func["name"].toString().trimmed();
@@ -312,14 +307,9 @@ void DisassemblerGraphView::loadCurrentGraph()
         }
         disassembly_blocks[db.entry] = db;
         prepareGraphNode(gb);
-        f.blocks.push_back(db);
 
         addBlock(gb);
     }
-
-    anal.functions[f.entry] = f;
-    anal.status = "Ready.";
-    anal.entry = f.entry;
 
     if (!func["blocks"].toArray().isEmpty()) {
         computeGraph(entry);

--- a/src/widgets/DisassemblerGraphView.h
+++ b/src/widgets/DisassemblerGraphView.h
@@ -83,32 +83,6 @@ class DisassemblerGraphView : public GraphView
         bool indirectcall = false;
     };
 
-    struct Function {
-        bool ready;
-        ut64 entry;
-        ut64 update_id;
-        std::vector<DisassemblyBlock> blocks;
-    };
-
-    struct Analysis {
-        ut64 entry = 0;
-        std::unordered_map<ut64, Function> functions;
-        bool ready = false;
-        ut64 update_id = 0;
-        QString status = "Analyzing...";
-
-        bool find_instr(ut64 addr, ut64 &func, ut64 &instr)
-        {
-            //TODO implement
-            Q_UNUSED(addr);
-            Q_UNUSED(func);
-            Q_UNUSED(instr);
-            return false;
-        }
-
-        //dummy class
-    };
-
 public:
     DisassemblerGraphView(QWidget *parent);
     ~DisassemblerGraphView() override;
@@ -129,7 +103,6 @@ public:
 
     int getWidth() { return width; }
     int getHeight() { return height; }
-
     std::unordered_map<ut64, GraphBlock> getBlocks() { return blocks; }
 public slots:
     void refreshView();

--- a/src/widgets/GraphView.cpp
+++ b/src/widgets/GraphView.cpp
@@ -381,7 +381,12 @@ QPolygonF GraphView::recalculatePolygon(QPolygonF polygon)
 void GraphView::paintEvent(QPaintEvent *event)
 {
     Q_UNUSED(event);
-    QPainter p(viewport());
+    if (useCache) {
+        drawGraph();
+        return;
+    }
+    pixmap = QPixmap(viewport()->width(), viewport()->height());
+    QPainter p(&pixmap);
 
     p.setRenderHint(QPainter::Antialiasing);
 
@@ -436,8 +441,16 @@ void GraphView::paintEvent(QPaintEvent *event)
             }
         }
     }
-
+    drawGraph();
     emit refreshBlock();
+}
+
+void GraphView::drawGraph()
+{
+    QRectF target(0.0, 0.0, viewport()->width(), viewport()->height());
+    QRectF source(0.0, 0.0, viewport()->width(), viewport()->height());
+    QPainter p(viewport());
+    p.drawPixmap(target, pixmap, source);
 }
 
 // Prepare graph

--- a/src/widgets/GraphView.h
+++ b/src/widgets/GraphView.h
@@ -109,6 +109,13 @@ public:
      */
     bool useCache = false;
 
+    /**
+     * @brief keep the current addr of the fcn of Graph
+     * Everytime overview updates its contents, it compares this value with the one in Graph
+     * if they aren't same, then Overview needs to update the pixmap cache.
+     */
+    ut64 currentFcnAddr = 0;
+
 protected:
     std::unordered_map<ut64, GraphBlock> blocks;
     QColor backgroundColor = QColor(Qt::white);

--- a/src/widgets/GraphView.h
+++ b/src/widgets/GraphView.h
@@ -104,6 +104,11 @@ public:
     int offset_x = 0;
     int offset_y = 0;
 
+    /**
+     * @brief flag to control if the cached pixmap should be used
+     */
+    bool useCache = false;
+
 protected:
     std::unordered_map<ut64, GraphBlock> blocks;
     QColor backgroundColor = QColor(Qt::white);
@@ -129,6 +134,7 @@ protected:
     virtual void wheelEvent(QWheelEvent *event) override;
     virtual EdgeConfiguration edgeConfiguration(GraphView::GraphBlock &from, GraphView::GraphBlock *to);
 
+    void drawGraph();
     bool event(QEvent *event) override;
 
     // Mouse events
@@ -142,6 +148,12 @@ protected:
     void centerY();
     int width = 0;
     int height = 0;
+
+    /**
+     * @brief pixmap that caches the graph nodes
+     */
+    QPixmap pixmap;
+
 private:
     bool checkPointClicked(QPointF &point, int x, int y, bool above_y = false);
 

--- a/src/widgets/OverviewView.cpp
+++ b/src/widgets/OverviewView.cpp
@@ -94,6 +94,7 @@ void OverviewView::mousePressEvent(QMouseEvent *event)
     qreal x = event->localPos().x() - w / 2;
     qreal y = event->localPos().y() - h / 2;
     rangeRect = QRectF(x, y, w, h);
+    useCache = true;
     viewport()->update();
     emit mouseMoved();
     mouseContainsRect(event);
@@ -113,6 +114,7 @@ void OverviewView::mouseMoveEvent(QMouseEvent *event)
     qreal x = event->localPos().x() - initialDiff.x();
     qreal y = event->localPos().y() - initialDiff.y();
     rangeRect = QRectF(x, y, rangeRect.width(), rangeRect.height());
+    useCache = true;
     viewport()->update();
     emit mouseMoved();
 }

--- a/src/widgets/OverviewView.cpp
+++ b/src/widgets/OverviewView.cpp
@@ -19,14 +19,14 @@ void OverviewView::setData(int baseWidth, int baseHeight, std::unordered_map<ut6
     width = baseWidth;
     height = baseHeight;
     blocks = baseBlocks;
-    refreshView();
+    scaleAndCenter();
 }
 
 OverviewView::~OverviewView()
 {
 }
 
-void OverviewView::refreshView()
+void OverviewView::scaleAndCenter()
 {
     current_scale = (qreal)viewport()->width() / width;
     qreal h_scale = (qreal)viewport()->height() / height;
@@ -34,6 +34,11 @@ void OverviewView::refreshView()
         current_scale = h_scale;
     }
     center();
+}
+
+void OverviewView::refreshView()
+{
+    scaleAndCenter();
     viewport()->update();
 }
 

--- a/src/widgets/OverviewView.h
+++ b/src/widgets/OverviewView.h
@@ -36,7 +36,11 @@ public:
 
 public slots:
     /**
-     * @brief refresh the view and adjust the scale
+     * @brief calculate the scale to fit the all nodes in and center them in the viewport
+     */
+    void scaleAndCenter();
+    /**
+     * @brief scale and center all nodes in, then run update
      */
     void refreshView();
 

--- a/src/widgets/OverviewView.h
+++ b/src/widgets/OverviewView.h
@@ -36,10 +36,6 @@ public:
 
 public slots:
     /**
-     * @brief calculate the scale to fit the all nodes in and center them in the viewport
-     */
-    void scaleAndCenter();
-    /**
      * @brief scale and center all nodes in, then run update
      */
     void refreshView();
@@ -82,6 +78,11 @@ private:
      * so as to change the rect point properly along with mouse.
      */
     QPointF initialDiff;
+
+    /**
+     * @brief calculate the scale to fit the all nodes in and center them in the viewport
+     */
+    void scaleAndCenter();
 
     /**
      * @brief draw the computed blocks passed by Graph


### PR DESCRIPTION
Optimized the performance of Overview.

Before, overview redrew all the nodes when it needed to update only the red rectangle, so basically it went through all the blocks and the edges to calculate positions just to update the red rectangle, which obviously had been making things uber slow.

Now, Overview utilizes QPixmap to keep the cache of all the nodes and edges, so it doesn't have to go through everything anymore just to update the red rectangle.