### PR TITLE
Invalidate overview graph cache when changing color.

### DIFF
--- a/src/widgets/OverviewView.cpp
+++ b/src/widgets/OverviewView.cpp
@@ -146,6 +146,7 @@ void OverviewView::colorsUpdatedSlot()
     disassemblyBackgroundColor = ConfigColor("gui.overview.node");
     graphNodeColor = ConfigColor("gui.border");
     backgroundColor = ConfigColor("gui.background");
+    setCacheDirty();
     refreshView();
 }
 


### PR DESCRIPTION


**Closing issues**
Closes #1496.