### PR TITLE
Improve hexdump width calculation.

### DIFF
--- a/src/widgets/HexdumpWidget.cpp
+++ b/src/widgets/HexdumpWidget.cpp
@@ -1225,8 +1225,8 @@ void HexdumpWidget::zoomOut(int range)
 void HexdumpWidget::updateWidths()
 {
     // Update width
-    ui->hexHexText->document()->adjustSize();
-    ui->hexHexText->setFixedWidth(ui->hexHexText->document()->size().width());
+    auto idealWidth = ui->hexHexText->document()->idealWidth();
+    ui->hexHexText->document()->setTextWidth(idealWidth);
 
     ui->hexOffsetText->document()->adjustSize();
     ui->hexOffsetText->setFixedWidth(ui->hexOffsetText->document()->size().width());


### PR DESCRIPTION
`idealWidth` seems to work better than "resonable size" chosen by `adjustSize`. It still doesn't work too well when zooming, but it didn't work before as well.

**Test plan (required)**
Tested with all sizes(4, 8, 16, 32) in hex and octal modes.
Before:
![Before](https://user-images.githubusercontent.com/7101031/54882161-e9a0cd00-4e5f-11e9-8814-ccdb024722d6.png)
After:
![After](https://user-images.githubusercontent.com/7101031/54882165-eefe1780-4e5f-11e9-8d3d-459490084f4e.png)


**Closing issues**
Closes #1351 