### PR TITLE
navigate through graph view with arrows

### DIFF
--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -91,12 +91,6 @@ DisassemblerGraphView::DisassemblerGraphView(QWidget *parent)
     QShortcut *shortcut_prev_instr = new QShortcut(QKeySequence(Qt::Key_K), this);
     shortcut_prev_instr->setContext(Qt::WidgetShortcut);
     connect(shortcut_prev_instr, SIGNAL(activated()), this, SLOT(prevInstr()));
-    QShortcut *shortcut_next_instr_arrow = new QShortcut(QKeySequence::MoveToNextLine, this);
-    shortcut_next_instr_arrow->setContext(Qt::WidgetShortcut);
-    connect(shortcut_next_instr_arrow, SIGNAL(activated()), this, SLOT(nextInstr()));
-    QShortcut *shortcut_prev_instr_arrow = new QShortcut(QKeySequence::MoveToPreviousLine, this);
-    shortcut_prev_instr_arrow->setContext(Qt::WidgetShortcut);
-    connect(shortcut_prev_instr_arrow, SIGNAL(activated()), this, SLOT(prevInstr()));
     shortcuts.append(shortcut_disassembly);
     shortcuts.append(shortcut_escape);
     shortcuts.append(shortcut_zoom_in);
@@ -104,8 +98,6 @@ DisassemblerGraphView::DisassemblerGraphView(QWidget *parent)
     shortcuts.append(shortcut_zoom_reset);
     shortcuts.append(shortcut_next_instr);
     shortcuts.append(shortcut_prev_instr);
-    shortcuts.append(shortcut_next_instr_arrow);
-    shortcuts.append(shortcut_prev_instr_arrow);
 
     // Export Graph menu
     mMenu->addSeparator();

--- a/src/widgets/GraphView.cpp
+++ b/src/widgets/GraphView.cpp
@@ -5,6 +5,7 @@
 #include <vector>
 #include <QPainter>
 #include <QMouseEvent>
+#include <QKeyEvent>
 #include <QPropertyAnimation>
 
 #ifndef QT_NO_OPENGL
@@ -484,6 +485,33 @@ void GraphView::mouseDoubleClickEvent(QMouseEvent *event)
             return;
         }
     }
+}
+
+void GraphView::keyPressEvent(QKeyEvent* event)
+{
+    constexpr qreal delta = 30.0;
+    int dx = 0, dy = 0;
+    switch (event->key()) {
+    case Qt::Key_Up:
+        dy = -static_cast<int>(delta / current_scale);
+        break;
+    case Qt::Key_Down:
+        dy = static_cast<int>(delta / current_scale);
+        break;
+    case Qt::Key_Left:
+        dx = -static_cast<int>(delta / current_scale);
+        break;
+    case Qt::Key_Right:
+        dx = static_cast<int>(delta / current_scale);
+        break;
+    default:
+        QAbstractScrollArea::keyPressEvent(event);
+        return;
+    }
+    offset.rx() += dx;
+    offset.ry() += dy;
+    viewport()->update();
+    event->accept();
 }
 
 void GraphView::mouseReleaseEvent(QMouseEvent *event)

--- a/src/widgets/GraphView.cpp
+++ b/src/widgets/GraphView.cpp
@@ -489,20 +489,20 @@ void GraphView::mouseDoubleClickEvent(QMouseEvent *event)
 
 void GraphView::keyPressEvent(QKeyEvent* event)
 {
-    constexpr qreal delta = 30.0;
+    const int delta = static_cast<int>(30.0 / current_scale);
     int dx = 0, dy = 0;
     switch (event->key()) {
     case Qt::Key_Up:
-        dy = -static_cast<int>(delta / current_scale);
+        dy = -delta;
         break;
     case Qt::Key_Down:
-        dy = static_cast<int>(delta / current_scale);
+        dy = delta;
         break;
     case Qt::Key_Left:
-        dx = -static_cast<int>(delta / current_scale);
+        dx = -delta;
         break;
     case Qt::Key_Right:
-        dx = static_cast<int>(delta / current_scale);
+        dx = delta;
         break;
     default:
         QAbstractScrollArea::keyPressEvent(event);

--- a/src/widgets/GraphView.h
+++ b/src/widgets/GraphView.h
@@ -87,6 +87,8 @@ protected:
     void mouseReleaseEvent(QMouseEvent *event) override;
     void mouseDoubleClickEvent(QMouseEvent *event) override;
 
+    void keyPressEvent(QKeyEvent *event) override;
+
     void paintEvent(QPaintEvent *event) override;
 
     void center();


### PR DESCRIPTION
<!-- *Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.* 

Please provide enough information so that others can review your pull request:

Explain the **details** for making this change. What existing problem does the pull request solve? -->

Cutter used to seek back and forward whenever user pressed up/down arrows in graph widget. I changed this behavior so now arrows are provide navigation.

**Test plan (required)**
Very laggy GIF is attached.
![Peek 2019-04-08 21-09](https://user-images.githubusercontent.com/42874998/55746622-d175a400-5a42-11e9-9c34-08dfdcbe697d.gif)


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**
closes #1397
<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
