### PR TITLE
Make graph layout more failure resistant.

### DIFF
--- a/src/widgets/GraphGridLayout.cpp
+++ b/src/widgets/GraphGridLayout.cpp
@@ -123,6 +123,10 @@ void GraphGridLayout::CalculateLayout(std::unordered_map<ut64, GraphBlock> &bloc
     auto block_order = topoSort(layoutState, entry);
     computeBlockPlacement(entry, layoutState);
 
+    for (auto &blockIt : blocks) {
+        layoutState.edge[blockIt.first].resize(blockIt.second.edges.size());
+    }
+
     // Prepare edge routing
     auto &entryb = layoutState.grid_blocks[entry];
     EdgesVector horiz_edges, vert_edges;
@@ -145,9 +149,10 @@ void GraphGridLayout::CalculateLayout(std::unordered_map<ut64, GraphBlock> &bloc
     for (ut64 blockId : block_order) {
         GraphBlock &block = blocks[blockId];
         GridBlock &start = layoutState.grid_blocks[blockId];
+        size_t i = 0;
         for (const auto &edge : block.edges) {
             GridBlock &end = layoutState.grid_blocks[edge.target];
-            layoutState.edge[blockId].push_back(routeEdge(horiz_edges, vert_edges, edge_valid, start, end));
+            layoutState.edge[blockId][i++] = routeEdge(horiz_edges, vert_edges, edge_valid, start, end);
         }
     }
 
@@ -237,6 +242,10 @@ void GraphGridLayout::CalculateLayout(std::unordered_map<ut64, GraphBlock> &bloc
         size_t index = 0;
         assert(block.edges.size() == layoutState.edge[block.entry].size());
         for (GridEdge &edge : layoutState.edge[block.entry]) {
+            if (edge.points.empty()) {
+                qDebug() << "Warning, unrouted edge.";
+                continue;
+            }
             auto start = edge.points[0];
             auto start_col = start.col;
             auto last_index = edge.start_index;

--- a/src/widgets/GraphView.cpp
+++ b/src/widgets/GraphView.cpp
@@ -158,6 +158,9 @@ void GraphView::paintEvent(QPaintEvent *event)
         // TODO: Only draw edges if they are actually visible ...
         // Draw edges
         for (GraphEdge &edge : block.edges) {
+            if (edge.polyline.empty()) {
+                continue;
+            }
             QPolygonF polyline = recalculatePolygon(edge.polyline);
             EdgeConfiguration ec = edgeConfiguration(block, &blocks[edge.target]);
             QPen pen(ec.color);


### PR DESCRIPTION

Prevents assert from triggering or code crashing when there unreachable blocks in graph view.

**Test plan (required)**

* Compile cutter in debug mode
* Find a function that looks like #1419 example, observe that assert triggers
* Apply this PR and  observe that graph view works

Better fix that prevents that actually processes unreachable blocks and their edges will be part of #1419, I am still working on it. 
I am still making this PR because gradual degradation in edge cases is better than cutter not being usable at all.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**

<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
