### PR TITLE
Make "note" a Note

### DIFF
--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -20,9 +20,10 @@ To get the location of this directory and a list of currently loaded plugins, na
 The plugins directory contains two subdirectories, ``native`` and ``python`` for C++ and Python plugins respectively,
 which will be created automatically by Cutter.
 
-Note that support for Python plugins is only available if Cutter was built with the options ``CUTTER_ENABLE_PYTHON``
-and ``CUTTER_ENABLE_PYTHON_BINDINGS`` enabled.
-This is the case for all official builds from GitHub Releases starting with version 1.8.0.
+.. note::
+   The support for Python plugins is only available if Cutter was built with the options ``CUTTER_ENABLE_PYTHON``
+   and ``CUTTER_ENABLE_PYTHON_BINDINGS`` enabled.
+   This is the case for all official builds from GitHub Releases starting with version 1.8.0.
 
 
 Creating Plugins


### PR DESCRIPTION
currently, the note for building options looks like this:

![image](https://user-images.githubusercontent.com/20182642/54882055-cb869d00-4e5e-11e9-95c2-003cdba893fd.png)

This PR makes it looks better, something similar to this:

![image](https://user-images.githubusercontent.com/20182642/54882061-e35e2100-4e5e-11e9-8979-cfe19196570b.png)

