### PR TITLE
Feature/dialogs optimization

### DIFF
--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -1039,9 +1039,8 @@ void MainWindow::on_actionRedoSeek_triggered()
 
 void MainWindow::on_actionDisasAdd_comment_triggered()
 {
-    CommentsDialog *c = new CommentsDialog(this);
-    c->exec();
-    delete c;
+    CommentsDialog c(this);
+    c.exec();
 }
 
 void MainWindow::on_actionRefresh_contents_triggered()

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -915,10 +915,10 @@ void MainWindow::on_actionLockUnlock_triggered()
 
 void MainWindow::on_actionFunctionsRename_triggered()
 {
-    RenameDialog *r = new RenameDialog(this);
+    RenameDialog r(this);
     // Get function based on click position
     //r->setFunctionName(fcn_name);
-    r->open();
+    r.exec();
 }
 
 void MainWindow::on_actionDefault_triggered()

--- a/src/dialogs/EditInstructionDialog.cpp
+++ b/src/dialogs/EditInstructionDialog.cpp
@@ -2,7 +2,7 @@
 #include "ui_EditInstructionDialog.h"
 #include "core/Cutter.h"
 
-EditInstructionDialog::EditInstructionDialog(QWidget *parent, InstructionEditMode editMode) :
+EditInstructionDialog::EditInstructionDialog(InstructionEditMode editMode, QWidget *parent) :
     QDialog(parent),
     ui(new Ui::EditInstructionDialog),
     editMode(editMode)

