### PR TITLE
Refactor color scheme edit feature

### DIFF
--- a/src/common/ColorSchemeFileSaver.cpp
+++ b/src/common/ColorSchemeFileSaver.cpp
@@ -56,7 +56,7 @@ QString ColorSchemeFileSaver::copy(const QString &srcThemeName,
                                    const QString &copyThemeName) const
 {
     if (!isSchemeExist(srcThemeName)) {
-        return tr("TODO");
+        return tr("Scheme <b>%1</b> does not exist.").arg(srcThemeName);
     }
     QString currTheme = Config()->getColorTheme();
     Config()->setColorTheme(srcThemeName);
@@ -77,7 +77,8 @@ QString ColorSchemeFileSaver::save(const QJsonDocument &scheme, const QString &s
 {
     QFile fOut(customR2ThemesLocationPath + QDir::separator() + schemeName);
     if (!fOut.open(QFile::WriteOnly | QFile::Truncate)) {
-        return "TODO";
+        return tr("Error occurred during copying. Please make sure you have access to %1")
+                .arg(customR2ThemesLocationPath);
     }
 
     QJsonObject obj = scheme.object();

--- a/src/common/ColorSchemeFileSaver.h
+++ b/src/common/ColorSchemeFileSaver.h
@@ -21,14 +21,27 @@ public:
 
     virtual ~ColorSchemeFileSaver() {}
 
-    QFile::FileError copy(const QString &srcSchemeName, const QString &copySchemeName) const;
 
-    QFile::FileError save(const QString &scheme, const QString &schemeName) const;
+    /**
+     * @brief Copies @a srcSchemeName with name @a copySchemeName.
+     * @param srcSchemeName
+     * Name of scheme to be copied.
+     * @param copySchemeName
+     * Name of copy.
+     * @return "" on success or error message.
+     */
+    QString copy(const QString &srcSchemeName, const QString &copySchemeName) const;
+
+    QString save(const QJsonDocument& scheme, const QString &schemeName) const;
 
     bool isCustomScheme(const QString &schemeName) const;
 
-    bool isNameEngaged(const QString &name) const;
+    bool isSchemeExist(const QString &name) const;
 
+    /**
+     * @brief Returns colors for color options used in Cutter, but not
+     * in radare2 (such as navbar colors, breakpoint colors, etc).
+     */
     QMap<QString, QColor> getCutterSpecific() const;
 
     QStringList getCustomSchemes() const;

--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -393,8 +393,8 @@ void Configuration::setColorTheme(const QString &theme)
         Core()->cmd(QStringLiteral("eco %1").arg(theme));
         s.setValue("theme", theme);
     }
+
     // Duplicate interesting colors into our Cutter Settings
-    // Dirty fix for arrow colors, TODO refactor getColor, setColor, etc.
     QJsonDocument colors = Core()->cmdj("ecj");
     QJsonObject colorsObject = colors.object();
 
@@ -403,13 +403,15 @@ void Configuration::setColorTheme(const QString &theme)
         if (rgb.size() != 3) {
             continue;
         }
-        s.setValue("colors." + it.key(), QColor(rgb[0].toInt(), rgb[1].toInt(), rgb[2].toInt()));
+        setColor(it.key(), QColor(rgb[0].toInt(), rgb[1].toInt(), rgb[2].toInt()));
     }
 
     QMap<QString, QColor> cutterSpecific = ColorSchemeFileWorker().getCutterSpecific();
-    for (auto &it : cutterSpecific.keys())
+    for (auto &it : cutterSpecific.keys()){
         setColor(it, cutterSpecific[it]);
+    }
 
+    // Trick Cutter to load colors that are not specified in standard scheme
     if (!ColorSchemeFileWorker().isCustomScheme(theme)) {
         setTheme(getTheme());
     }

--- a/src/dialogs/preferences/AppearanceOptionsWidget.cpp
+++ b/src/dialogs/preferences/AppearanceOptionsWidget.cpp
@@ -178,6 +178,9 @@ void AppearanceOptionsWidget::on_deleteButton_clicked()
             ColorSchemeFileWorker().deleteScheme(Config()->getColorTheme());
             updateThemeFromConfig(false);
         }
+    } else {
+        QMessageBox::critical(this, tr("Permission denied"),
+                              tr("You do not have permissions to change this color scheme."));
     }
 }
 

--- a/src/dialogs/preferences/AppearanceOptionsWidget.cpp
+++ b/src/dialogs/preferences/AppearanceOptionsWidget.cpp
@@ -154,7 +154,7 @@ void AppearanceOptionsWidget::on_copyButton_clicked()
         newSchemeName = QInputDialog::getText(this, tr("Enter scheme name"),
                                               tr("Name:"), QLineEdit::Normal,
                                               QDir::home().dirName());
