### PR TITLE
Enable "emu.str" by default and change "asm.cmt.col" to 70 - fix #1269

### DIFF
--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -33,7 +33,7 @@ static const QHash<QString, QVariant> asmOptions = {
     { "asm.flags.offset",   false },
     { "asm.emu",            false },
     { "asm.cmt.right",      true },
-    { "asm.cmt.col",        35 },
+    { "asm.cmt.col",        70 },
     { "asm.var.summary",    false },
     { "asm.bytes",          false },
     { "asm.size",           false },
@@ -49,6 +49,7 @@ static const QHash<QString, QVariant> asmOptions = {
     { "asm.tabs",           5 },
     { "asm.tabs.off",       5 },
     { "asm.marks",          false },
+    { "emu.str",            true },
     { "esil.breakoninvalid",   true },
     { "graph.offset",       false}
 };


### PR DESCRIPTION
Update default config to improve asm output as suggested in issue #1269 