### PR TITLE
docker/Dockerfile: Make build noninteractive

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,9 @@
 FROM ubuntu:rolling
 LABEL maintainer "pschmied <ps1337@mailbox.org>"
 
+# Prevent build fails because of interactive scripts when compiling
+ENV DEBIAN_FRONTEND noninteractive
+
 # Dependencies
 RUN apt-get update && \
     apt-get -y install \


### PR DESCRIPTION
This fixes an issue related to #1138 where the image build was not passing. The image now builds and runs for me locally when building without cache.

Please note that someone should still re-setup the build pipeline on [Docker Hub](https://hub.docker.com/r/radareorg/cutter/builds) since there's currently no image auto build configured for the cutter repository:

```
No autobuilds available
This repository doesn't have any autobuilds
```

Cheers


