### PR TITLE
Implement Getter for MainWindow's menus

### DIFF
--- a/src/bindings/bindings.xml
+++ b/src/bindings/bindings.xml
@@ -8,12 +8,11 @@
 
     <object-type name="CutterCore" />
     <object-type name="Configuration" />
-    <object-type name="MainWindow" />
-    <object-type name="BasicBlockHighlighter" />
-    <object-type name="CutterDockWidget" />
-    <object-type name="MainWindow">
+    <object-type name="MainWindow" >
         <enum-type name="MenuType" />
     </object-type>
+    <object-type name="BasicBlockHighlighter" />
+    <object-type name="CutterDockWidget" />
 
     <template name="plugin_meta_get">
         SbkObject *wrapper = Shiboken::BindingManager::instance().retrieveWrapper(this);

--- a/src/bindings/bindings.xml
+++ b/src/bindings/bindings.xml
@@ -11,6 +11,9 @@
     <object-type name="MainWindow" />
     <object-type name="BasicBlockHighlighter" />
     <object-type name="CutterDockWidget" />
+    <object-type name="MainWindow">
+        <enum-type name="MenuType" />
+    </object-type>
 
     <template name="plugin_meta_get">
         SbkObject *wrapper = Shiboken::BindingManager::instance().retrieveWrapper(this);

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -451,6 +451,33 @@ void MainWindow::addExtraWidget(QDockWidget *extraDock)
     restoreExtraDock.restoreWidth(extraDock->widget());
 }
 
+/**
+ * @brief Getter for MainWindow's different menus
+ * @param type The type which represents the desired menu
+ * @return The requested menu or nullptr if "type" is invalid
+**/
+QMenu *MainWindow::getMenuByType(MenuType type)
+{
+    switch (type) {
+    case MenuType::File:
+        return ui->menuFile;
+    case MenuType::Edit:
+        return ui->menuEdit;
+    case MenuType::View:
+        return ui->menuView;
+    case MenuType::Windows:
+        return ui->menuWindows;
+    case MenuType::Debug:
+        return ui->menuDebug;
+    case MenuType::Help:
+        return ui->menuHelp;
+    case MenuType::Plugins:
+        return ui->menuPlugins;
+    default:
+        return nullptr;
+    }
+}
+
 void MainWindow::addPluginDockWidget(QDockWidget *dockWidget, QAction *action)
 {
     addDockWidget(Qt::TopDockWidgetArea, dockWidget);

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -99,6 +99,8 @@ public:
     void addExtraWidget(QDockWidget *extraDock);
 
     void addPluginDockWidget(QDockWidget *dockWidget, QAction *action);
+    enum class MenuType { File, Edit, View, Windows, Debug, Help, Plugins };
+    QMenu *getMenuByType(MenuType type);
     void addMenuFileAction(QAction *action);
 
     void updateDockActionChecked(QAction * action);


### PR DESCRIPTION
<!-- *Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.* 
Please provide enough information so that others can review your pull request:
Explain the **details** for making this change. What existing problem does the pull request solve? -->

Creates an ENUM to represent the default Menus of MainWindow and a function to get a Menu by a specific type. This is also a useful binding for python plugins.

For example, to add a new action to the Edit menu, I can simply do:

```
# create a new action
action = QAction("some action", main)
# connect the action to a function
action.triggered.connect(do_something)

# get handle to the Edit menu of MainWindow
editMenu = main.getMenuByType(main.MenuType.Edit)

# Add the action to the Edit menu
editMenu.addAction(action)
```

![image](https://user-images.githubusercontent.com/20182642/55395879-36b12d00-554b-11e9-8054-80969a925770.png)


