### PR TITLE
Do not update sectionWidget position outside valid range.

### DIFF
--- a/src/widgets/SectionsWidget.cpp
+++ b/src/widgets/SectionsWidget.cpp
@@ -410,6 +410,8 @@ void AddrDockScene::mousePressEvent(QGraphicsSceneMouseEvent *event)
             disableCenterOn = false;
             return;
         }
+    } else {
+        QToolTip::hideText();
     }
 }
 
@@ -434,7 +436,7 @@ RVA AddrDockScene::getAddrFromPos(int posY, bool seek)
             return addrMap[name] + (float)addrSizeMap[name] * ((float)(posY - y) / (float)h);
         }
     }
-    return 0;
+    return RVA_INVALID;
 }
 
 RawAddrDock::RawAddrDock(SectionsModel *model, QWidget *parent) :


### PR DESCRIPTION

**Test plan (required)**
* Hover mouse over section graph
* Hover mouse bellow section graph
* Hover mouse above section graph
![Peek 2019-03-26 00-21](https://user-images.githubusercontent.com/7101031/54958442-5d290400-4f5e-11e9-9427-0e6f60bb034a.gif)

**Closing issues**

Fixes #1306 