### PR TITLE
Improve hexWidget keyboard navigation and selection.

### DIFF
--- a/src/widgets/HexWidget.h
+++ b/src/widgets/HexWidget.h
@@ -43,12 +43,15 @@ public:
     void update(uint64_t addr)
     {
         m_empty = false;
-        if (addr >= m_init) {
+        if (addr > m_init) {
             m_start = m_init;
-            m_end = addr;
-        } else {
+            m_end = addr - 1;
+        } else if (addr < m_init) {
             m_start = addr;
-            m_end = m_init;
+            m_end = m_init - 1;
+        } else {
+            m_start = m_end = m_init;
+            m_empty = true;
         }
     }
 
@@ -125,8 +128,8 @@ private:
     void updateMetrics();
     void updateAreasPosition();
     void updateAreasHeight();
-    void moveCursor(int offset);
-    void setCursorAddr(uint64_t addr);
+    void moveCursor(int offset, bool select = false);
+    void setCursorAddr(uint64_t addr, bool select = false);
     void updateCursorMeta();
     void setCursorOnAscii(bool ascii);
     const QColor itemColor(uint8_t byte);

--- a/src/widgets/HexWidget.h
+++ b/src/widgets/HexWidget.h
@@ -12,7 +12,7 @@ struct HexCursor {
     QTimer blinkTimer;
     QRect screenPos;
     uint64_t address;
-    QString cachedString;
+    QString cachedChar;
     QColor cachedColor;
 
     void blink() { isVisible = !isVisible; }
@@ -58,6 +58,11 @@ public:
     bool intersects(uint64_t start, uint64_t end)
     {
         return !m_empty && !(m_end <= start || m_start >= end);
+    }
+
+    bool contains(uint64_t pos) const
+    {
+        return !m_empty && m_start <= pos && pos <= m_end;
     }
 
     int size()

--- a/src/widgets/HexWidget.h
+++ b/src/widgets/HexWidget.h
@@ -128,12 +128,15 @@ private:
     void moveCursor(int offset);
     void setCursorAddr(uint64_t addr);
     void updateCursorMeta();
+    void setCursorOnAscii(bool ascii);
     const QColor itemColor(uint8_t byte);
     QVariant readItem(int offset, QColor *color = nullptr);
     QString renderItem(int offset, QColor *color = nullptr);
     QChar renderAscii(int offset, QColor *color = nullptr);
     void updateDataCache();
-    uint64_t screenPosToAddr(const QPoint &point);
+    uint64_t screenPosToAddr(const QPoint &point) const;
+    uint64_t asciiPosToAddr(const QPoint &point) const;
+    uint64_t currentAreaPosToAddr(const QPoint &point) const;
     QRect itemRectangle(uint offset);
     QRect asciiRectangle(uint offset);
 
@@ -205,6 +208,11 @@ private:
     static inline bool isPrintable(uint8_t byte)
     {
         return (byte >= '!' && byte <= '~');
+    }
+
+    const QRect &currentArea() const
+    {
+        return cursorOnAscii ? asciiArea : itemArea;
     }
 
     bool cursorEnabled;


### PR DESCRIPTION
* allow selecting using mouse on ascii side
* range selection using keyboard
* Change posToOffset calculation so that it changes in the middle of symbol. Allows handling mouse selection and keyboard selection the same way.
* endOfLine/startOfLine shortcuts
* move cursor to 0 instead of ignore action, when doing pageUp near start