-    } while ((!newSchemeName.isEmpty() && ColorSchemeFileWorker().isNameEngaged(newSchemeName))
+    } while ((!newSchemeName.isEmpty() && ColorSchemeFileWorker().isSchemeExist(newSchemeName))
         || newSchemeName.contains(QRegExp("[^\\w.()\\[\\]_-]"))
         || newSchemeName.startsWith('.'));
 

--- a/src/widgets/ColorSchemePrefWidget.h
+++ b/src/widgets/ColorSchemePrefWidget.h
@@ -11,6 +11,14 @@ namespace Ui {
 class ColorSchemePrefWidget;
 }
 
+
+struct ColorOption {
+    QString optionName;
+    QString displayingText;
+    QColor color;
+};
+Q_DECLARE_METATYPE(ColorOption);
+
 class ColorSchemePrefWidget : public QWidget
 {
     Q_OBJECT
@@ -24,9 +32,16 @@ public slots:
     void updateSchemeFromConfig();
 
 private slots:
-    void newColor();
+    /**
+     * @brief Shows color choose dialog and changes current color.
+     * Triggered when ColorViewButton is clicked.
+     */
+    void changeCurrentColor();
 
-    void indexChanged(const QModelIndex &ni);
+    void colorOptionChanged(const ColorOption& option);
+
+    void resetCurrentColor();
+
 
 private:
     Ui::ColorSchemePrefWidget *ui;
@@ -52,13 +67,6 @@ signals:
     void clicked();
 };
 
-struct ColorOption {
-    QString optionName;
-    QString displayingText;
-    QColor color;
-};
-Q_DECLARE_METATYPE(ColorOption);
-
 
 class ColorSettingsModel : public QAbstractListModel
 {
@@ -69,11 +77,7 @@ public:
 
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
 
-    void setColor(const QString &option, const QColor &color);
-
-    QColor getBackroundColor() const;
-
-    QColor getTextColor() const;
+    bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
 
     int rowCount(const QModelIndex &parent = QModelIndex()) const override
     {
@@ -82,6 +86,8 @@ public:
     }
 
     void updateScheme();
+
+    QJsonDocument getScheme() const;
 
 private:
     QList<ColorOption> m_data;
@@ -104,7 +110,7 @@ public:
 
 private:
     QColor backgroundColor;
-    QColor textColor;
+    QColor standardTextColor;
 };
 
 class PreferencesListView : public QListView
@@ -120,8 +126,12 @@ protected slots:
     void currentChanged(const QModelIndex &current,
                         const QModelIndex &previous) override;
 
+    void dataChanged(const QModelIndex & topLeft, const QModelIndex & bottomRight,
+                     const QVector<int> &roles = QVector<int>()) override;
+
 signals:
     void indexChanged(const QModelIndex &ni);
+    void colorOptionChanged(const ColorOption& option);
 
 private:
     ColorOptionDelegate *delegate;

--- a/src/widgets/ColorSchemePrefWidget.ui
+++ b/src/widgets/ColorSchemePrefWidget.ui
@@ -24,7 +24,7 @@
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_2">
          <item>
-          <widget class="ColorViewButton" name="colorViewFore">
+          <widget class="ColorViewButton" name="colorViewButton">
            <property name="sizePolicy">
             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
              <horstretch>0</horstretch>

--- a/src/widgets/ColorSchemePrefWidget.ui
+++ b/src/widgets/ColorSchemePrefWidget.ui
@@ -47,8 +47,11 @@
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
+           <property name="toolTip">
+            <string>Sets color depending on system palette.</string>
+           </property>
            <property name="text">
-            <string>Set Default</string>
+            <string>Use Native</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
<!-- *Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.* 

Please provide enough information so that others can review your pull request:

Explain the **details** for making this change. What existing problem does the pull request solve? -->

Currently our scheme edit feature is a mess. There are some bugs I found, but I think it maybe isn't all.
First of all, when you copy standard r2 scheme it does not go well:
![copy-fails](https://user-images.githubusercontent.com/42874998/54496362-74814500-48ff-11e9-90fe-a8efa4b8d803.gif)

As you can see, not all color options is copied, so other is set to black and it looks terrible.

Second of all we have button "Set default", but this button has no action assigned to it. And if user tries to edit standard r2 theme, when he clicks on button nothing happens.
![other-fails](https://user-images.githubusercontent.com/42874998/54496399-ed809c80-48ff-11e9-8cda-c409d0238fc4.gif)


So, this PR is closing copy issue:
![copy-feature](https://user-images.githubusercontent.com/42874998/54496417-23be1c00-4900-11e9-82ff-6718e0f5121a.gif)

provides action to "Set default" button:
![set-default](https://user-images.githubusercontent.com/42874998/54496430-43554480-4900-11e9-823a-427e9d697b9c.gif)

and provides message to user that he can't edit standard schemes:
![access-denied](https://user-images.githubusercontent.com/42874998/54496439-5f58e600-4900-11e9-8657-66d2cb1bcea5.gif)

And maybe something else I forgot to mention. 