### PR TITLE
Add X-Refs context menu item for Flags Widget

### DIFF
--- a/src/widgets/FlagsWidget.cpp
+++ b/src/widgets/FlagsWidget.cpp
@@ -213,6 +213,7 @@ void FlagsWidget::on_actionXrefs_triggered()
     xresfDialog.fillRefsForAddress(flag.offset, RAddressString(flag.offset), false);
     xresfDialog.exec();
 }
+
 void FlagsWidget::showContextMenu(const QPoint &pt)
 {
     QMenu *menu = new QMenu(ui->flagsTreeView);

--- a/src/widgets/FlagsWidget.h
+++ b/src/widgets/FlagsWidget.h
@@ -71,6 +71,7 @@ private slots:
 
     void on_actionRename_triggered();
     void on_actionDelete_triggered();
+    void on_actionXrefs_triggered();
 
     void showContextMenu(const QPoint &pt);
 

--- a/src/widgets/FlagsWidget.ui
+++ b/src/widgets/FlagsWidget.ui
@@ -98,10 +98,27 @@
    <property name="text">
     <string>Rename</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+N</string>
+   </property>
   </action>
   <action name="actionDelete">
    <property name="text">
     <string>Delete</string>
+   </property>
+   <property name="shortcut">
+    <string>Del</string>
+   </property>
+  </action>
+  <action name="actionXrefs">
+   <property name="text">
+    <string>X-Refs</string>
+   </property>
+   <property name="toolTip">
+    <string>Show X-Refs of this flag</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+X</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
**Detailed description**

This PR adds X-Refs to the context menu of the Flags widget.


**Test plan (required)**
Go to the Flags widget. Right Click a flag and choose X-Refs. Alternatively, choose a flag and press <kbd>CTRL</kbd>+<kbd>X</kbd>.

![image](https://user-images.githubusercontent.com/20182642/57031635-e19f2e80-6c50-11e9-8971-953303033991.png)

**Closing issues**

Closes #922
