### PR TITLE
Fix layout save and restore feature

### DIFF
--- a/src/common/CutterSeekable.cpp
+++ b/src/common/CutterSeekable.cpp
@@ -50,6 +50,7 @@ void CutterSeekable::toggleSynchronization()
 {
     synchronized = !synchronized;
     onCoreSeekChanged(Core()->getOffset());
+    emit syncChanged();
 }
 
 bool CutterSeekable::isSynchronized()

--- a/src/common/CutterSeekable.h
+++ b/src/common/CutterSeekable.h
@@ -82,5 +82,5 @@ private:
 
 signals:
     void seekableSeekChanged(RVA addr);
-
+    void syncChanged();
 };

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -319,6 +319,13 @@ void MainWindow::initDocks()
     }
 
     updateMemberPointers();
+    if (!disassemblyDock) {
+        on_actionExtraDisassembly_triggered();
+    } else if (!graphDock) {
+        on_actionExtraGraph_triggered();
+    } else if (!hexdumpDock) {
+        on_actionExtraHexdump_triggered();
+    }
 }
 
 void MainWindow::initLayout()

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -94,8 +94,7 @@ public:
     void setFilename(const QString &fn);
     void refreshOmniBar(const QStringList &flags);
 
-    void addToDockWidgetList(QDockWidget *dockWidget);
-    void addDockWidgetAction(QDockWidget *dockWidget, QAction *action);
+    void addWidget(QDockWidget* widget);
     void addExtraWidget(CutterDockWidget *extraDock);
 
     void addPluginDockWidget(QDockWidget *dockWidget, QAction *action);
@@ -205,7 +204,7 @@ private:
     Configuration *configuration;
 
     QList<QDockWidget *> dockWidgets;
-    QMap<QAction *, QDockWidget *> dockWidgetActions;
+    QMultiMap<QAction *, QDockWidget *> dockWidgetsOfAction;
     DisassemblyWidget  *disassemblyDock = nullptr;
     HexdumpWidget      *hexdumpDock = nullptr;
     PseudocodeWidget   *pseudocodeDock = nullptr;
@@ -253,6 +252,7 @@ private:
     void resetToDebugLayout();
     void restoreDebugLayout();
 
+    void resetDockWidgetList();
     void restoreDocks();
     void hideAllDocks();
     void showZenDocks();
@@ -268,8 +268,6 @@ private:
     QMap<QString, std::pair<std::function<CutterDockWidget*(MainWindow*, QAction*)>, QAction*>> mapper;
 
     QString getUniqueObjectName(const QString &className) const;
-
-    void removeFromDockWidgetsList(const QString &objName);
 };
 
 #endif // MAINWINDOW_H

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -268,6 +268,8 @@ private:
     QMap<QString, std::pair<std::function<CutterDockWidget*(MainWindow*, QAction*)>, QAction*>> mapper;
 
     QString getUniqueObjectName(const QString &className) const;
+
+    void initCorners();
 };
 
 #endif // MAINWINDOW_H

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -246,12 +246,14 @@ private:
     void initToolBar();
     void initDocks();
     void initLayout();
+    void initCorners();
     void displayInitialOptionsDialog(const InitialOptions &options = InitialOptions(), bool skipOptionsDialog = false);
 
     void resetToDefaultLayout();
     void resetToDebugLayout();
     void restoreDebugLayout();
 
+    void updateMemberPointers();
     void resetDockWidgetList();
     void restoreDocks();
     void hideAllDocks();
@@ -265,13 +267,13 @@ private:
     void setOverviewData();
     bool isOverviewActive();
 
+    /**
+     * @brief Map, where key is class name an value is pair of
+     * pointer to class constructor and action that passed to this constructor.
+     */
     QMap<QString, std::pair<std::function<CutterDockWidget*(MainWindow*, QAction*)>, QAction*>> mapper;
 
     QString getUniqueObjectName(const QString &className) const;
-
-    void initCorners();
-
-    void updateMemberPointers();
 };
 
 #endif // MAINWINDOW_H

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -270,6 +270,8 @@ private:
     QString getUniqueObjectName(const QString &className) const;
 
     void initCorners();
+
+    void updateMemberPointers();
 };
 
 #endif // MAINWINDOW_H

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -264,6 +264,12 @@ private:
     void updateDockActionsChecked();
     void setOverviewData();
     bool isOverviewActive();
