### PR TITLE
Fixed a few issues with the XRef dialog

### DIFF
--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -716,7 +716,7 @@ void DisassemblyContextMenu::on_actionSetFunctionVarTypes_triggered()
 
 void DisassemblyContextMenu::on_actionXRefs_triggered()
 {
-    XrefsDialog dialog(this);
+    XrefsDialog dialog(nullptr);
     dialog.fillRefsForAddress(offset, RAddressString(offset), false);
     dialog.exec();
 }

--- a/src/widgets/FunctionsWidget.cpp
+++ b/src/widgets/FunctionsWidget.cpp
@@ -655,7 +655,7 @@ void FunctionsWidget::on_action_References_triggered()
     // Get selected item in functions tree view
     FunctionDescription function = ui->functionsTreeView->selectionModel()->currentIndex().data(
                                        FunctionModel::FunctionDescriptionRole).value<FunctionDescription>();
-    XrefsDialog x(this);
+    XrefsDialog x(nullptr);
     x.fillRefsForAddress(function.offset, function.name, true);
     x.exec();
 }

--- a/src/widgets/StringsWidget.cpp
+++ b/src/widgets/StringsWidget.cpp
@@ -271,7 +271,7 @@ void StringsWidget::on_actionX_refs_triggered()
     StringDescription str = ui->stringsTreeView->selectionModel()->currentIndex().data(
                                 StringsModel::StringDescriptionRole).value<StringDescription>();
 
-    XrefsDialog x(this);
+    XrefsDialog x(nullptr);
     x.fillRefsForAddress(str.vaddr, RAddressString(str.vaddr), false);
     x.setAttribute(Qt::WA_DeleteOnClose);
     x.exec();


### PR DESCRIPTION
Fixes: #1337, #1368 

The issue with the dialogs was in theirs constructing. If pass the parent to the dialog, it is created with the top left corner in (0; 0) of the parent. And in order to give it an offset `QWidget::move(x, y)` can be used. BTW, it's commonly used to create the different kinds of Pop-ups. The XRef dialog shouldn't have a parent. So just passing a `nullptr` for visibility.
