### PR TITLE
Fix crash because of mixing debug and release CRT.

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -2649,7 +2649,7 @@ QString CutterCore::ansiEscapeToHtml(const QString &text)
         return QString();
     }
     QString r = QString::fromUtf8(html, len);
-    free(html);
+    r_free(html);
     return r;
 }
 


### PR DESCRIPTION
Memory allocated in r2-side has to be released with `r_free`

**Test plan (required)**

1. Build r2 with help of `prepare_r2.bat` (will have Release configuration by-default)
2. build Cutter in debug mode
3. Run it, it hasn't crash
