### PR TITLE
Show a tooltip with Asm\Hex preview on search hits

### DIFF
--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -78,6 +78,7 @@ public:
     QString cmdFunctionAt(QString addr);
     QString cmdFunctionAt(RVA addr);
     QString createFunctionAt(RVA addr, QString name);
+    QStringList getDisassemblyPreview(RVA address, int num_of_lines);
 
     /* Flags */
     void delFlag(RVA addr);
@@ -184,7 +185,7 @@ public:
     QString getConfig(const QString &k) { return getConfig(k.toUtf8().constData()); }
     QList<QString> getColorThemes();
 
-    /* Assembly related methods */
+    /* Assembly\Hexdump related methods */
     QByteArray assemble(const QString &code);
     QString disassemble(const QByteArray &data);
     QString disassembleSingleInstruction(RVA addr);
@@ -192,6 +193,9 @@ public:
 
     static QByteArray hexStringToBytes(const QString &hex);
     static QString bytesToHexString(const QByteArray &bytes);
+    enum class HexdumpFormats { Normal, Half, Word, Quad, Signed, Octal };
+    QString hexdump(RVA offset, int size, HexdumpFormats format);
+    QString getHexdumpPreview(RVA offset, int size);
 
     void setCPU(QString arch, QString cpu, int bits);
     void setEndianness(bool big);

--- a/src/widgets/FunctionsWidget.cpp
+++ b/src/widgets/FunctionsWidget.cpp
@@ -198,34 +198,10 @@ QVariant FunctionModel::data(const QModelIndex &index, int role) const
         return static_cast<int>(Qt::AlignLeft | Qt::AlignVCenter);
 
     case Qt::ToolTipRole: {
-        QList<DisassemblyLine> disassemblyLines;
-        {
-            // temporarily simplify the disasm output to get it colorful and simple to read
-            TempConfig tempConfig;
-            tempConfig
-                .set("scr.color", COLOR_MODE_16M)
-                .set("asm.lines", false)
-                .set("asm.var", false)
-                .set("asm.comments", false)
-                .set("asm.bytes", false)
-                .set("asm.lines.fcn", false)
-                .set("asm.lines.out", false)
-                .set("asm.lines.bb", false)
-                .set("asm.bb.line", false);
 
-            disassemblyLines = Core()->disassembleLines(function.offset, kMaxTooltipDisasmPreviewLines + 1);
-        }
-        QStringList disasmPreview;
-        for (const DisassemblyLine &line : disassemblyLines) {
-            if (!function.contains(line.offset)) {
-                break;
-            }
-            disasmPreview << line.text;
-            if (disasmPreview.length() >= kMaxTooltipDisasmPreviewLines) {
-                disasmPreview << "...";
-                break;
-            }
-        }
+        QStringList disasmPreview = Core()->getDisassemblyPreview(function.offset, kMaxTooltipDisasmPreviewLines);
+        
+        
 
         const QStringList &summary = Core()->cmdList(QString("pdsf @ %1").arg(function.offset));
 

--- a/src/widgets/FunctionsWidget.cpp
+++ b/src/widgets/FunctionsWidget.cpp
@@ -200,11 +200,7 @@ QVariant FunctionModel::data(const QModelIndex &index, int role) const
     case Qt::ToolTipRole: {
 
         QStringList disasmPreview = Core()->getDisassemblyPreview(function.offset, kMaxTooltipDisasmPreviewLines);
-        
-        
-
         const QStringList &summary = Core()->cmdList(QString("pdsf @ %1").arg(function.offset));
-
         const QFont &fnt = Config()->getFont();
         QFontMetrics fm{ fnt };
 


### PR DESCRIPTION
This PR will show a tooltip with disassembly\hexdump preview upon hovering a search hit. This will make it easier for the user to find their desired result out of many.

The solution differs between CODE and DATA and will show Disassembly or Hexdump accordingly.

**Test plan (required)**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Hexdump:
![image](https://user-images.githubusercontent.com/20182642/56472448-2a8fff80-6467-11e9-8608-94e813d8fde3.png)

Disassembly:
![image](https://user-images.githubusercontent.com/20182642/56472494-b30ea000-6467-11e9-9314-b5be703c69e4.png)




<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**

closes #399
