### PR TITLE
Fixed a bug related to reset_settings

### DIFF
--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -1026,8 +1026,8 @@ void MainWindow::on_actionReset_settings_triggered()
                                                            tr("Do you really want to clear all settings?"),
                                                            QMessageBox::Ok | QMessageBox::Cancel);
     if (ret == QMessageBox::Ok) {
-        on_actionDefault_triggered();
         Config()->resetAll();
+        on_actionDefault_triggered();
     }
 }
 


### PR DESCRIPTION
I found a bug when resetting settings.

Reproduce:

Open Graph Overview then reset settings, then you will see Graph Overview does not properly honor the settings.

Fix:

when reset settings, clear the settings first then reset layout, the order should be like this.


![bug](https://user-images.githubusercontent.com/29271244/54769779-4aa08900-4c45-11e9-9009-74f942a99154.png)

![bug2](https://user-images.githubusercontent.com/29271244/54769824-6146e000-4c45-11e9-9475-723a39c61530.png)

 