### PR TITLE
Enable dock grouped dragging when available.

### DIFF
--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -161,6 +161,10 @@ void MainWindow::initUI()
     for (auto plugin : Plugins()->getPlugins()) {
         plugin->setupInterface(this);
     }
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
+    setDockOptions(dockOptions() | DockOption::GroupedDragging);
+#endif
 }
 
 void MainWindow::initToolBar()


### PR DESCRIPTION
See second animation [here](https://woboq.com/blog/qdockwidget-changes-in-56.html)  demonstrating how group dragging is supposed to work.

**Test plan (required)**
* Drag by tittle bar and observe observe that whole group of tabs is moved.
* Drag using tab bar and observe that single tab gets moved.

**Closing issues**

Closes #1271 