### PR TITLE
improve build.sh script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -100,7 +100,7 @@ fi
 $(find_lrelease) ./src/Cutter.pro
 
 # Build
-if [ "${QMAKE_CONF/CUTTER_ENABLE_CRASH_REPORTS=true}" != $QMAKE_CONF ]; then
+if [ "${QMAKE_CONF/CUTTER_ENABLE_CRASH_REPORTS=true/something}" != $QMAKE_CONF ]; then
 	prepare_breakpad
 fi
 mkdir -p "$BUILD"

--- a/scripts/prepare_breakpad_linux.sh
+++ b/scripts/prepare_breakpad_linux.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 git clone https://github.com/google/breakpad.git
 cd breakpad

--- a/scripts/prepare_breakpad_macos.sh
+++ b/scripts/prepare_breakpad_macos.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 SCRIPTPATH=$(realpath "$(dirname "${BASH_SOURCE[0]}")")
 


### PR DESCRIPTION
 <!-- Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request. -->

closes #1509

**Additional changes:**
Now user can pass qmake parameters via script arguments (like so `./build.sh CUTTER_ENABLE_CRASH_REPORTS=true`)