### PR TITLE
Fix a bug regarding highlighting the words in Graph

### DIFF
--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -855,6 +855,7 @@ void DisassemblerGraphView::blockClicked(GraphView::GraphBlock &block, QMouseEve
     if (event->button() == Qt::RightButton) {
         mMenu->exec(event->globalPos());
     }
+    viewport()->update();
 }
 
 void DisassemblerGraphView::blockDoubleClicked(GraphView::GraphBlock &block, QMouseEvent *event,


### PR DESCRIPTION
Fix #1319 

Very obvious. Graph needs to update the viewport after the block being clicked and it'd not been like that so.