### PR TITLE
Add emu.str in Preferences->Metadata (#1276)

### DIFF
--- a/src/dialogs/preferences/AsmOptionsWidget.cpp
+++ b/src/dialogs/preferences/AsmOptionsWidget.cpp
@@ -42,6 +42,7 @@ void AsmOptionsWidget::updateAsmOptionsFromVars()
     qhelpers::setCheckedWithoutSignals(ui->fcnlinesCheckBox, Config()->getConfigBool("asm.lines.fcn"));
     qhelpers::setCheckedWithoutSignals(ui->flgoffCheckBox, Config()->getConfigBool("asm.flags.offset"));
     qhelpers::setCheckedWithoutSignals(ui->emuCheckBox, Config()->getConfigBool("asm.emu"));
+    qhelpers::setCheckedWithoutSignals(ui->emuStrCheckBox, Config()->getConfigBool("emu.str"));
     qhelpers::setCheckedWithoutSignals(ui->varsumCheckBox, Config()->getConfigBool("asm.var.summary"));
     qhelpers::setCheckedWithoutSignals(ui->sizeCheckBox, Config()->getConfigBool("asm.size"));
 
@@ -180,6 +181,12 @@ void AsmOptionsWidget::on_flgoffCheckBox_toggled(bool checked)
 void AsmOptionsWidget::on_emuCheckBox_toggled(bool checked)
 {
     Config()->setConfig("asm.emu", checked);
+    triggerAsmOptionsChanged();
+}
+
+void AsmOptionsWidget::on_emuStrCheckBox_toggled(bool checked)
+{
+    Config()->setConfig("emu.str", checked);
     triggerAsmOptionsChanged();
 }
 

--- a/src/dialogs/preferences/AsmOptionsWidget.h
+++ b/src/dialogs/preferences/AsmOptionsWidget.h
@@ -43,6 +43,7 @@ private slots:
     void on_fcnlinesCheckBox_toggled(bool checked);
     void on_flgoffCheckBox_toggled(bool checked);
     void on_emuCheckBox_toggled(bool checked);
+    void on_emuStrCheckBox_toggled(bool checked);
     void on_cmtrightCheckBox_toggled(bool checked);
     void on_cmtcolSpinBox_valueChanged(int value);
     void on_varsumCheckBox_toggled(bool checked);

--- a/src/dialogs/preferences/AsmOptionsWidget.ui
+++ b/src/dialogs/preferences/AsmOptionsWidget.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QTabWidget" name="asmOptionsTab">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="asmStyleTab">
       <attribute name="title">
@@ -53,11 +53,11 @@
         </widget>
        </item>
        <item>
-	<widget class="QCheckBox" name="indentCheckBox">
-	 <property name="text">
-	  <string>Indent disassembly based on reflines depth (asm.indent)</string>
-	 </property>
-	</widget>
+        <widget class="QCheckBox" name="indentCheckBox">
+         <property name="text">
+          <string>Indent disassembly based on reflines depth (asm.indent)</string>
+         </property>
+        </widget>
        </item>
        <item>
         <widget class="QCheckBox" name="describeCheckBox">
@@ -236,6 +236,13 @@
         <widget class="QCheckBox" name="emuCheckBox">
          <property name="text">
           <string>Run ESIL emulation analysis (asm.emu)</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="emuStrCheckBox">
+         <property name="text">
+          <string>Show only strings if any in the asm.emu output (emu.str)</string>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
This PR solves #1276 .

**Test plan (required)**

`emu.str` on:
![](https://i.imgur.com/ypCY2kh.jpg)
`emu.str` off:
![](https://i.imgur.com/AECnEvf.jpg)

Although there is an odd behavior that is also reproducible in the radare 2 CLI: if you check and then uncheck again, the result in the disassembly will be as if asm.emu was turned on, is that intended or am I missing something?
