### PR TITLE
Make plugins path selectable and bold

### DIFF
--- a/src/dialogs/preferences/PluginsOptionsWidget.cpp
+++ b/src/dialogs/preferences/PluginsOptionsWidget.cpp
@@ -21,8 +21,9 @@ PluginsOptionsWidget::PluginsOptionsWidget(PreferencesDialog *dialog)
     setLayout(layout);
 
     auto dirLabel = new QLabel(this);
+    dirLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
     layout->addWidget(dirLabel);
-    dirLabel->setText(tr("Plugins are loaded from %1").arg(Plugins()->getPluginsDirectory()));
+    dirLabel->setText(tr("Plugins are loaded from <b>%1</b>").arg(Plugins()->getPluginsDirectory()));
 
     auto treeWidget = new QTreeWidget(this);
     layout->addWidget(treeWidget);


### PR DESCRIPTION
<!-- *Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.* 

Please provide enough information so that others can review your pull request:

Explain the **details** for making this change. What existing problem does the pull request solve? -->

The Plugins Options widget showed the path for the Plugins directory, but the path itself wasn't selectable. This PR will make the label selectable.

![image](https://user-images.githubusercontent.com/20182642/55547267-9e957e00-56d9-11e9-8de6-da49c124a4cd.png)


**Test plan (required)**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Open "Preferences" window, click on Plugins on the left pane, select the path

<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**

<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
 

N/A