### PR TITLE
Start placing edges from centre.

### DIFF
--- a/src/widgets/GraphGridLayout.cpp
+++ b/src/widgets/GraphGridLayout.cpp
@@ -228,6 +228,9 @@ void GraphGridLayout::CalculateLayout(std::unordered_map<ut64, GraphBlock> &bloc
     }
 
     // Compute coordinates for edges
+    auto position_from_middle = [](int index, int spacing, int column_count) {
+        return spacing * (((index & 1) ? 1 : -1) * ((index + 1) / 2) + (column_count - 1) / 2);
+    };
     for (auto &blockIt : blocks) {
         GraphBlock &block = blockIt.second;
 
@@ -242,7 +245,8 @@ void GraphGridLayout::CalculateLayout(std::unordered_map<ut64, GraphBlock> &bloc
             auto start_col = start.col;
             auto last_index = edge.start_index;
             // This is the start point of the edge.
-            auto first_pt = QPoint(col_edge_x[start_col] + (layoutConfig.block_horizontal_margin * last_index) +
+            auto first_pt = QPoint(col_edge_x[start_col] +
+                                   position_from_middle(last_index, layoutConfig.block_horizontal_margin, col_edge_count[start_col]) +
                                    (layoutConfig.block_horizontal_margin / 2),
                                    block.y + block.height);
             auto last_pt = first_pt;
@@ -257,11 +261,12 @@ void GraphGridLayout::CalculateLayout(std::unordered_map<ut64, GraphBlock> &bloc
                 QPoint new_pt;
                 // block_vertical_margin/2 gives the margin from block to the horizontal lines
                 if (start_col == end_col)
-                    new_pt = QPoint(last_pt.x(), row_edge_y[end_row] + (layoutConfig.block_vertical_margin * last_index)
-                                    +
+                    new_pt = QPoint(last_pt.x(), row_edge_y[end_row] +
+                                    position_from_middle(last_index, layoutConfig.block_vertical_margin, row_edge_count[end_row]) +
                                     (layoutConfig.block_vertical_margin / 2));
                 else
-                    new_pt = QPoint(col_edge_x[end_col] + (layoutConfig.block_horizontal_margin * last_index) +
+                    new_pt = QPoint(col_edge_x[end_col] +
+                                    position_from_middle(last_index, layoutConfig.block_horizontal_margin, col_edge_count[end_col]) +
                                     (layoutConfig.block_horizontal_margin / 2), last_pt.y());
                 pts.push_back(new_pt);
                 last_pt = new_pt;


### PR DESCRIPTION
Start placing edge from middle of column.

Reduces amount of cases where edges endpoint is outside block. The cause for problem can be easily understood from screenshot bellow: edge placement is calculated by first counting maximum amount of edges in column and then placing them from left side.

Placing from middle solves most cases except:
* The blocks with large amount of edges (mostly switch blocks) - not a big problem as it is clear where edges are going
*  in the same segment as large amount of edges, previously it affected everything in the same column

Can be further improved by implementing #1416

**Test plan (required)**

After on the left, before on the right.

![Ekrānattēls no 2019-04-15 22-35-14](https://user-images.githubusercontent.com/7101031/56160499-fe403300-5fcf-11e9-9af9-7038e0bf3a91.png)


**Closing issues**

Solves most common case for #781.
