### PR TITLE
Show recent files ordered by opening time.

### DIFF
--- a/src/dialogs/NewfileDialog.ui
+++ b/src/dialogs/NewfileDialog.ui
@@ -278,7 +278,7 @@
                <bool>true</bool>
               </property>
               <property name="sortingEnabled">
-               <bool>true</bool>
+               <bool>false</bool>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
Disable sorting in alphabetical order so that the code ordering by opening time can work.

**Test plan (required)**

* Fill recent file list opening few different binaries
* Before patch open file from near the bottom of list
* Reopen cutter and observe that last opened file is still at the bottom
* Apply patch
* Open file near the bottom of list
* Reopen cutter and observe that last opened file has been moved to the top

**Closing issues**

<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

Fixes #1452 
