### PR TITLE
Take pixel ratio into account for graph cache.

### DIFF
--- a/src/Cutter.pro
+++ b/src/Cutter.pro
@@ -311,7 +311,8 @@ SOURCES += \
     common/BasicBlockHighlighter.cpp \
     dialogs/LinkTypeDialog.cpp \
     common/UpdateWorker.cpp \
-    widgets/MemoryDockWidget.cpp
+    widgets/MemoryDockWidget.cpp \
+    common/HighDpiPixmap.cpp
 
 HEADERS  += \
     core/Cutter.h \
@@ -428,7 +429,8 @@ HEADERS  += \
     common/BasicBlockHighlighter.h \
     common/UpdateWorker.h \
     dialogs/LinkTypeDialog.h \
-    widgets/MemoryDockWidget.h
+    widgets/MemoryDockWidget.h \
+    common/HighDpiPixmap.h
 
 FORMS    += \
     dialogs/AboutDialog.ui \

--- a/src/CutterApplication.cpp
+++ b/src/CutterApplication.cpp
@@ -29,6 +29,7 @@ CutterApplication::CutterApplication(int &argc, char **argv) : QApplication(argc
     setApplicationVersion(CUTTER_VERSION_FULL);
     setWindowIcon(QIcon(":/img/cutter.svg"));
     setAttribute(Qt::AA_DontShowIconsInMenus);
+    setAttribute(Qt::AA_UseHighDpiPixmaps);
     setLayoutDirection(Qt::LeftToRight);
 
     // WARN!!! Put initialization code below this line. Code above this line is mandatory to be run First

--- a/src/common/HighDpiPixmap.cpp
+++ b/src/common/HighDpiPixmap.cpp
@@ -1,0 +1,23 @@
+#include "common/HighDpiPixmap.h"
+
+#include <QGuiApplication>
+#include <QScreen>
+
+static qreal GetDevicePixelRatio(qreal devicePixelRatio)
+{
+    if (devicePixelRatio > 0) {
+        return devicePixelRatio;
+    }
+    qreal ratio = 1;
+    for (auto screen : QGuiApplication::screens()) {
+        ratio = std::max(ratio, screen->devicePixelRatio());
+    }
+    return ratio;
+}
+
+HighDpiPixmap::HighDpiPixmap(int width, int height, qreal devicePixelRatio)
+    : QPixmap(int(width * GetDevicePixelRatio(devicePixelRatio)),
+              int(height * GetDevicePixelRatio(devicePixelRatio)))
+{
+    setDevicePixelRatio(GetDevicePixelRatio(devicePixelRatio));
+}

--- a/src/common/HighDpiPixmap.h
+++ b/src/common/HighDpiPixmap.h
@@ -1,0 +1,11 @@
+#ifndef HIGHDPIPIXMAP_H
+#define HIGHDPIPIXMAP_H
+
+#include <QPixmap>
+class HighDpiPixmap : public QPixmap
+{
+public:
+    HighDpiPixmap(int width, int height, qreal devicePixelRatio = -1);
+};
+
+#endif // HIGHDPIPIXMAP_H

--- a/src/dialogs/NewFileDialog.cpp
+++ b/src/dialogs/NewFileDialog.cpp
@@ -4,6 +4,7 @@
 #include "dialogs/AboutDialog.h"
 #include "ui_NewfileDialog.h"
 #include "common/Helpers.h"
+#include "common/HighDpiPixmap.h"
 
 #include <QFileDialog>
 #include <QtGui>
@@ -33,7 +34,7 @@ static QIcon getIconFor(const QString &str, int pos)
     int w = 64;
     int h = 64;
 
-    QPixmap pixmap(w, h);
+    HighDpiPixmap pixmap(w, h);
     pixmap.fill(Qt::transparent);
 
     QPainter pixPaint(&pixmap);

--- a/src/widgets/GraphView.cpp
+++ b/src/widgets/GraphView.cpp
@@ -381,11 +381,14 @@ QPolygonF GraphView::recalculatePolygon(QPolygonF polygon)
 void GraphView::paintEvent(QPaintEvent *event)
 {
     Q_UNUSED(event);
-    if (useCache) {
+    qreal dpr = devicePixelRatioF();
+    if (useCache && qFuzzyCompare(dpr, cachePixelRatio)) {
         drawGraph();
         return;
     }
-    pixmap = QPixmap(viewport()->width(), viewport()->height());
+    cachePixelRatio = dpr;
+    pixmap = QPixmap(int(viewport()->width() * dpr), int(viewport()->height() * dpr));
+    pixmap.setDevicePixelRatio(dpr);
     QPainter p(&pixmap);
 
     p.setRenderHint(QPainter::Antialiasing);
@@ -448,7 +451,7 @@ void GraphView::paintEvent(QPaintEvent *event)
 void GraphView::drawGraph()
 {
     QRectF target(0.0, 0.0, viewport()->width(), viewport()->height());
-    QRectF source(0.0, 0.0, viewport()->width(), viewport()->height());
+    QRectF source(0.0, 0.0, viewport()->width() * cachePixelRatio, viewport()->height() * cachePixelRatio);
     QPainter p(viewport());
     p.drawPixmap(target, pixmap, source);
 }

--- a/src/widgets/GraphView.cpp
+++ b/src/widgets/GraphView.cpp
@@ -382,11 +382,10 @@ void GraphView::paintEvent(QPaintEvent *event)
 {
     Q_UNUSED(event);
     qreal dpr = devicePixelRatioF();
-    if (useCache && qFuzzyCompare(dpr, cachePixelRatio)) {
+    if (useCache && qFuzzyCompare(dpr, pixmap.devicePixelRatioF())) {
         drawGraph();
         return;
     }
-    cachePixelRatio = dpr;
     pixmap = QPixmap(int(viewport()->width() * dpr), int(viewport()->height() * dpr));
     pixmap.setDevicePixelRatio(dpr);
     QPainter p(&pixmap);
@@ -396,9 +395,8 @@ void GraphView::paintEvent(QPaintEvent *event)
     int render_width = viewport()->width();
     int render_height = viewport()->height();
 
-    QRect viewportRect(viewport()->rect().topLeft(), viewport()->rect().bottomRight() - QPoint(1, 1));
     p.setBrush(backgroundColor);
-    p.drawRect(viewportRect);
+    p.drawRect(viewport()->rect());
     p.setBrush(Qt::black);
 
     p.scale(current_scale, current_scale);
@@ -451,7 +449,8 @@ void GraphView::paintEvent(QPaintEvent *event)
 void GraphView::drawGraph()
 {
     QRectF target(0.0, 0.0, viewport()->width(), viewport()->height());
-    QRectF source(0.0, 0.0, viewport()->width() * cachePixelRatio, viewport()->height() * cachePixelRatio);
+    QRectF source(0.0, 0.0, viewport()->width() * pixmap.devicePixelRatioF(),
+                  viewport()->height() * pixmap.devicePixelRatioF());
     QPainter p(viewport());
     p.drawPixmap(target, pixmap, source);
 }

--- a/src/widgets/GraphView.h
+++ b/src/widgets/GraphView.h
@@ -107,7 +107,6 @@ public:
      * @brief flag to control if the cached pixmap should be used
      */
     bool useCache = false;
-    qreal cachePixelRatio = -1;
 
     /**
      * @brief keep the current addr of the fcn of Graph

--- a/src/widgets/GraphView.h
+++ b/src/widgets/GraphView.h
@@ -107,6 +107,7 @@ public:
      * @brief flag to control if the cached pixmap should be used
      */
     bool useCache = false;
+    qreal cachePixelRatio = -1;
 
     /**
      * @brief keep the current addr of the fcn of Graph


### PR DESCRIPTION
Take pixel ratio into account when dealing with graphview cache. Changes based on [this](https://stackoverflow.com/questions/42011410/qt-drawing-high-dpi-qpixmaps) example. 

Needs a bit more work as there are some graphic artifacts on the right and bottom edges, probably caused by bad floating point usage in size calculations.

**Test plan (required)**
* Tested on Linux(gnome 2.32) by forcing mixed high dpi mode using `export QT_SCREEN_SCALE_FACTORS="1;2"` because Qt currently doesn't take into account gnome desktop scaling settings. There is an issue in QT bugtracker for that.
* Would be good to test on windows 10, if I remember correctly QT respected windows desktop scaling settings
* Would be good to test on macOS (don't have access to it)

**Closing issues**
Closes #1395 
