### PR TITLE
Analysis maximum basic block fix

### DIFF
--- a/src/common/AnalTask.cpp
+++ b/src/common/AnalTask.cpp
@@ -81,8 +81,6 @@ void AnalTask::runTask()
         Core()->setEndianness(options.endian == InitialOptions::Endianness::Big);
     }
 
-    Core()->setBBSize(options.bbsize);
-
     Core()->cmd("fs *");
 
     if (!options.script.isNull()) {

--- a/src/common/InitialOptions.h
+++ b/src/common/InitialOptions.h
@@ -30,8 +30,6 @@ struct InitialOptions
     QString pdbFile;
     QString script;
 
-    int bbsize = 0;
-
     QList<QString> analCmd = { "aaa" };
 
     QString shellcode;

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -768,11 +768,6 @@ void CutterCore::setEndianness(bool big)
     setConfig("cfg.bigendian", big);
 }
 
-void CutterCore::setBBSize(int size)
-{
-    setConfig("anal.bb.maxsize", size);
-}
-
 QByteArray CutterCore::assemble(const QString &code)
 {
     CORE_LOCK();

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -195,7 +195,6 @@ public:
 
     void setCPU(QString arch, QString cpu, int bits);
     void setEndianness(bool big);
-    void setBBSize(int size);
 
     /* SDB */
     QList<QString> sdbList(QString path);

--- a/src/dialogs/InitialOptionsDialog.cpp
+++ b/src/dialogs/InitialOptionsDialog.cpp
@@ -28,8 +28,9 @@ InitialOptionsDialog::InitialOptionsDialog(MainWindow *main):
 
     // Fill the plugins combo
     asm_plugins = core->getAsmPluginNames();
-    for (const auto &plugin : asm_plugins)
+    for (const auto &plugin : asm_plugins) {
         ui->archComboBox->addItem(plugin, plugin);
+    }
     ui->archComboBox->setToolTip(core->cmd("e? asm.arch").trimmed());
 
     // cpu combo box
@@ -38,16 +39,16 @@ InitialOptionsDialog::InitialOptionsDialog(MainWindow *main):
     updateCPUComboBox();
 
     // os combo box
-    for (const auto &plugin : core->cmdList("e asm.os=?"))
+    for (const auto &plugin : core->cmdList("e asm.os=?")) {
         ui->kernelComboBox->addItem(plugin, plugin);
+    }
     ui->kernelComboBox->setToolTip(core->cmd("e? asm.os").trimmed());
 
     ui->bitsComboBox->setToolTip(core->cmd("e? asm.bits").trimmed());
 
-    ui->entry_analbb->setToolTip(core->cmd("e? anal.bb.maxsize").trimmed());
-
-    for (const auto &plugin : core->getRBinPluginDescriptions("bin"))
+    for (const auto &plugin : core->getRBinPluginDescriptions("bin")) {
         ui->formatComboBox->addItem(plugin.name, QVariant::fromValue(plugin));
+    }
 
     ui->hideFrame->setVisible(false);
     ui->analoptionsFrame->setVisible(false);
@@ -75,8 +76,9 @@ void InitialOptionsDialog::updateCPUComboBox()
     QString cmd = "e asm.cpu=?";
 
     QString arch = getSelectedArch();
-    if (!arch.isNull())
+    if (!arch.isNull()) {
         cmd += " @a:" + arch;
+    }
 
     ui->cpuComboBox->addItem("");
     ui->cpuComboBox->addItems(core->cmdList(cmd));
@@ -135,8 +137,9 @@ QString InitialOptionsDialog::getSelectedArch() const
 QString InitialOptionsDialog::getSelectedCPU() const
 {
     QString cpu = ui->cpuComboBox->currentText();
-    if (cpu.isNull() || cpu.isEmpty())
+    if (cpu.isNull() || cpu.isEmpty()) {
         return nullptr;
+    }
     return cpu;
 }
 
@@ -148,16 +151,6 @@ int InitialOptionsDialog::getSelectedBits() const
     }
 
     return 0;
-}
-
-int InitialOptionsDialog::getSelectedBBSize() const
-{
-    QString sel_bbsize = ui->entry_analbb->text();
-    bool ok;
-    int bbsize = sel_bbsize.toInt(&ok);
-    if (ok)
-        return bbsize;
-    return 1024;
 }
 
 InitialOptions::Endianness InitialOptionsDialog::getSelectedEndianness() const
@@ -266,7 +259,6 @@ void InitialOptionsDialog::setupAndStartAnalysis(/*int level, QList<QString> adv
 
 
     options.endian = getSelectedEndianness();
-    options.bbsize = getSelectedBBSize();
 
     int level = ui->analSlider->value();
     switch (level) {

--- a/src/dialogs/InitialOptionsDialog.h
+++ b/src/dialogs/InitialOptionsDialog.h
@@ -53,7 +53,6 @@ private:
     QString getSelectedArch() const;
     QString getSelectedCPU() const;
     int getSelectedBits() const;
-    int getSelectedBBSize() const;
     InitialOptions::Endianness getSelectedEndianness() const;
     QString getSelectedOS() const;
     QList<QString> getSelectedAdvancedAnalCmds() const;

--- a/src/dialogs/InitialOptionsDialog.ui
+++ b/src/dialogs/InitialOptionsDialog.ui
@@ -933,38 +933,6 @@
                     </layout>
                    </widget>
                   </item>
-                  <item row="4" column="0">
-                   <widget class="QLabel" name="analbbLabel">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="minimumSize">
-                     <size>
-                      <width>0</width>
-                      <height>0</height>
-                     </size>
-                    </property>
-                    <property name="text">
-                     <string>BasicBlock maxsize:</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="4" column="1">
-                   <widget class="QLineEdit" name="entry_analbb">
-                    <property name="text">
-                     <string>1024</string>
-                    </property>
-                    <property name="frame">
-                     <bool>false</bool>
-                    </property>
-                    <property name="alignment">
-                     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                    </property>
-                   </widget>
-                  </item>
                  </layout>
                 </item>
                </layout>


### PR DESCRIPTION
The option was changed to anal.bb.maxsize, but the format also changed
from integer to 'size' e.g. 512K. This fixes the inputs and uses the
value from r2 (512K).
