### PR TITLE
Help not getting lost in empty parts of graph.

### DIFF
--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -519,6 +519,11 @@ void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block)
 
     qreal render_height = viewport()->size().height();
 
+    // Stop rendering text when it's too small
+    if (charHeight * getViewScale() * p.device()->devicePixelRatioF() < 4) {
+        return;
+    }
+
     // Render node text
     auto x = blockX + (2 * charWidth);
     int y = static_cast<int>(blockY + (2 * charWidth));
@@ -718,7 +723,7 @@ void DisassemblerGraphView::zoom(QPointF mouseRelativePos, double velocity)
     auto globalMouse = mouseRelativePos + getViewOffset();
     mouseRelativePos *= getViewScale();
     qreal newScale = getViewScale() * std::pow(1.25, velocity);
-    newScale = std::max(newScale, 0.3);
+    newScale = std::max(newScale, 0.05);
     mouseRelativePos /= newScale;
     setViewScale(newScale);
 

--- a/src/widgets/GraphGridLayout.cpp
+++ b/src/widgets/GraphGridLayout.cpp
@@ -111,7 +111,6 @@ void GraphGridLayout::CalculateLayout(std::unordered_map<ut64, GraphBlock> &bloc
     }
 
     // Prepare edge routing
-    //auto &entryb = layoutState.grid_blocks[entry];
     int col_count = 1;
     int row_count = 0;
     for (const auto &blockIt : layoutState.grid_blocks) {
@@ -183,30 +182,30 @@ void GraphGridLayout::CalculateLayout(std::unordered_map<ut64, GraphBlock> &bloc
     row_y.assign(row_count, 0);
     std::vector<int> col_edge_x(col_count + 1);
     std::vector<int> row_edge_y(row_count + 1);
-    int x = layoutConfig.block_horizontal_margin * 2;
-    for (int i = 0; i < col_count; i++) {
+    int x = layoutConfig.block_horizontal_margin;
+    for (int i = 0; i <= col_count; i++) {
         col_edge_x[i] = x;
         x += layoutConfig.block_horizontal_margin * col_edge_count[i];
-        col_x[i] = x;
-        x += col_width[i];
+        if (i < col_count) {
+            col_x[i] = x;
+            x += col_width[i];
+        }
     }
-    int y = layoutConfig.block_vertical_margin * 2;
-    for (int i = 0; i < row_count; i++) {
+    int y = layoutConfig.block_vertical_margin;
+    for (int i = 0; i <= row_count; i++) {
         row_edge_y[i] = y;
-        // TODO: The 1 when row_edge_count is 0 is not needed on the original.. not sure why it's required for us
         if (!row_edge_count[i]) {
+            // prevent 2 blocks being put on top of each other without any space
             row_edge_count[i] = 1;
         }
         y += layoutConfig.block_vertical_margin * row_edge_count[i];
-        row_y[i] = y;
-        y += row_height[i];
+        if (i < row_count) {
+            row_y[i] = y;
+            y += row_height[i];
+        }
     }
-    col_edge_x[col_count] = x;
-    row_edge_y[row_count] = y;
-    width = x + (layoutConfig.block_horizontal_margin * 2) + (layoutConfig.block_horizontal_margin *
-                                                              col_edge_count[col_count]);
-    height = y + (layoutConfig.block_vertical_margin * 2) + (layoutConfig.block_vertical_margin *
-                                                             row_edge_count[row_count]);
+    width = x + (layoutConfig.block_horizontal_margin);
+    height = y + (layoutConfig.block_vertical_margin);
 
     //Compute node positions
     for (auto &blockIt : blocks) {

--- a/src/widgets/GraphView.h
+++ b/src/widgets/GraphView.h
@@ -91,6 +91,10 @@ protected:
     int width = 0;
     int height = 0;
 
+    void clampViewOffset();
+    void setViewOffsetInternal(QPoint pos, bool emitSignal = true);
+    void addViewOffset(QPoint move, bool emitSignal = true);
+
 private:
     void centerX(bool emitSignal);
     void centerY(bool emitSignal);


### PR DESCRIPTION
* Limit how far outside image view can be moved.  Don't allow going further than ~3/4 of screen outside image borders. That should be enough to allow focusing on block as wanted by #727 .
* Allow using main view as overview by increasing maximum zoom out level. When zoomed out sufficiently far stop rendering text and ensure that edges are still visible.
* Fix showBlock position calculation when zoomed out. Previous code resulted in block being slightly out of screen when navigating using t/f keys.

**Test plan (required)**

* Test that maximum offset calculation works when using:
    * left click drag
    * middle click drag
    * arrow keys
    * scroll wheel
* Zoom out as far as possible and test that
    * edges are still visible
    * text doesn't disappear while still readable
    * repeat with QT_SCALE_FACTOR set to 2
* test that showBlock works the same at various zoom levels and display scaling levels

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**

Closing #1459.