### PR TITLE
Added hotkeys for undo and redo seek

### DIFF
--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -158,6 +158,10 @@ void MainWindow::initUI()
     connect(core->getAsyncTaskManager(), &AsyncTaskManager::tasksChanged, this,
             &MainWindow::updateTasksIndicator);
 
+    //Undo and redo seek
+    ui->actionBackward->setShortcut(QKeySequence::Back);
+    ui->actionForward->setShortcut(QKeySequence::Forward);
+    
     /* Setup plugins interfaces */
     for (auto plugin : Plugins()->getPlugins()) {
         plugin->setupInterface(this);


### PR DESCRIPTION
 <!-- Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request. -->


**Detailed description**
This adds hotkeys for undo and redo seek using the QKeySequence back and forward respectively.
Undo seek is bound on windows to `Alt+Left` or `Backspace`, on MacOS it's `Ctrl+[`, and on *nix it's `Alt+Left`. 
Redo seek is bound on windows to `Alt+Right` or `Shift+Backspace`, on MacOS it's `Ctrl+]`, and on *nix it's `Alt+Right`.

**Test plan (required)**
I've tested and it works fine with my machine. 

<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**
closes #1299 
<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