+
+    QMap<QString, std::pair<std::function<CutterDockWidget*(MainWindow*, QAction*)>, QAction*>> mapper;
+
+    QString getUniqueObjectName(const QString &className) const;
+
+    void removeFromDockWidgetsList(const QString &objName);
 };
 
 #endif // MAINWINDOW_H

--- a/src/widgets/CutterDockWidget.cpp
+++ b/src/widgets/CutterDockWidget.cpp
@@ -8,12 +8,12 @@ CutterDockWidget::CutterDockWidget(MainWindow *parent, QAction *action) :
     QDockWidget(parent),
     action(action)
 {
+    if (action) {
+        addAction(action);
+        connect(action, &QAction::triggered, this, &CutterDockWidget::toggleDockWidget);
+    }
     if (parent) {
-        parent->addToDockWidgetList(this);
-        if (action) {
-            parent->addDockWidgetAction(this, action);
-            connect(action, &QAction::triggered, this, &CutterDockWidget::toggleDockWidget);
-        }
+        parent->addWidget(this);
     }
 
     // Install event filter to catch redraw widgets when needed

--- a/src/widgets/CutterDockWidget.cpp
+++ b/src/widgets/CutterDockWidget.cpp
@@ -39,7 +39,7 @@ bool CutterDockWidget::eventFilter(QObject *object, QEvent *event)
 void CutterDockWidget::toggleDockWidget(bool show)
 {
     if (!show) {
-        this->close();
+        this->hide();
     } else {
         this->show();
         this->raise();
@@ -73,6 +73,8 @@ void CutterDockWidget::closeEvent(QCloseEvent *event)
     if (isTransient) {
         deleteLater();
     }
+
+    emit closed();
 }
 
 QAction *CutterDockWidget::getBoundAction() const

--- a/src/widgets/CutterDockWidget.h
+++ b/src/widgets/CutterDockWidget.h
@@ -57,6 +57,7 @@ public:
 
 signals:
     void becameVisibleToUser();
+    void closed();
 
 public slots:
     void toggleDockWidget(bool show);

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -28,12 +28,12 @@
 
 #include <cmath>
 
-DisassemblerGraphView::DisassemblerGraphView(QWidget *parent)
+DisassemblerGraphView::DisassemblerGraphView(QWidget *parent, CutterSeekable* seekable)
     : GraphView(parent),
       mFontMetrics(nullptr),
       blockMenu(new DisassemblyContextMenu(this)),
       contextMenu(new QMenu(this)),
-      seekable(new CutterSeekable(this))
+      seekable(seekable)
 {
     highlight_token = nullptr;
     auto *layout = new QVBoxLayout(this);
@@ -106,7 +106,7 @@ DisassemblerGraphView::DisassemblerGraphView(QWidget *parent)
     actionExportGraph.setText(tr("Export Graph"));
     connect(&actionExportGraph, SIGNAL(triggered(bool)), this, SLOT(on_actionExportGraph_triggered()));
     actionSyncOffset.setText(tr("Sync/unsync offset"));
-    connect(&actionSyncOffset, SIGNAL(triggered(bool)), this, SLOT(toggleSync()));
+    connect(&actionSyncOffset, &QAction::triggered, this, [this]() { this->seekable->toggleSynchronization(); });
 
     // Context menu that applies to everything
     contextMenu->addAction(&actionExportGraph);
@@ -153,16 +153,6 @@ DisassemblerGraphView::~DisassemblerGraphView()
 {
     for (QShortcut *shortcut : shortcuts) {
         delete shortcut;
-    }
-}
-
-void DisassemblerGraphView::toggleSync()
-{
-    seekable->toggleSynchronization();
-    if (seekable->isSynchronized()) {
-        parentWidget()->setWindowTitle(windowTitle);
-    } else {
-        parentWidget()->setWindowTitle(windowTitle + CutterSeekable::tr(" (unsynced)"));
     }
 }
 

--- a/src/widgets/DisassemblerGraphView.h
+++ b/src/widgets/DisassemblerGraphView.h
@@ -84,7 +84,7 @@ class DisassemblerGraphView : public GraphView
     };
 
 public:
-    DisassemblerGraphView(QWidget *parent);
+    DisassemblerGraphView(QWidget *parent, CutterSeekable* seekable);
     ~DisassemblerGraphView() override;
     std::unordered_map<ut64, DisassemblyBlock> disassembly_blocks;
     virtual void drawBlock(QPainter &p, GraphView::GraphBlock &block) override;
@@ -112,8 +112,6 @@ public slots:
     void colorsUpdatedSlot();
     void fontsUpdatedSlot();
     void onSeekChanged(RVA addr);
-    void toggleSync();
-
     void zoom(QPointF mouseRelativePos, double velocity);
     void zoomReset();
 

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -39,7 +39,7 @@ DisassemblyWidget::DisassemblyWidget(MainWindow *main, QAction *action)
     ,   mDisasScrollArea(new DisassemblyScrollArea(this))
     ,   mDisasTextEdit(new DisassemblyTextEdit(this))
 {
-    setObjectName("DisassemblyWidget 0");
+    setObjectName("DisassemblyWidget");
 
     topOffset = bottomOffset = RVA_INVALID;
     cursorLineOffset = 0;

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -40,17 +40,7 @@ DisassemblyWidget::DisassemblyWidget(MainWindow *main, QAction *action)
     ,   mDisasTextEdit(new DisassemblyTextEdit(this))
     ,   seekable(new CutterSeekable(this))
 {
-    /*
-     * Ugly hack just for the layout issue
-     * QSettings saves the state with the object names
-     * By doing this hack,
-     * you can at least avoid some mess by dismissing all the Extra Widgets
-     */
-    QString name = "Disassembly";
-    if (!action) {
-        name = "Extra Disassembly";
-    }
-    setObjectName(name);
+    setObjectName("DisassemblyWidget 0");
 
     topOffset = bottomOffset = RVA_INVALID;
     cursorLineOffset = 0;

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -38,7 +38,6 @@ DisassemblyWidget::DisassemblyWidget(MainWindow *main, QAction *action)
     ,   mCtxMenu(new DisassemblyContextMenu(this))
     ,   mDisasScrollArea(new DisassemblyScrollArea(this))
     ,   mDisasTextEdit(new DisassemblyTextEdit(this))
-    ,   seekable(new CutterSeekable(this))
 {
     setObjectName("DisassemblyWidget 0");
 
@@ -175,17 +174,6 @@ DisassemblyWidget::DisassemblyWidget(MainWindow *main, QAction *action)
     ADD_ACTION(QKeySequence(Qt::CTRL + Qt::Key_Equal), Qt::WidgetWithChildrenShortcut, &DisassemblyWidget::zoomIn)
     ADD_ACTION(QKeySequence(Qt::CTRL + Qt::Key_Minus), Qt::WidgetWithChildrenShortcut, &DisassemblyWidget::zoomOut)
 #undef ADD_ACTION
-}
-
-void DisassemblyWidget::toggleSync()
-{
-    QString windowTitle = tr("Disassembly");
-    seekable->toggleSynchronization();
-    if (seekable->isSynchronized()) {
-        setWindowTitle(windowTitle);
-    } else {
-        setWindowTitle(windowTitle + CutterSeekable::tr(" (unsynced)"));
-    }
 }
 
 void DisassemblyWidget::setPreviewMode(bool previewMode)

--- a/src/widgets/DisassemblyWidget.h
+++ b/src/widgets/DisassemblyWidget.h
@@ -29,7 +29,6 @@ public slots:
     void fontsUpdatedSlot();
     void colorsUpdatedSlot();
     void seekPrev();
-    void toggleSync();
     void setPreviewMode(bool previewMode);
 
 protected slots:
@@ -82,7 +81,6 @@ private:
     QList<QTextEdit::ExtraSelection> getSameWordsSelections();
 
     QAction syncIt;
-    CutterSeekable *seekable;
 };
 
 class DisassemblyScrollArea : public QAbstractScrollArea

--- a/src/widgets/GraphWidget.cpp
+++ b/src/widgets/GraphWidget.cpp
@@ -6,17 +6,7 @@
 GraphWidget::GraphWidget(MainWindow *main, QAction *action) :
     MemoryDockWidget(CutterCore::MemoryWidgetType::Graph, main, action)
 {
-    /*
-     * Ugly hack just for the layout issue
-     * QSettings saves the state with the object names
-     * By doing this hack,
-     * you can at least avoid some mess by dismissing all the Extra Widgets
-     */
-    QString name = "Graph";
-    if (!action) {
-        name = "Extra Graph";
-    }
-    setObjectName(name);
+    setObjectName("GraphWidget 0");
     setAllowedAreas(Qt::AllDockWidgetAreas);
     graphView = new DisassemblerGraphView(this);
     setWidget(graphView);

--- a/src/widgets/GraphWidget.cpp
+++ b/src/widgets/GraphWidget.cpp
@@ -8,7 +8,7 @@ GraphWidget::GraphWidget(MainWindow *main, QAction *action) :
 {
     setObjectName("GraphWidget 0");
     setAllowedAreas(Qt::AllDockWidgetAreas);
-    graphView = new DisassemblerGraphView(this);
+    graphView = new DisassemblerGraphView(this, seekable);
     setWidget(graphView);
 
     // getting the name of the class is implementation defined, and cannot be

--- a/src/widgets/GraphWidget.cpp
+++ b/src/widgets/GraphWidget.cpp
@@ -6,7 +6,7 @@
 GraphWidget::GraphWidget(MainWindow *main, QAction *action) :
     MemoryDockWidget(CutterCore::MemoryWidgetType::Graph, main, action)
 {
-    setObjectName("GraphWidget 0");
+    setObjectName("GraphWidget");
     setAllowedAreas(Qt::AllDockWidgetAreas);
     graphView = new DisassemblerGraphView(this, seekable);
     setWidget(graphView);

--- a/src/widgets/HexdumpWidget.cpp
+++ b/src/widgets/HexdumpWidget.cpp
@@ -17,9 +17,9 @@
 
 HexdumpWidget::HexdumpWidget(MainWindow *main, QAction *action) :
     MemoryDockWidget(CutterCore::MemoryWidgetType::Hexdump, main, action),
-    ui(new Ui::HexdumpWidget),
-    seekable(new CutterSeekable(this))
+    ui(new Ui::HexdumpWidget)
 {
+    seekable = new CutterSeekable(this);
     ui->setupUi(this);
 
     setObjectName("HexdumpWidget 0");
@@ -665,17 +665,6 @@ void HexdumpWidget::showHexdumpContextMenu(const QPoint &pt)
 
     menu->exec(ui->hexHexText->mapToGlobal(pt));
     delete menu;
-}
-
-void HexdumpWidget::toggleSync()
-{
-    QString windowTitle = tr("Hexdump");
-    seekable->toggleSynchronization();
-    if (seekable->isSynchronized()) {
-        setWindowTitle(windowTitle);
-    } else {
-        setWindowTitle(windowTitle + CutterSeekable::tr(" (unsynced)"));
-    }
 }
 
 void HexdumpWidget::showHexASCIIContextMenu(const QPoint &pt)

--- a/src/widgets/HexdumpWidget.cpp
+++ b/src/widgets/HexdumpWidget.cpp
@@ -22,17 +22,7 @@ HexdumpWidget::HexdumpWidget(MainWindow *main, QAction *action) :
 {
     ui->setupUi(this);
 
-    /*
-     * Ugly hack just for the layout issue
-     * QSettings saves the state with the object names
-     * By doing this hack,
-     * you can at least avoid some mess by dismissing all the Extra Widgets
-     */
-    QString name = "Hexdump";
-    if (!action) {
-        name = "Extra Hexdump";
-    }
-    setObjectName(name);
+    setObjectName("HexdumpWidget 0");
 
     // Setup hex highlight
     //connect(ui->hexHexText, SIGNAL(cursorPositionChanged()), this, SLOT(highlightHexCurrentLine()));

--- a/src/widgets/HexdumpWidget.cpp
+++ b/src/widgets/HexdumpWidget.cpp
@@ -19,7 +19,6 @@ HexdumpWidget::HexdumpWidget(MainWindow *main, QAction *action) :
     MemoryDockWidget(CutterCore::MemoryWidgetType::Hexdump, main, action),
     ui(new Ui::HexdumpWidget)
 {
-    seekable = new CutterSeekable(this);
     ui->setupUi(this);
 
     setObjectName("HexdumpWidget 0");

--- a/src/widgets/HexdumpWidget.cpp
+++ b/src/widgets/HexdumpWidget.cpp
@@ -21,7 +21,7 @@ HexdumpWidget::HexdumpWidget(MainWindow *main, QAction *action) :
 {
     ui->setupUi(this);
 
-    setObjectName("HexdumpWidget 0");
+    setObjectName("HexdumpWidget");
 
     ui->copyMD5->setIcon(QIcon(":/img/icons/copy.svg"));
     ui->copySHA1->setIcon(QIcon(":/img/icons/copy.svg"));

--- a/src/widgets/HexdumpWidget.h
+++ b/src/widgets/HexdumpWidget.h
@@ -32,7 +32,7 @@ class HexdumpWidget : public MemoryDockWidget
 public:
     explicit HexdumpWidget(MainWindow *main, QAction *action = nullptr);
     ~HexdumpWidget();
-    Highlighter        *highlighter;
+    Highlighter *highlighter;
 
 public slots:
     void initParsing();

--- a/src/widgets/HexdumpWidget.h
+++ b/src/widgets/HexdumpWidget.h
@@ -32,7 +32,7 @@ class HexdumpWidget : public MemoryDockWidget
 public:
     explicit HexdumpWidget(MainWindow *main, QAction *action = nullptr);
     ~HexdumpWidget();
-    Highlighter        *highlighter;
+    Highlighter *highlighter;
     enum Format {
         Hex,
         Octal,
@@ -54,7 +54,6 @@ public slots:
     void zoomIn(int range = 1);
     void zoomOut(int range = 1);
     void zoomReset();
-    void toggleSync();
 
 protected:
     virtual void resizeEvent(QResizeEvent *event) override;
@@ -114,7 +113,6 @@ private:
     ut64 requestedSelectionEndAddress=0;
     HexdumpRangeDialog  rangeDialog;
     QAction syncAction;
-    CutterSeekable *seekable;
     qreal defaultFontSize;
 
 private slots:

--- a/src/widgets/MemoryDockWidget.cpp
+++ b/src/widgets/MemoryDockWidget.cpp
@@ -1,12 +1,32 @@
 #include "MemoryDockWidget.h"
+#include "common/CutterSeekable.h"
 
 #include <QAction>
 
 MemoryDockWidget::MemoryDockWidget(CutterCore::MemoryWidgetType type, MainWindow *parent, QAction *action)
     : CutterDockWidget(parent, action)
-    , mType(type)
+    , mType(type), seekable(new CutterSeekable(this))
 {
     connect(Core(), &CutterCore::raisePrioritizedMemoryWidget, this, &MemoryDockWidget::handleRaiseMemoryWidget);
+    connect(seekable, &CutterSeekable::syncChanged, this, [this]() {
+        if (seekable->isSynchronized()) {
+            setWindowTitle(windowTitle().remove(CutterSeekable::tr(" (unsynced)")));
+        } else {
+            setWindowTitle(windowTitle() + CutterSeekable::tr(" (unsynced)"));
+        }
+    });
+}
+
+bool MemoryDockWidget::isSynced() const
+{
+    return seekable && seekable->isSynchronized();
+}
+
+void MemoryDockWidget::toggleSync()
+{
+    if (seekable) {
+        seekable->toggleSynchronization();
+    }
 }
 
 void MemoryDockWidget::handleRaiseMemoryWidget(CutterCore::MemoryWidgetType raiseType)

--- a/src/widgets/MemoryDockWidget.h
+++ b/src/widgets/MemoryDockWidget.h
@@ -4,6 +4,8 @@
 #include "CutterDockWidget.h"
 #include "core/Cutter.h"
 
+class CutterSeekable;
+
 class MemoryDockWidget : public CutterDockWidget
 {
     Q_OBJECT
@@ -11,10 +13,19 @@ public:
     MemoryDockWidget(CutterCore::MemoryWidgetType type, MainWindow *parent, QAction *action = nullptr);
     ~MemoryDockWidget() {}
 
+    bool isSynced() const;
+
+public slots:
+    void toggleSync();
+
 private:
     void handleRaiseMemoryWidget(CutterCore::MemoryWidgetType raiseType);
 
     CutterCore::MemoryWidgetType mType;
+
+protected:
+    CutterSeekable *seekable = nullptr;
+
 };
 
 #endif // MEMORYDOCKWIDGET_H


### PR DESCRIPTION
 <!-- Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request. -->
Cutter can not save and restore extra widgets and its geometry. This PR implements this feature.

Quick description:
every instance of graph/disasm/hexdump now has unique object name like `"ClassName id"`. When closing Cutter saves all dock widget's names and when starting it creates as much widgets as needed and names it with names that was stored. Plus when you close one of this widgets, one is deleted from widgets list and its id is now free. 

<!-- Explain the **details** for making this change. What existing problem does the pull request solve? Please provide enough information so that others can review your pull request -->




<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
