### PR TITLE
Force overview to update itself when the settings are changed

### DIFF
--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -306,7 +306,7 @@ void MainWindow::toggleOverview(bool visibility, GraphWidget *targetGraph)
     }
     targetGraphDock = targetGraph;
     connect(targetGraphDock->graphView, SIGNAL(refreshBlock()), this, SLOT(updateOverview()));
-    connect(targetGraphDock->graphView, SIGNAL(viewRefreshed()), this, SLOT(updateOverview()));
+    connect(targetGraphDock->graphView, SIGNAL(viewRefreshed()), this, SLOT(forceUpdateOverview()));
     connect(targetGraphDock->graphView, SIGNAL(viewZoomed()), this, SLOT(updateOverview()));
     connect(targetGraphDock, &GraphWidget::graphClose, [this]() {
         disconnectOverview();
@@ -328,7 +328,7 @@ void MainWindow::toggleOverview(bool visibility, GraphWidget *targetGraph)
 void MainWindow::disconnectOverview()
 {
     disconnect(targetGraphDock->graphView, SIGNAL(refreshBlock()), this, SLOT(updateOverview()));
-    disconnect(targetGraphDock->graphView, SIGNAL(viewRefreshed()), this, SLOT(updateOverview()));
+    disconnect(targetGraphDock->graphView, SIGNAL(viewRefreshed()), this, SLOT(forceUpdateOverview()));
     disconnect(targetGraphDock->graphView, SIGNAL(viewZoomed()), this, SLOT(updateOverview()));
     disconnect(overviewDock->graphView, SIGNAL(mouseMoved()), this, SLOT(adjustGraph()));
     disconnect(overviewDock->graphView, SIGNAL(refreshBlock()), this, SLOT(updateOverviewAddr()));


### PR DESCRIPTION
Issue: Overview does not apply the changes in the settings immediately.

Reproduce procedure: go to Preference when Overview is open then tweak the width of Graph. Graph adjusts self to it, yet Overview doesn't. 

Fix: Even when the settings were changed, Overview had been using the cache. So fixed that to force update.