### PR TITLE
Build an app bundle on macOS

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -148,7 +148,8 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
 endif()
 
 
-add_executable(Cutter ${UI_FILES} ${QRC_FILES} ${SOURCE_FILES} ${HEADER_FILES} ${BINDINGS_SOURCE})
+add_executable(Cutter MACOSX_BUNDLE ${UI_FILES} ${QRC_FILES} ${SOURCE_FILES} ${HEADER_FILES} ${BINDINGS_SOURCE})
+set_target_properties(Cutter PROPERTIES MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/macos/Info.plist")
 
 target_link_libraries(Cutter Qt5::Core Qt5::Widgets Qt5::Gui Qt5::Svg Qt5::Network)
 target_link_libraries(Cutter ${RADARE2_LIBRARIES})


### PR DESCRIPTION
<!-- *Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.* 

Please provide enough information so that others can review your pull request:

Explain the **details** for making this change. What existing problem does the pull request solve? -->

This change makes CMake output an app bundle on macOS (`Cutter.app` with proper setup). This was previously done by qmake.

**Test plan (required)**

Output executable *Cutter* should be located at `${CMAKE_CURRENT_BINARY_DIR}/Cutter.app/Contents/MacOS/Cutter`. Double-clicking the bundle in Finder works as expected.

**Closing issues**

None.