### PR TITLE
Focus on visible disasm or graph

### DIFF
--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -598,7 +598,7 @@ void MainWindow::finalizeOpen()
     // widgets are invisible but extra ones are visible
 
     // Graph with function in it has focus priority over DisasmWidget
-    // if there are bot graph and disasm.
+    // if there are both graph and disasm.
     // Otherwise Disasm has focus priority over Graph
 
     // If there are no graph/disasm widgets focus on MainWindow

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -600,34 +600,29 @@ void MainWindow::finalizeOpen()
     // Graph with function in it has focus priority over DisasmWidget
     // if there are bot graph and disasm.
     // Otherwise Disasm has focus priority over Graph
+
+    // If there are no graph/disasm widgets focus on MainWindow
+
     setFocus();
     const QString disasmWidgetClassName = disassemblyDock->metaObject()->className();
     const QString graphWidgetClassName = graphDock->metaObject()->className();
-    GraphWidget *focusedGraph = nullptr;
-    QWidget *focusedDisasm = nullptr;
     bool graphContainsFunc = false;
     for (auto dockWidget : dockWidgets) {
         const QString className = dockWidget->metaObject()->className();
         if (className == graphWidgetClassName && !dockWidget->visibleRegion().isNull()) {
-            focusedGraph = qobject_cast<GraphWidget*>(dockWidget->widget());
-            graphContainsFunc = !focusedGraph->getGraphView()->getBlocks().empty();
+            graphContainsFunc = !qobject_cast<GraphWidget*>(dockWidget)->getGraphView()->getBlocks().empty();
             if (graphContainsFunc) {
+                dockWidget->widget()->setFocus();
                 break;
             }
         }
         if (className == disasmWidgetClassName && !dockWidget->visibleRegion().isNull()) {
-            focusedDisasm = dockWidget;
-            if (focusedGraph) {
+            if (!graphContainsFunc) {
+                dockWidget->widget()->setFocus();
+            } else {
                 break;
             }
         }
-    }
-    if (graphContainsFunc) {
-        focusedGraph->setFocus();
-    } else if (focusedDisasm) {
-        focusedDisasm->setFocus();
-    } else if (focusedGraph) {
-        focusedGraph->setFocus();
     }
 }
 

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -590,6 +590,7 @@ void MainWindow::finalizeOpen()
     showMaximized();
 
     // Set focus to disasm or graph widget
+    setFocus();
     const QString disasmWidgetClassName = disassemblyDock->metaObject()->className();
     const QString graphWidgetClassName = graphDock->metaObject()->className();
     for (auto dockWidget : dockWidgets) {

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -618,7 +618,8 @@ void MainWindow::finalizeOpen()
         }
         if (className == disasmWidgetClassName && !dockWidget->visibleRegion().isNull()) {
             if (!graphContainsFunc) {
-                dockWidget->widget()->setFocus();
+                auto disasm = qobject_cast<DisassemblyWidget*>(dockWidget);
+                disasm->setFocus();
             } else {
                 break;
             }

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -588,6 +588,18 @@ void MainWindow::finalizeOpen()
     // Add fortune message
     core->message("\n" + core->cmd("fo"));
     showMaximized();
+
+    // Set focus to disasm or graph widget
+    const QString disasmWidgetClassName = disassemblyDock->metaObject()->className();
+    const QString graphWidgetClassName = graphDock->metaObject()->className();
+    for (auto dockWidget : dockWidgets) {
+        const QString className = dockWidget->metaObject()->className();
+        if ((className == disasmWidgetClassName ||
+             className == graphWidgetClassName) &&
+            !dockWidget->visibleRegion().isNull()) {
+            dockWidget->setFocus();
+        }
+    }
 }
 
 bool MainWindow::saveProject(bool quit)
@@ -675,25 +687,11 @@ void MainWindow::readSettingsOrDefault()
 
     // make sure all DockWidgets are part of the MainWindow
     // also show them, so newly installed plugin widgets are shown right away
-    const QString disasmWidgetClassName = disassemblyDock->metaObject()->className();
-    const QString graphWidgetClassName = graphDock->metaObject()->className();
     for (auto dockWidget : dockWidgets) {
         if (dockWidgetArea(dockWidget) == Qt::DockWidgetArea::NoDockWidgetArea) {
             addDockWidget(Qt::DockWidgetArea::TopDockWidgetArea, dockWidget);
             dockWidget->show();
         }
-        const QString className = dockWidget->metaObject()->className();
-        if ((className == disasmWidgetClassName ||
-             className == graphWidgetClassName) &&
-            dockWidget->isVisibleTo(this)) {
-            dockWidget->setFocus();
-        }
-    }
-
-    if (disassemblyDock->isVisibleTo(this)) {
-        disassemblyDock->setFocus();
-    } else if (graphDock->isVisibleTo(this)) {
-        graphDock->setFocus();
     }
 
     responsive = settings.value("responsive").toBool();

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -675,11 +675,25 @@ void MainWindow::readSettingsOrDefault()
 
     // make sure all DockWidgets are part of the MainWindow
     // also show them, so newly installed plugin widgets are shown right away
+    const QString disasmWidgetClassName = disassemblyDock->metaObject()->className();
+    const QString graphWidgetClassName = graphDock->metaObject()->className();
     for (auto dockWidget : dockWidgets) {
         if (dockWidgetArea(dockWidget) == Qt::DockWidgetArea::NoDockWidgetArea) {
             addDockWidget(Qt::DockWidgetArea::TopDockWidgetArea, dockWidget);
             dockWidget->show();
         }
+        const QString className = dockWidget->metaObject()->className();
+        if ((className == disasmWidgetClassName ||
+             className == graphWidgetClassName) &&
+            dockWidget->isVisibleTo(this)) {
+            dockWidget->setFocus();
+        }
+    }
+
+    if (disassemblyDock->isVisibleTo(this)) {
+        disassemblyDock->setFocus();
+    } else if (graphDock->isVisibleTo(this)) {
+        graphDock->setFocus();
     }
 
     responsive = settings.value("responsive").toBool();


### PR DESCRIPTION
<!-- *Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.* 

Please provide enough information so that others can review your pull request:

Explain the **details** for making this change. What existing problem does the pull request solve? -->

Now as @xarkes mentioned "start emulation" button has focus on start of Cutter. 
I changed it so first visible disasm or graph widget has focus or if there are no visible disasm or graph - "start emulation" button has.

<!-- Demonstrate  the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**
closes #1284
<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