--- a/src/dialogs/EditInstructionDialog.h
+++ b/src/dialogs/EditInstructionDialog.h
@@ -18,7 +18,7 @@ class EditInstructionDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit EditInstructionDialog(QWidget *parent, InstructionEditMode isEditingBytes);
+    explicit EditInstructionDialog(InstructionEditMode isEditingBytes, QWidget *parent = nullptr);
     ~EditInstructionDialog();
 
     QString getInstruction();

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -790,39 +790,39 @@ void DisassemblyContextMenu::on_actionDeleteFunction_triggered()
 void DisassemblyContextMenu::on_actionEditFunction_triggered()
 {
     RCore *core = Core()->core();
-    EditFunctionDialog *dialog = new EditFunctionDialog(this);
+    EditFunctionDialog dialog(this);
     RAnalFunction *fcn = r_anal_get_fcn_in(core->anal, offset, 0);
 
     if (fcn) {
-        dialog->setWindowTitle(tr("Edit function %1").arg(fcn->name));
-        dialog->setNameText(fcn->name);
+        dialog.setWindowTitle(tr("Edit function %1").arg(fcn->name));
+        dialog.setNameText(fcn->name);
 
         QString startAddrText = "0x" + QString::number(fcn->addr, 16);
-        dialog->setStartAddrText(startAddrText);
+        dialog.setStartAddrText(startAddrText);
 
         QString endAddrText = "0x" + QString::number(fcn->addr + fcn->_size, 16);
-        dialog->setEndAddrText(endAddrText);
+        dialog.setEndAddrText(endAddrText);
 
         QString stackSizeText;
         stackSizeText.sprintf("%d", fcn->stack);
-        dialog->setStackSizeText(stackSizeText);
+        dialog.setStackSizeText(stackSizeText);
 
         QStringList callConList = Core()->cmd("afcl").split("\n");
         callConList.removeLast();
-        dialog->setCallConList(callConList);
-        dialog->setCallConSelected(fcn->cc);
+        dialog.setCallConList(callConList);
+        dialog.setCallConSelected(fcn->cc);
 
 
-        if (dialog->exec()) {
-            QString new_name = dialog->getNameText();
+        if (dialog.exec()) {
+            QString new_name = dialog.getNameText();
             Core()->renameFunction(fcn->name, new_name);
-            QString new_start_addr = dialog->getStartAddrText();
+            QString new_start_addr = dialog.getStartAddrText();
             fcn->addr = Core()->math(new_start_addr);
-            QString new_end_addr = dialog->getEndAddrText();
+            QString new_end_addr = dialog.getEndAddrText();
             Core()->cmd("afu " + new_end_addr);
-            QString new_stack_size = dialog->getStackSizeText();
+            QString new_stack_size = dialog.getStackSizeText();
             fcn->stack = int(Core()->math(new_stack_size));
-            Core()->cmd("afc " + dialog->getCallConSelected());
+            Core()->cmd("afc " + dialog.getCallConSelected());
             emit Core()->functionsChanged();
         }
     }

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -753,11 +753,11 @@ void DisassemblyContextMenu::on_actionSetToData_triggered()
 
 void DisassemblyContextMenu::on_actionSetToDataEx_triggered()
 {
-    auto dialog = new SetToDataDialog(offset, this->window());
-    if (!dialog->exec()) {
+    SetToDataDialog dialog(offset, this->window());
+    if (!dialog.exec()) {
         return;
     }
-    setToData(dialog->getItemSize(), dialog->getItemCount());
+    setToData(dialog.getItemSize(), dialog.getItemCount());
 }
 
 void DisassemblyContextMenu::on_actionStructureOffsetMenu_triggered(QAction *action)

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -714,9 +714,9 @@ void DisassemblyContextMenu::on_actionSetFunctionVarTypes_triggered()
 
 void DisassemblyContextMenu::on_actionXRefs_triggered()
 {
-    XrefsDialog *dialog = new XrefsDialog(this);
-    dialog->fillRefsForAddress(offset, RAddressString(offset), false);
-    dialog->exec();
+    XrefsDialog dialog(this);
+    dialog.fillRefsForAddress(offset, RAddressString(offset), false);
+    dialog.exec();
 }
 
 void DisassemblyContextMenu::on_actionDisplayOptions_triggered()

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -721,9 +721,9 @@ void DisassemblyContextMenu::on_actionXRefs_triggered()
 
 void DisassemblyContextMenu::on_actionDisplayOptions_triggered()
 {
-    auto *dialog = new PreferencesDialog(this->window());
-    dialog->showSection(PreferencesDialog::Section::Disassembly);
-    dialog->show();
+    PreferencesDialog dialog(this->window());
+    dialog.showSection(PreferencesDialog::Section::Disassembly);
+    dialog.exec();
 }
 
 void DisassemblyContextMenu::on_actionSetToCode_triggered()

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -626,8 +626,8 @@ void DisassemblyContextMenu::on_actionAnalyzeFunction_triggered()
 
 void DisassemblyContextMenu::on_actionAddFlag_triggered()
 {
-    FlagDialog *dialog = new FlagDialog(offset, this->parentWidget());
-    dialog->exec();
+    FlagDialog dialog(offset, this->parentWidget());
+    dialog.exec();
 }
 
 void DisassemblyContextMenu::on_actionRename_triggered()

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -449,16 +449,16 @@ QList<QKeySequence> DisassemblyContextMenu::getAddBPSequence() const
 
 void DisassemblyContextMenu::on_actionEditInstruction_triggered()
 {
-    EditInstructionDialog *e = new EditInstructionDialog(this, EDIT_TEXT);
-    e->setWindowTitle(tr("Edit Instruction at %1").arg(RAddressString(offset)));
+    EditInstructionDialog e(EDIT_TEXT, this);
+    e.setWindowTitle(tr("Edit Instruction at %1").arg(RAddressString(offset)));
 
     QString oldInstructionOpcode = Core()->getInstructionOpcode(offset);
     QString oldInstructionBytes = Core()->getInstructionBytes(offset);
 
-    e->setInstruction(oldInstructionOpcode);
+    e.setInstruction(oldInstructionOpcode);
 
-    if (e->exec()) {
-        QString userInstructionOpcode = e->getInstruction();
+    if (e.exec()) {
+        QString userInstructionOpcode = e.getInstruction();
         if (userInstructionOpcode != oldInstructionOpcode) {
             Core()->editInstruction(offset, userInstructionOpcode);
 
@@ -520,14 +520,14 @@ void DisassemblyContextMenu::on_actionJmpReverse_triggered()
 
 void DisassemblyContextMenu::on_actionEditBytes_triggered()
 {
-    EditInstructionDialog *e = new EditInstructionDialog(this, EDIT_BYTES);
-    e->setWindowTitle(tr("Edit Bytes at %1").arg(RAddressString(offset)));
+    EditInstructionDialog e(EDIT_BYTES, this);
+    e.setWindowTitle(tr("Edit Bytes at %1").arg(RAddressString(offset)));
 
     QString oldBytes = Core()->getInstructionBytes(offset);
-    e->setInstruction(oldBytes);
+    e.setInstruction(oldBytes);
 
-    if (e->exec()) {
-        QString bytes = e->getInstruction();
+    if (e.exec()) {
+        QString bytes = e.getInstruction();
         if (bytes != oldBytes) {
             Core()->editBytes(offset, bytes);
 

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -594,17 +594,17 @@ void DisassemblyContextMenu::on_actionAddComment_triggered()
     QString oldComment = Core()->cmd("CC." + RAddressString(offset));
     // Remove newline at the end added by cmd
     oldComment.remove(oldComment.length() - 1, 1);
-    CommentsDialog *c = new CommentsDialog(this);
+    CommentsDialog c(this);
 
     if (oldComment.isNull() || oldComment.isEmpty()) {
-        c->setWindowTitle(tr("Add Comment at %1").arg(RAddressString(offset)));
+        c.setWindowTitle(tr("Add Comment at %1").arg(RAddressString(offset)));
     } else {
-        c->setWindowTitle(tr("Edit Comment at %1").arg(RAddressString(offset)));
+        c.setWindowTitle(tr("Edit Comment at %1").arg(RAddressString(offset)));
     }
 
-    c->setComment(oldComment);
-    if (c->exec()) {
-        QString comment = c->getComment();
+    c.setComment(oldComment);
+    if (c.exec()) {
+        QString comment = c.getComment();
         if (comment.isEmpty()) {
             Core()->delComment(offset);
         } else {

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -615,11 +615,11 @@ void DisassemblyContextMenu::on_actionAddComment_triggered()
 
 void DisassemblyContextMenu::on_actionAnalyzeFunction_triggered()
 {
-    RenameDialog *dialog = new RenameDialog(this);
-    dialog->setWindowTitle(tr("Analyze function at %1").arg(RAddressString(offset)));
-    dialog->setPlaceholderText(tr("Function name"));
-    if (dialog->exec()) {
-        QString function_name = dialog->getName();
+    RenameDialog dialog(this);
+    dialog.setWindowTitle(tr("Analyze function at %1").arg(RAddressString(offset)));
+    dialog.setPlaceholderText(tr("Function name"));
+    if (dialog.exec()) {
+        QString function_name = dialog.getName();
         Core()->createFunctionAt(offset, function_name);
     }
 }
@@ -634,24 +634,24 @@ void DisassemblyContextMenu::on_actionRename_triggered()
 {
     RCore *core = Core()->core();
 
-    RenameDialog *dialog = new RenameDialog(this);
+    RenameDialog dialog(this);
 
     RAnalFunction *fcn = r_anal_get_fcn_at (core->anal, offset, R_ANAL_FCN_TYPE_NULL);
     RFlagItem *f = r_flag_get_i (core->flags, offset);
     if (fcn) {
         /* Rename function */
-        dialog->setWindowTitle(tr("Rename function %1").arg(fcn->name));
-        dialog->setName(fcn->name);
-        if (dialog->exec()) {
-            QString new_name = dialog->getName();
+        dialog.setWindowTitle(tr("Rename function %1").arg(fcn->name));
+        dialog.setName(fcn->name);
+        if (dialog.exec()) {
+            QString new_name = dialog.getName();
             Core()->renameFunction(fcn->name, new_name);
         }
     } else if (f) {
         /* Rename current flag */
-        dialog->setWindowTitle(tr("Rename flag %1").arg(f->name));
-        dialog->setName(f->name);
-        if (dialog->exec()) {
-            QString new_name = dialog->getName();
+        dialog.setWindowTitle(tr("Rename flag %1").arg(f->name));
+        dialog.setName(f->name);
+        if (dialog.exec()) {
+            QString new_name = dialog.getName();
             Core()->renameFlag(f->name, new_name);
         }
     } else {
@@ -669,22 +669,22 @@ void DisassemblyContextMenu::on_actionRenameUsedHere_triggered()
     QJsonObject thingUsedHere = array.first().toObject();
     QString type = thingUsedHere.value("type").toString();
 
-    RenameDialog *dialog = new RenameDialog(this);
+    RenameDialog dialog(this);
 
     QString oldName;
 
     if (type == "address") {
         RVA offset = thingUsedHere["offset"].toVariant().toULongLong();
-        dialog->setWindowTitle(tr("Add flag at %1").arg(RAddressString(offset)));
-        dialog->setName("label." + QString::number(offset, 16));
+        dialog.setWindowTitle(tr("Add flag at %1").arg(RAddressString(offset)));
+        dialog.setName("label." + QString::number(offset, 16));
     } else {
         oldName = thingUsedHere.value("name").toString();
-        dialog->setWindowTitle(tr("Rename %1").arg(oldName));
-        dialog->setName(oldName);
+        dialog.setWindowTitle(tr("Rename %1").arg(oldName));
+        dialog.setName(oldName);
     }
 
-    if (dialog->exec()) {
-        QString newName = dialog->getName().trimmed();
+    if (dialog.exec()) {
+        QString newName = dialog.getName().trimmed();
         if (!newName.isEmpty()) {
             Core()->cmd("an " + newName + " @ " + QString::number(offset));
 

--- a/src/widgets/BreakpointWidget.cpp
+++ b/src/widgets/BreakpointWidget.cpp
@@ -186,10 +186,10 @@ void BreakpointWidget::showBreakpointContextMenu(const QPoint &pt)
 
 void BreakpointWidget::addBreakpointDialog()
 {
-    BreakpointsDialog *dialog = new BreakpointsDialog(this);
+    BreakpointsDialog dialog(this);
 
-    if (dialog->exec()) {
-        QString bps = dialog->getBreakpoints();
+    if (dialog.exec()) {
+        QString bps = dialog.getBreakpoints();
         if (!bps.isEmpty()) {
             QStringList bpList = bps.split(' ', QString::SkipEmptyParts);
             for (const QString &bp : bpList) {

--- a/src/widgets/DebugActions.cpp
+++ b/src/widgets/DebugActions.cpp
@@ -161,12 +161,12 @@ void DebugActions::continueUntilMain()
 
 void DebugActions::attachProcessDialog()
 {
-    AttachProcDialog *dialog = new AttachProcDialog(main);
+    AttachProcDialog dialog(main);
     bool success = false;
     while (!success) {
         success = true;
-        if (dialog->exec()) {
-            int pid = dialog->getPID();
+        if (dialog.exec()) {
+            int pid = dialog.getPID();
             if (pid >= 0) {
                 attachProcess(pid);
             } else {
@@ -177,7 +177,6 @@ void DebugActions::attachProcessDialog()
             }
         }
     }
-    delete dialog;
 }
 
 void DebugActions::attachProcess(int pid)

--- a/src/widgets/FlagsWidget.cpp
+++ b/src/widgets/FlagsWidget.cpp
@@ -182,10 +182,10 @@ void FlagsWidget::on_actionRename_triggered()
     FlagDescription flag = ui->flagsTreeView->selectionModel()->currentIndex().data(
                                FlagsModel::FlagDescriptionRole).value<FlagDescription>();
 
-    RenameDialog *r = new RenameDialog(this);
-    r->setName(flag.name);
-    if (r->exec()) {
-        QString new_name = r->getName();
+    RenameDialog r(this);
+    r.setName(flag.name);
+    if (r.exec()) {
+        QString new_name = r.getName();
         Core()->renameFlag(flag.name, new_name);
     }
 }

--- a/src/widgets/FunctionsWidget.cpp
+++ b/src/widgets/FunctionsWidget.cpp
@@ -620,14 +620,14 @@ void FunctionsWidget::on_actionFunctionsRename_triggered()
                                        FunctionModel::FunctionDescriptionRole).value<FunctionDescription>();
 
     // Create dialog
-    RenameDialog *r = new RenameDialog(this);
+    RenameDialog r(this);
 
     // Set function name in dialog
-    r->setName(function.name);
+    r.setName(function.name);
     // If user accepted
-    if (r->exec()) {
+    if (r.exec()) {
         // Get new function name
-        QString new_name = r->getName();
+        QString new_name = r.getName();
 
         // Rename function in r2 core
         Core()->renameFunction(function.name, new_name);

--- a/src/widgets/FunctionsWidget.cpp
+++ b/src/widgets/FunctionsWidget.cpp
@@ -600,11 +600,11 @@ void FunctionsWidget::on_actionDisasAdd_comment_triggered()
                                        FunctionModel::FunctionDescriptionRole).value<FunctionDescription>();
 
     // Create dialog
-    CommentsDialog *c = new CommentsDialog(this);
+    CommentsDialog c(this);
 
-    if (c->exec()) {
+    if (c.exec()) {
         // Get new function name
-        QString comment = c->getComment();
+        QString comment = c.getComment();
         // Rename function in r2 core
         Core()->setComment(function.offset, comment);
         // Seek to new renamed function

--- a/src/widgets/FunctionsWidget.cpp
+++ b/src/widgets/FunctionsWidget.cpp
@@ -649,9 +649,9 @@ void FunctionsWidget::on_action_References_triggered()
     // Get selected item in functions tree view
     FunctionDescription function = ui->functionsTreeView->selectionModel()->currentIndex().data(
                                        FunctionModel::FunctionDescriptionRole).value<FunctionDescription>();
-    XrefsDialog *x = new XrefsDialog(this);
-    x->fillRefsForAddress(function.offset, function.name, true);
-    x->exec();
+    XrefsDialog x(this);
+    x.fillRefsForAddress(function.offset, function.name, true);
+    x.exec();
 }
 
 void FunctionsWidget::showTitleContextMenu(const QPoint &pt)

--- a/src/widgets/StackWidget.cpp
+++ b/src/widgets/StackWidget.cpp
@@ -131,14 +131,14 @@ void StackWidget::editStack()
     bool ok;
     int row = viewStack->selectionModel()->currentIndex().row();
     QString offset = viewStack->selectionModel()->currentIndex().sibling(row, 0).data().toString();
-    EditInstructionDialog *e = new EditInstructionDialog(this, EDIT_NONE);
-    e->setWindowTitle(tr("Edit stack at %1").arg(offset));
+    EditInstructionDialog e(EDIT_NONE, this);
+    e.setWindowTitle(tr("Edit stack at %1").arg(offset));
 
     QString oldBytes = viewStack->selectionModel()->currentIndex().sibling(row, 1).data().toString();
-    e->setInstruction(oldBytes);
+    e.setInstruction(oldBytes);
 
-    if (e->exec()) {
-        QString bytes = e->getInstruction();
+    if (e.exec()) {
+        QString bytes = e.getInstruction();
         if (bytes != oldBytes) {
             Core()->editBytesEndian(offset.toULongLong(&ok, 16), bytes);
         }

--- a/src/widgets/StringsWidget.cpp
+++ b/src/widgets/StringsWidget.cpp
@@ -274,10 +274,10 @@ void StringsWidget::on_actionX_refs_triggered()
     StringDescription str = ui->stringsTreeView->selectionModel()->currentIndex().data(
                                 StringsModel::StringDescriptionRole).value<StringDescription>();
 
-    XrefsDialog *x = new XrefsDialog(this);
-    x->fillRefsForAddress(str.vaddr, RAddressString(str.vaddr), false);
-    x->setAttribute(Qt::WA_DeleteOnClose);
-    x->exec();
+    XrefsDialog x(this);
+    x.fillRefsForAddress(str.vaddr, RAddressString(str.vaddr), false);
+    x.setAttribute(Qt::WA_DeleteOnClose);
+    x.exec();
 }
 
 void StringsWidget::on_actionCopy()


### PR DESCRIPTION
A lot of dialogs do not delete after close them. They delete only after teminate application. So its memory leak. 

my patch fixes most of these problems.

Example leak;
https://github.com/radareorg/cutter/blob/master/src/menus/DisassemblyContextMenu.cpp#L452

function void DisassemblyContextMenu::on_actionEditInstruction_triggered()

create EditInstructionDialog every time.

