### PR TITLE
Fix a bug of Overview perf

### DIFF
--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -344,7 +344,7 @@ void MainWindow::setOverviewData()
 
 bool MainWindow::isOverviewActive()
 {
-    if (!overviewDock || overviewDock->userClosed) {
+    if (!overviewDock || overviewDock->userClosed || !overviewDock->isVisible) {
         return false;
     }
     if (core->isGraphEmpty()) {

--- a/src/widgets/OverviewWidget.cpp
+++ b/src/widgets/OverviewWidget.cpp
@@ -15,6 +15,7 @@ OverviewWidget::OverviewWidget(MainWindow *main, QAction *action) :
     });
 
     connect(this, &QDockWidget::visibilityChanged, this, [ = ](bool visibility) {
+        isVisible = visibility;
         if (visibility) {
             updateContents();
         }

--- a/src/widgets/OverviewWidget.h
+++ b/src/widgets/OverviewWidget.h
@@ -19,6 +19,7 @@ public:
      * @brief if user closed this widget explicitly
      */
     bool userClosed = false;
+    bool isVisible = false;
 private:
     RefreshDeferrer *refreshDeferrer;
     /**


### PR DESCRIPTION
Fix #1320 

Issue: 
Overview caches its contents such as drawn nodes, edges, by caching the address too, to use it for the algorithm to trigger the cached contents to be used at the right time. It updates the address no sooner than it finishes updating the contents, but when it's in background, it never updates the address because it does not update the contents when it is background, so that cached contents will never be used and that makes Graph really slow like it used to be a while ago.

Reproduce procedure:
First of all, dock some random widget on Overview dock, then hide Overview with it.
Second, you go to some random huge function such as /bin/ls main and move around, then you will see the issue there.

Fix:
Check if Overview is visible, and it should not update anything at all when it is not visible. Once it comes back to visible then it needs to update its contents immediately according to Graph, then caches the result.