### PR TITLE
Add Ctrl-Shift-C shortcut

### DIFF
--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -27,7 +27,7 @@ DisassemblyContextMenu::DisassemblyContextMenu(QWidget *parent)
 
     copySeparator = addSeparator();
 
-    initAction(&actionCopyAddr, tr("Copy address"), SLOT(on_actionCopyAddr_triggered()));
+    initAction(&actionCopyAddr, tr("Copy address"), SLOT(on_actionCopyAddr_triggered()), getCopyAddressSequence());
     addAction(&actionCopyAddr);
 
     initAction(&actionAddComment, tr("Add Comment"),
@@ -386,6 +386,11 @@ QKeySequence DisassemblyContextMenu::getCopySequence() const
 QKeySequence DisassemblyContextMenu::getCommentSequence() const
 {
     return {Qt::Key_Semicolon};
+}
+
+QKeySequence DisassemblyContextMenu::getCopyAddressSequence() const
+{
+    return {Qt::CTRL + Qt::SHIFT + Qt::Key_C};
 }
 
 QKeySequence DisassemblyContextMenu::getSetToCodeSequence() const

--- a/src/menus/DisassemblyContextMenu.h
+++ b/src/menus/DisassemblyContextMenu.h
@@ -79,6 +79,7 @@ private slots:
 private:
     QKeySequence getCopySequence() const;
     QKeySequence getCommentSequence() const;
+    QKeySequence getCopyAddressSequence() const;
     QKeySequence getSetToCodeSequence() const;
     QKeySequence getSetAsStringSequence() const;
     QKeySequence getSetToDataSequence() const;


### PR DESCRIPTION
Copy current address in disassembly and graph mode

**Test plan (required)**
Hit Ctrl-Shift-C in either graph or disassembly view and paste the address elsewhere.

**Closing issues**

Closes #1474
