### PR TITLE
Add Ctrl-Shift-C shortcut

### DIFF
--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -25,10 +25,10 @@ DisassemblyContextMenu::DisassemblyContextMenu(QWidget *parent)
     initAction(&actionCopy, tr("Copy"), SLOT(on_actionCopy_triggered()), getCopySequence());
     addAction(&actionCopy);
 
-    copySeparator = addSeparator();
-
-    initAction(&actionCopyAddr, tr("Copy address"), SLOT(on_actionCopyAddr_triggered()));
+    initAction(&actionCopyAddr, tr("Copy address"), SLOT(on_actionCopyAddr_triggered()), getCopyAddressSequence());
     addAction(&actionCopyAddr);
+
+    copySeparator = addSeparator();
 
     initAction(&actionAddComment, tr("Add Comment"),
                SLOT(on_actionAddComment_triggered()), getCommentSequence());
@@ -386,6 +386,11 @@ QKeySequence DisassemblyContextMenu::getCopySequence() const
 QKeySequence DisassemblyContextMenu::getCommentSequence() const
 {
     return {Qt::Key_Semicolon};
+}
+
+QKeySequence DisassemblyContextMenu::getCopyAddressSequence() const
+{
+    return {Qt::CTRL + Qt::SHIFT + Qt::Key_C};
 }
 
 QKeySequence DisassemblyContextMenu::getSetToCodeSequence() const

--- a/src/menus/DisassemblyContextMenu.h
+++ b/src/menus/DisassemblyContextMenu.h
@@ -79,6 +79,7 @@ private slots:
 private:
     QKeySequence getCopySequence() const;
     QKeySequence getCommentSequence() const;
+    QKeySequence getCopyAddressSequence() const;
     QKeySequence getSetToCodeSequence() const;
     QKeySequence getSetAsStringSequence() const;
     QKeySequence getSetToDataSequence() const;

--- a/src/widgets/HexdumpWidget.cpp
+++ b/src/widgets/HexdumpWidget.cpp
@@ -13,6 +13,7 @@
 #include <QClipboard>
 #include <QScrollBar>
 #include <QInputDialog>
+#include <QShortcut>
 
 HexdumpWidget::HexdumpWidget(MainWindow *main, QAction *action) :
     MemoryDockWidget(CutterCore::MemoryWidgetType::Hexdump, main, action),
@@ -36,6 +37,11 @@ HexdumpWidget::HexdumpWidget(MainWindow *main, QAction *action) :
     // Setup hex highlight
     //connect(ui->hexHexText, SIGNAL(cursorPositionChanged()), this, SLOT(highlightHexCurrentLine()));
     //highlightHexCurrentLine();
+
+    auto cpyAddrShortcut = new QShortcut(QKeySequence{Qt::CTRL + Qt::SHIFT + Qt::Key_C}, this);
+    cpyAddrShortcut->setContext(Qt::WidgetWithChildrenShortcut);
+    ui->actionCopyAddressAtCursor->setShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_C);
+    connect(cpyAddrShortcut, &QShortcut::activated, this, &HexdumpWidget::on_actionCopyAddressAtCursor_triggered);
 
     ui->copyMD5->setIcon(QIcon(":/img/icons/copy.svg"));
     ui->copySHA1->setIcon(QIcon(":/img/icons/copy.svg"));
@@ -617,6 +623,11 @@ void HexdumpWidget::showHexdumpContextMenu(const QPoint &pt)
     // Set Hexdump popup menu
     QMenu *menu = ui->hexHexText->createStandardContextMenu();
     menu->clear();
+
+    menu->addAction(ui->actionCopyAddressAtCursor);
+
+    menu->addSeparator();
+
     /*menu->addAction(ui->actionHexCopy_Hexpair);
     menu->addAction(ui->actionHexCopy_ASCII);
     menu->addAction(ui->actionHexCopy_Text);
@@ -978,6 +989,14 @@ void HexdumpWidget::scrollChanged()
 /*
  * Actions callback functions
  */
+
+void HexdumpWidget::on_actionCopyAddressAtCursor_triggered()
+{
+    auto addr = hexPositionToAddress(ui->hexHexText->textCursor().position());
+
+    QClipboard *clipboard = QApplication::clipboard();
+    clipboard->setText(RAddressString(addr));
+}
 
 void HexdumpWidget::on_actionHideHexdump_side_panel_triggered()
 {

--- a/src/widgets/HexdumpWidget.h
+++ b/src/widgets/HexdumpWidget.h
@@ -134,6 +134,8 @@ private slots:
     void on_parseTypeComboBox_currentTextChanged(const QString &arg1);
     void on_parseEndianComboBox_currentTextChanged(const QString &arg1);
 
+    void on_actionCopyAddressAtCursor_triggered();
+
     void on_action1column_triggered();
     void on_action2columns_triggered();
     void on_action4columns_triggered();

--- a/src/widgets/HexdumpWidget.ui
+++ b/src/widgets/HexdumpWidget.ui
@@ -764,6 +764,14 @@
     <string>Copy Text</string>
    </property>
   </action>
+  <action name="actionCopyAddressAtCursor">
+   <property name="text">
+    <string>Copy Address</string>
+   </property>
+   <property name="toolTip">
+    <string>Copy Address at Cursor</string>
+   </property>
+  </action>
   <action name="action1column">
    <property name="text">
     <string>1</string>


### PR DESCRIPTION
Copies address at cursor from hexdump, graph and disassembly views

I don't really know Qt, so double check the `new QShortcut` usage

**Test plan**

Copied addresses from hex, graph and disassem views with both menu and shortcut

**Closing issues**

Fix #1474
