### PR TITLE
Use same font size for all text in hexdump widget.

### DIFF
--- a/src/widgets/HexdumpWidget.h
+++ b/src/widgets/HexdumpWidget.h
@@ -53,6 +53,7 @@ public slots:
 
     void zoomIn(int range = 1);
     void zoomOut(int range = 1);
+    void zoomReset();
     void toggleSync();
 
 protected:
@@ -102,6 +103,7 @@ private:
     int hexAddressToPosition(RVA address);
     int asciiAddressToPosition(RVA address);
     void updateWidths();
+    void syncScale();
 
     void updateParseWindow(RVA start_address, int size);
     void clearParseWindow();
@@ -113,6 +115,7 @@ private:
     HexdumpRangeDialog  rangeDialog;
     QAction syncAction;
     CutterSeekable *seekable;
+    qreal defaultFontSize;
 
 private slots:
     void onSeekChanged(RVA addr);

--- a/src/widgets/HexdumpWidget.ui
+++ b/src/widgets/HexdumpWidget.ui
@@ -911,6 +911,20 @@
     <string>Select Block...</string>
    </property>
   </action>
+  <action name="actionResetZoom">
+   <property name="enabled">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Reset zoom</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+0</string>
+   </property>
+   <property name="shortcutContext">
+    <enum>Qt::WindowShortcut</enum>
+   </property>
+  </action>
  </widget>
  <resources>
   <include location="../resources.qrc"/>


### PR DESCRIPTION
Mismatch was caused by:
* header field font size not being updated
* section bellow mouse being zoomed twice (once by hexdumpwidget and once by QTextEdit code)

I considered disabling the builtin zooming of QTextEdit. I couldn't find any property in QTextEdit documentation, didn't want to subclass QTextEdit just to disable zooming, couldn't get eventFilter working. In the end just copying font  size seemed like simplest solution.


**Test plan (required)**
Zoom in and zoom out.
![Zoom in](https://user-images.githubusercontent.com/7101031/56495789-7abaa080-64ff-11e9-9999-053b6373b763.png)
![Zoom out](https://user-images.githubusercontent.com/7101031/56495792-7abaa080-64ff-11e9-90a4-b376a2cb8193.png)
Tried with QT_SCALE_FACTOR=2 as well.

**Closing issues**
Closes #1468, #1469 