### PR TITLE
improve project choose page

### DIFF
--- a/src/dialogs/NewFileDialog.cpp
+++ b/src/dialogs/NewFileDialog.cpp
@@ -61,6 +61,9 @@ NewFileDialog::NewFileDialog(MainWindow *main) :
     ui->projectsListWidget->addAction(ui->actionRemove_project);
     ui->logoSvgWidget->load(Config()->getLogoFile());
 
+    // radare2 does not seem to save this config so here we load this manually
+    Core()->setConfig("dir.projects", Config()->getDirProjects());
+
     fillRecentFilesList();
     fillIOPluginsList();
     fillProjectsList();
@@ -104,11 +107,12 @@ void NewFileDialog::on_selectProjectsDirButton_clicked()
         tr("Select project path (dir.projects)"),
         currentDir));
 
-    if (!dir.isEmpty()) {
+    if (dir.isEmpty()) {
         return;
     }
 
     Config()->setDirProjects(dir);
+    Core()->setConfig("dir.projects", dir);
     fillProjectsList();
 }
 

--- a/src/dialogs/NewFileDialog.cpp
+++ b/src/dialogs/NewFileDialog.cpp
@@ -110,6 +110,12 @@ void NewFileDialog::on_selectProjectsDirButton_clicked()
     if (dir.isEmpty()) {
         return;
     }
+    if (!QFileInfo(dir).isWritable()) {
+        QMessageBox::critical(this, tr("Permission denied"),
+                              tr("You do not have wtire access to the %1 directory.")
+                              .arg(dir));
+        return;
+    }
 
     Config()->setDirProjects(dir);
     Core()->setConfig("dir.projects", dir);

--- a/src/dialogs/NewFileDialog.cpp
+++ b/src/dialogs/NewFileDialog.cpp
@@ -112,7 +112,7 @@ void NewFileDialog::on_selectProjectsDirButton_clicked()
     }
     if (!QFileInfo(dir).isWritable()) {
         QMessageBox::critical(this, tr("Permission denied"),
-                              tr("You do not have wtire access to the %1 directory.")
+                              tr("You do not have write access to <b>%1</b>")
                               .arg(dir));
         return;
     }


### PR DESCRIPTION
<!-- *Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.* 

Please provide enough information so that others can review your pull request:

Explain the **details** for making this change. What existing problem does the pull request solve? -->

Text edit with current `dir.projects` path does not changes upon clicking "select" button and choosing another path.
Plus there were a bug that if you cancel dir-choosing dialog empty string will be saved as `dir.projects`.
And Cutter could not handle situation when user chose directory he didn't have access to.

These three issues is fixed in PR.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**
closes #1148
<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
