### PR TITLE
Rewrite block sorting and placment so that unreachable blocks are processed.

### DIFF
--- a/src/widgets/GraphGridLayout.cpp
+++ b/src/widgets/GraphGridLayout.cpp
@@ -46,18 +46,10 @@ std::vector<ut64> GraphGridLayout::topoSort(LayoutState &state, ut64 entry)
                 if (targetState == 0) {
                     targetState = 1;
                     stack.push({target, 0});
-                    //state.grid_blocks[v].tree_edge.push_back(target);
-                    //state.grid_blocks[target].has_parent = true;
                     state.grid_blocks[v].dag_edge.push_back(target);
-                } else if (targetState == 1) {
-                    // in stack, loop edge
-                } else {
-                    if (!state.grid_blocks[target].has_parent) {
-                        //state.grid_blocks[v].tree_edge.push_back(target);
-                        //state.grid_blocks[target].has_parent = true;
-                    }
+                } else if (targetState == 2) {
                     state.grid_blocks[v].dag_edge.push_back(target);
-                }
+                } // else {  targetState == 1 in stack, loop edge }
             } else {
                 stack.pop();
                 visited[v] = 2;

--- a/src/widgets/GraphGridLayout.h
+++ b/src/widgets/GraphGridLayout.h
@@ -23,8 +23,10 @@ private:
 
     struct GridBlock {
         ut64 id;
-        std::vector<ut64> incoming;
         std::vector<ut64> tree_edge; // subset of outgoing edges that form a tree
+        std::vector<ut64> dag_edge; // subset of outgoing edges that form a tree
+        std::size_t has_parent = false;
+        int level = 0;
 
         // Number of rows in block
         int row_count = 0;
@@ -63,9 +65,13 @@ private:
         std::unordered_map<ut64, std::vector<GridEdge>> edge;
     };
 
+    using GridBlockMap = std::unordered_map<ut64, GridBlock>;
+
+    void computeAllBlockPlacement(const std::vector<ut64> &blockOrder,
+                                  LayoutState &layoutState) const;
     void computeBlockPlacement(ut64 blockId,
                                LayoutState &layoutState) const;
-    void adjustGraphLayout(GridBlock &block, std::unordered_map<ut64, GridBlock> &blocks,
+    void adjustGraphLayout(GridBlock &block, GridBlockMap &blocks,
                            int col, int row) const;
     static std::vector<ut64> topoSort(LayoutState &state, ut64 entry);
 


### PR DESCRIPTION
Change block processing order so that unreachable blocks and edges between them are also placed. Prevents unreachable blocks from being stacked in corner (#1419).

Also prevents some instances of same row edges, and upwards going edges that are not part of loop.


From the comments on top of some unreachable blocks it seems that there might be a bug in cutter code preparing input for GraphView, looks like r2 has identified those blocks as part of case switch/case statement.

**Test plan (required)**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->


**Closing issues**

Closes #1419 