### PR TITLE
Fix a font issue

### DIFF
--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -374,6 +374,7 @@ void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block)
 
     p.setPen(Qt::black);
     p.setBrush(Qt::gray);
+    p.setFont(Config()->getFont());
     p.drawRect(blockX, blockY, block.width, block.height);
 
     breakpoints = Core()->getBreakpointsAddresses();


### PR DESCRIPTION
Graph does not get the font because in initFont() DissassemblerGraphView register font to the view itself and not to the pixmap which is used to draw the graph on. 

So in paintEvent, the font needs to be registered to the pen and that solves the issue.