### PR TITLE
Add compiler information to dashboard (#1379)

### DIFF
--- a/src/widgets/Dashboard.cpp
+++ b/src/widgets/Dashboard.cpp
@@ -53,6 +53,7 @@ void Dashboard::updateContents()
     this->ui->subsysEdit->setText(item2["subsys"].toString());
     this->ui->endianEdit->setText(item2["endian"].toString());
     this->ui->compiledEdit->setText(item2["compiled"].toString());
+    this->ui->compilerEdit->setText(item2["compiler"].toString());
     this->ui->bitsEdit->setText(QString::number(item2["bits"].toDouble()));
 
     if (!item2["relro"].isUndefined()) {

--- a/src/widgets/Dashboard.ui
+++ b/src/widgets/Dashboard.ui
@@ -56,7 +56,7 @@
          <x>0</x>
          <y>0</y>
          <width>1055</width>
-         <height>979</height>
+         <height>982</height>
         </rect>
        </property>
        <layout class="QHBoxLayout" name="horizontalLayout_5">
@@ -836,6 +836,29 @@
                  </property>
                  <property name="readOnly">
                   <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item row="9" column="0">
+                <widget class="QLabel" name="label_5">
+                 <property name="font">
+                  <font>
+                   <weight>75</weight>
+                   <bold>true</bold>
+                  </font>
+                 </property>
+                 <property name="text">
+                  <string>Compiler:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="9" column="1">
+                <widget class="QLineEdit" name="compilerEdit">
+                 <property name="text">
+                  <string>--</string>
+                 </property>
+                 <property name="frame">
+                  <bool>false</bool>
                  </property>
                 </widget>
                </item>


### PR DESCRIPTION
This PR solves #1379.

**Test plan (required)**
With compiler:
![image](https://user-images.githubusercontent.com/2325589/54878687-d40fb100-4e27-11e9-895d-b76b4dbf36eb.png)

Without compiler:
![image](https://user-images.githubusercontent.com/2325589/54878699-fd304180-4e27-11e9-9a25-9f08910d229d.png)

I assume the information is in the correct column of the dashboard, and since `Compiled` is empty, I assume `Compiler` can be empty too without being hidden.