### PR TITLE
build.sh: Check for lrelease-qt5

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -11,9 +11,6 @@ QMAKE_CONF=""
 ROOT_DIR=`pwd`
 #QMAKE_CONF="CUTTER_ENABLE_JUPYTER=false CUTTER_ENABLE_QTWEBENGINE=false"
 
-# Create translations
-lrelease ./src/Cutter.pro
-
 check_r2() {
 	r2 -v >/dev/null 2>&1
 	if [ $? = 0 ]; then
@@ -37,6 +34,19 @@ find_qmake() {
 		exit 1
 	fi
 	echo "$qmakepath"
+}
+
+find_lrelease() {
+	lreleasepath=$(which lrelease-qt5)
+	if [ -z "$lreleasepath" ]; then
+		lreleasepath=$(which lrelease)
+	fi
+	if [ -z "$lreleasepath" ]; then
+		echo "You need lrelease to build Cutter."
+		echo "Please make sure lrelease is in your PATH environment variable."
+		exit 1
+	fi
+	echo "$lreleasepath"
 }
 
 find_gmake() {
@@ -72,6 +82,9 @@ if [ $? -eq 1 ]; then
 else
     echo "Correct radare2 version found, skipping..."
 fi
+
+# Create translations
+$(find_lrelease) ./src/Cutter.pro
 
 # Build
 mkdir -p "$BUILD"


### PR DESCRIPTION
On Fedora 29, lrelease is named lrelease-qt5.