### PR TITLE
Show context menu with non block specific graph actions everywhere.

### DIFF
--- a/src/widgets/DisassemblerGraphView.h
+++ b/src/widgets/DisassemblerGraphView.h
@@ -148,7 +148,8 @@ private:
     int baseline;
     bool emptyGraph;
 
-    DisassemblyContextMenu *mMenu;
+    DisassemblyContextMenu *blockMenu;
+    QMenu *contextMenu;
 
     void connectSeekChanged(bool disconnect);
 

--- a/src/widgets/GraphView.cpp
+++ b/src/widgets/GraphView.cpp
@@ -443,25 +443,27 @@ void GraphView::mousePressEvent(QMouseEvent *event)
     }
 
     // Check if a line beginning/end  was clicked
-    for (auto &blockIt : blocks) {
-        GraphBlock &block = blockIt.second;
-        for (GraphEdge &edge : block.edges) {
-            if (edge.polyline.length() < 2) {
-                continue;
-            }
-            QPointF start = edge.polyline.first();
-            QPointF end = edge.polyline.last();
-            if (checkPointClicked(start, x, y)) {
-                showBlock(blocks[edge.target]);
-                // TODO: Callback to child
-                return;
-                break;
-            }
-            if (checkPointClicked(end, x, y, true)) {
-                showBlock(block);
-                // TODO: Callback to child
-                return;
-                break;
+    if (event->button() == Qt::LeftButton) {
+        for (auto &blockIt : blocks) {
+            GraphBlock &block = blockIt.second;
+            for (GraphEdge &edge : block.edges) {
+                if (edge.polyline.length() < 2) {
+                    continue;
+                }
+                QPointF start = edge.polyline.first();
+                QPointF end = edge.polyline.last();
+                if (checkPointClicked(start, x, y)) {
+                    showBlock(blocks[edge.target]);
+                    // TODO: Callback to child
+                    return;
+                    break;
+                }
+                if (checkPointClicked(end, x, y, true)) {
+                    showBlock(block);
+                    // TODO: Callback to child
+                    return;
+                    break;
+                }
             }
         }
     }
@@ -470,8 +472,10 @@ void GraphView::mousePressEvent(QMouseEvent *event)
     if (event->button() == Qt::LeftButton) {
         //Left click outside any block, enter scrolling mode
         beginMouseDrag(event);
+        return;
     }
 
+    QAbstractScrollArea::mousePressEvent(event);
 }
 
 void GraphView::mouseMoveEvent(QMouseEvent *event)


### PR DESCRIPTION
Some of the graph context menu actions are not specific to block. It makes sense to show context menu with such actions when right clicking anywhere on graph.

This should reduce amount of issues like  #1352.

**Test plan (required)**
* Right click on block - observe that menu opens as before
* Click outside context menu and observe that only one context menu was opened
* Right click outside blocks and observe that context menu with relevant entries gets opened
* Verify that mouse drag still works
* Verify that clicking on arrow ends still works

![Ekrānattēls 2019-04-18 00-02-43](https://user-images.githubusercontent.com/7101031/56320811-9fb0bb80-616d-11e9-8f4e-d3ada229bbd4.png)

**Closing issues**

Fixes #1415
