### PR TITLE
Basic block highlight

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -7,6 +7,7 @@
 #include "common/CrashHandler.h"
 
 #include <QJsonObject>
+#include <QJsonArray>
 
 /**
  * @brief Migrate Settings used before Cutter 1.8

--- a/src/common/ColorThemeWorker.cpp
+++ b/src/common/ColorThemeWorker.cpp
@@ -8,8 +8,8 @@
 #include "common/Configuration.h"
 
 const QStringList ColorThemeWorker::cutterSpecificOptions = {
-    "hlword",
-    "hlline",
+    "wordHighlight",
+    "lineHighlight",
     "gui.main",
     "gui.imports",
     "highlightPC",

--- a/src/common/ColorThemeWorker.cpp
+++ b/src/common/ColorThemeWorker.cpp
@@ -136,7 +136,7 @@ QString ColorThemeWorker::save(const QJsonDocument &theme, const QString &themeN
                        .arg(QColor(arr[0].toInt(), arr[1].toInt(), arr[2].toInt(), arr[3].toInt()).name(format)).toUtf8());
         } else if (arr.size() == 3) {
             fOut.write(line.arg(it.key())
-                       .arg(QColor(arr[0].toInt(), arr[1].toInt(), arr[2].toInt(), arr[3].toInt()).name(format)).toUtf8());
+                       .arg(QColor(arr[0].toInt(), arr[1].toInt(), arr[2].toInt()).name(format)).toUtf8());
         }
     }
 
@@ -183,17 +183,22 @@ QJsonDocument ColorThemeWorker::getTheme(const QString& themeName) const
             QColor(sl[2]).getRgb(&r, &g, &b, &a);
             theme.insert(sl[1], QJsonArray({r, g, b, a}));
         }
-    }
-
-    for (auto &it : cutterSpecificOptions) {
-        if (!theme.contains(it)) {
+        for (auto &it : cutterSpecificOptions) {
+            if (!theme.contains(it)) {
+                mergeColors(Config()->getColor(it),
+                            Config()->getColor("gui.background")).getRgb(&r, &g, &b, &a);
+                Config()->getColor(it).getRgb(&r, &g, &b, &a);
+                theme.insert(it, QJsonArray({r, g, b, a}));
+            }
+        }
+    } else {
+        for (auto &it : cutterSpecificOptions) {
             mergeColors(Config()->getColor(it),
                         Config()->getColor("gui.background")).getRgb(&r, &g, &b, &a);
             Config()->getColor(it).getRgb(&r, &g, &b, &a);
             theme.insert(it, QJsonArray({r, g, b, a}));
         }
     }
-
 
     for (auto &key : radare2UnusedOptions) {
         theme.remove(key);

--- a/src/common/ColorThemeWorker.h
+++ b/src/common/ColorThemeWorker.h
@@ -124,7 +124,7 @@ private:
     ColorThemeWorker(const ColorThemeWorker &root) = delete;
     ColorThemeWorker &operator=(const ColorThemeWorker &) = delete;
 
-    QColor mergeColors(const QColor &upper, const QColor &lower) const;
+    QColor mergeColors(const QColor& upper, const QColor& lower) const;
 };
 
 #endif // COLORTHEMEWORKER_H

--- a/src/common/ColorThemeWorker.h
+++ b/src/common/ColorThemeWorker.h
@@ -124,7 +124,7 @@ private:
     ColorThemeWorker(const ColorThemeWorker &root) = delete;
     ColorThemeWorker &operator=(const ColorThemeWorker &) = delete;
 
-    QColor mergeColors(const QColor& upper, const QColor& lower) const;
+    QColor mergeColors(const QColor &upper, const QColor &lower) const;
 };
 
 #endif // COLORTHEMEWORKER_H

--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -248,8 +248,8 @@ void Configuration::loadNativeTheme()
         setColor("gui.background", QColor(30, 30, 30));
         setColor("gui.alt_background", QColor(42, 42, 42));
         setColor("gui.disass_selected", QColor(35, 35, 35));
-        setColor("hlline", QColor(255, 255, 255, 15));
-        setColor("hlword", QColor(20, 20, 20, 255));
+        setColor("lineHighlight", QColor(255, 255, 255, 15));
+        setColor("wordHighlight", QColor(20, 20, 20, 255));
         setColor("highlightPC", QColor(87, 26, 7));
         setColor("gui.tooltip.background", QColor(42, 44, 46));
         setColor("gui.tooltip.foreground", QColor(250, 252, 254));
@@ -259,8 +259,8 @@ void Configuration::loadNativeTheme()
         setColor("gui.background", QColor(255, 255, 255));
         setColor("gui.alt_background", QColor(245, 250, 255));
         setColor("gui.disass_selected", QColor(255, 255, 255));
-        setColor("hlline", QColor(210, 210, 255, 150));
-        setColor("hlword", QColor(179, 119, 214, 60));
+        setColor("lineHighlight", QColor(210, 210, 255, 150));
+        setColor("wordHighlight", QColor(179, 119, 214, 60));
         setColor("highlightPC", QColor(214, 255, 210));
         setColor("gui.dataoffset", QColor(0, 0, 0));
     }
@@ -291,8 +291,8 @@ void Configuration::loadLightTheme()
     setColor("gui.background", QColor(255, 255, 255));
     setColor("gui.alt_background", QColor(245, 250, 255));
     setColor("gui.disass_selected", QColor(255, 255, 255));
-    setColor("hlline",   QColor(210, 210, 255, 150));
-    setColor("hlword", QColor(179, 119, 214, 60));
+    setColor("lineHighlight",   QColor(210, 210, 255, 150));
+    setColor("wordHighlight", QColor(179, 119, 214, 60));
     setColor("highlightPC", QColor(214, 255, 210));
     setColor("gui.navbar.empty", QColor(220, 236, 245));
     setColor("gui.navbar.err", QColor(3, 170, 245));
@@ -363,8 +363,8 @@ void Configuration::loadDarkTheme()
     // Disassembly line selected
     setColor("gui.tooltip.background", QColor(42, 44, 46));
     setColor("gui.tooltip.foreground", QColor(250, 252, 254));
-    setColor("hlline", QColor(21, 29, 29, 150));
-    setColor("hlword", QColor(52, 58, 71, 255));
+    setColor("lineHighlight", QColor(21, 29, 29, 150));
+    setColor("wordHighlight", QColor(52, 58, 71, 255));
 }
 
 const QFont Configuration::getFont() const

--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -248,8 +248,8 @@ void Configuration::loadNativeTheme()
         setColor("gui.background", QColor(30, 30, 30));
         setColor("gui.alt_background", QColor(42, 42, 42));
         setColor("gui.disass_selected", QColor(35, 35, 35));
-        setColor("linehl", QColor(255, 255, 255, 15));
-        setColor("wordhl", QColor(20, 20, 20, 255));
+        setColor("hlline", QColor(255, 255, 255, 15));
+        setColor("hlword", QColor(20, 20, 20, 255));
         setColor("highlightPC", QColor(87, 26, 7));
         setColor("gui.tooltip.background", QColor(42, 44, 46));
         setColor("gui.tooltip.foreground", QColor(250, 252, 254));
@@ -259,8 +259,8 @@ void Configuration::loadNativeTheme()
         setColor("gui.background", QColor(255, 255, 255));
         setColor("gui.alt_background", QColor(245, 250, 255));
         setColor("gui.disass_selected", QColor(255, 255, 255));
-        setColor("linehl", QColor(210, 210, 255, 150));
-        setColor("wordhl", QColor(179, 119, 214, 60));
+        setColor("hlline", QColor(210, 210, 255, 150));
+        setColor("hlword", QColor(179, 119, 214, 60));
         setColor("highlightPC", QColor(214, 255, 210));
         setColor("gui.dataoffset", QColor(0, 0, 0));
     }
@@ -291,8 +291,8 @@ void Configuration::loadLightTheme()
     setColor("gui.background", QColor(255, 255, 255));
     setColor("gui.alt_background", QColor(245, 250, 255));
     setColor("gui.disass_selected", QColor(255, 255, 255));
-    setColor("linehl",   QColor(210, 210, 255, 150));
-    setColor("wordhl", QColor(179, 119, 214, 60));
+    setColor("hlline",   QColor(210, 210, 255, 150));
+    setColor("hlword", QColor(179, 119, 214, 60));
     setColor("highlightPC", QColor(214, 255, 210));
     setColor("gui.navbar.empty", QColor(220, 236, 245));
     setColor("gui.navbar.err", QColor(3, 170, 245));
@@ -363,8 +363,8 @@ void Configuration::loadDarkTheme()
     // Disassembly line selected
     setColor("gui.tooltip.background", QColor(42, 44, 46));
     setColor("gui.tooltip.foreground", QColor(250, 252, 254));
-    setColor("linehl", QColor(21, 29, 29, 150));
-    setColor("wordhl", QColor(52, 58, 71, 255));
+    setColor("hlline", QColor(21, 29, 29, 150));
+    setColor("hlword", QColor(52, 58, 71, 255));
 }
 
 const QFont Configuration::getFont() const
@@ -462,10 +462,10 @@ void Configuration::setColorTheme(const QString &theme)
     QJsonObject colorTheme = ThemeWorker().getTheme(theme).object();
     for (auto it = colorTheme.constBegin(); it != colorTheme.constEnd(); it++) {
         QJsonArray rgb = it.value().toArray();
-        if (rgb.size() != 3) {
+        if (rgb.size() != 4) {
             continue;
         }
-        setColor(it.key(), QColor(rgb[0].toInt(), rgb[1].toInt(), rgb[2].toInt()));
+        setColor(it.key(), QColor(rgb[0].toInt(), rgb[1].toInt(), rgb[2].toInt(), rgb[3].toInt()));
     }
 
     // Trick Cutter to load colors that are not specified in standard theme

--- a/src/dialogs/XrefsDialog.cpp
+++ b/src/dialogs/XrefsDialog.cpp
@@ -118,7 +118,7 @@ void XrefsDialog::highlightCurrentLine()
     if (ui->previewTextEdit->isReadOnly()) {
         QTextEdit::ExtraSelection selection = QTextEdit::ExtraSelection();
 
-        selection.format.setBackground(ConfigColor("hlline"));
+        selection.format.setBackground(ConfigColor("lineHighlight"));
         selection.format.setProperty(QTextFormat::FullWidthSelection, true);
         selection.cursor = ui->previewTextEdit->textCursor();
         selection.cursor.clearSelection();

--- a/src/dialogs/XrefsDialog.cpp
+++ b/src/dialogs/XrefsDialog.cpp
@@ -118,7 +118,7 @@ void XrefsDialog::highlightCurrentLine()
     if (ui->previewTextEdit->isReadOnly()) {
         QTextEdit::ExtraSelection selection = QTextEdit::ExtraSelection();
 
-        selection.format.setBackground(ConfigColor("linehl"));
+        selection.format.setBackground(ConfigColor("hlline"));
         selection.format.setProperty(QTextFormat::FullWidthSelection, true);
         selection.cursor = ui->previewTextEdit->textCursor();
         selection.cursor.clearSelection();

--- a/src/dialogs/preferences/ColorThemeEditDialog.cpp
+++ b/src/dialogs/preferences/ColorThemeEditDialog.cpp
@@ -41,7 +41,7 @@ ColorThemeEditDialog::ColorThemeEditDialog(QWidget *parent) :
                              .data(Qt::UserRole)
                              .value<ColorOption>()
                              .optionName;
-        ui->colorPicker->setAlphaEnabled(optionName == "hlword" || optionName == "hlline");
+        ui->colorPicker->setAlphaEnabled(optionName == "wordHighlight" || optionName == "lineHighlight");
     });
 
     ui->colorThemeListView->setCurrentIndex(ui->colorThemeListView->model()->index(0, 0));

--- a/src/dialogs/preferences/ColorThemeEditDialog.cpp
+++ b/src/dialogs/preferences/ColorThemeEditDialog.cpp
@@ -35,7 +35,15 @@ ColorThemeEditDialog::ColorThemeEditDialog(QWidget *parent) :
             previewDisasmWidget, &DisassemblyWidget::colorsUpdatedSlot);
 
     connect(ui->colorThemeListView, &ColorThemeListView::itemChanged,
-            ui->colorPicker, &ColorPicker::updateColor);
+            this, [this](const QColor& color) {
+        ui->colorPicker->updateColor(color);
+        QString optionName = ui->colorThemeListView->currentIndex()
+                             .data(Qt::UserRole)
+                             .value<ColorOption>()
+                             .optionName;
+        ui->colorPicker->setAlphaEnabled(optionName == "hlword" || optionName == "hlline");
+    });
+
     ui->colorThemeListView->setCurrentIndex(ui->colorThemeListView->model()->index(0, 0));
 
     connect(ui->colorPicker, &ColorPicker::colorChanged, this, &ColorThemeEditDialog::colorOptionChanged);

--- a/src/widgets/ColorPicker.cpp
+++ b/src/widgets/ColorPicker.cpp
@@ -434,7 +434,7 @@ QColor AlphaChannelBar::pointToColor(int x, int y) const
     return color;
 }
 
-QPoint AlphaChannelBar::colorToPoint(const QColor& color) const
+QPoint AlphaChannelBar::colorToPoint(const QColor &) const
 {
     return QPoint();
 }

--- a/src/widgets/ColorPicker.cpp
+++ b/src/widgets/ColorPicker.cpp
@@ -391,7 +391,6 @@ void AlphaChannelBar::paintEvent(QPaintEvent* event)
     QPainter p(this);
     QRect barRect = rect();
 
-    QColor color = currColor;
     qreal h, s, v, a;
     currColor.getHsvF(&h, &s, &v, &a);
     a = 1.0 - a;

--- a/src/widgets/ColorPicker.h
+++ b/src/widgets/ColorPicker.h
@@ -19,7 +19,7 @@ signals:
     void colorChanged(const QColor& color);
 
 public slots:
-    virtual void setColor(const QColor& color);
+    virtual void setColor(const QColor& color) = 0;
 
 protected:
     QColor currColor;
@@ -122,6 +122,8 @@ class ColorShowWidget : public ColorPickWidgetAbstract
 public:
     explicit ColorShowWidget(QWidget *parent = nullptr);
 
+    void setColor(const QColor& c) override;
+
 protected:
     void paintEvent(QPaintEvent *event) override;
 };
@@ -136,10 +138,10 @@ class ColorPickArea : public ColorPickerWidget
 public:
     explicit ColorPickArea(QWidget *parent = nullptr);
 
+    void setColor(const QColor& c) override;
+
 protected:
     void paintEvent(QPaintEvent *event) override;
-
-    void mouseEvent(QMouseEvent *event) override;
 
 private:
     QColor pointToColor(int x, int y) const override;
@@ -152,6 +154,8 @@ class AlphaChannelBar : public ColorPickerWidget
     Q_OBJECT
 public:
     AlphaChannelBar(QWidget *parent = nullptr) : ColorPickerWidget(parent) {}
+
+    void setColor(const QColor& c) override;
 
 protected:
     void paintEvent(QPaintEvent *event) override;
@@ -171,6 +175,8 @@ class ColorValueBar : public ColorPickerWidget
     Q_OBJECT
 public:
     ColorValueBar(QWidget *parent = nullptr) : ColorPickerWidget(parent) {}
+
+    void setColor(const QColor& c) override;
 
 protected:
     void paintEvent(QPaintEvent *event) override;

--- a/src/widgets/ColorPicker.h
+++ b/src/widgets/ColorPicker.h
@@ -46,6 +46,8 @@ public:
      */
     bool isPickingFromScreen() const;
 
+    void setAlphaEnabled(bool enabled);
+
 
 public slots:
     /**
@@ -101,8 +103,7 @@ protected:
     void mousePressEvent(QMouseEvent* event) override;
     void mouseMoveEvent(QMouseEvent* event) override;
 
-private:
-    void mouseEvent(QMouseEvent* event);
+    virtual void mouseEvent(QMouseEvent* event);
 
     /**
      * @brief pointToColor converts coordinates on widget to color these coordinates represents.
@@ -134,6 +135,23 @@ class ColorPickArea : public ColorPickerWidget
     Q_OBJECT
 public:
     explicit ColorPickArea(QWidget *parent = nullptr);
+
+protected:
+    void paintEvent(QPaintEvent *event) override;
+
+    void mouseEvent(QMouseEvent *event) override;
+
+private:
+    QColor pointToColor(int x, int y) const override;
+
+    QPoint colorToPoint(const QColor& color) const override;
+};
+
+class AlphaChannelBar : public ColorPickerWidget
+{
+    Q_OBJECT
+public:
+    AlphaChannelBar(QWidget *parent = nullptr) : ColorPickerWidget(parent) {}
 
 protected:
     void paintEvent(QPaintEvent *event) override;

--- a/src/widgets/ColorPicker.ui
+++ b/src/widgets/ColorPicker.ui
@@ -48,6 +48,16 @@
          </property>
         </widget>
        </item>
+       <item>
+        <widget class="ColorPickerHelpers::AlphaChannelBar" name="alphaChannelBar" native="true">
+         <property name="minimumSize">
+          <size>
+           <width>30</width>
+           <height>0</height>
+          </size>
+         </property>
+        </widget>
+       </item>
       </layout>
      </item>
      <item>
@@ -339,6 +349,12 @@
   </customwidget>
   <customwidget>
    <class>ColorPickerHelpers::ColorShowWidget</class>
+   <extends>QWidget</extends>
+   <header>widgets/ColorPicker.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ColorPickerHelpers::AlphaChannelBar</class>
    <extends>QWidget</extends>
    <header>widgets/ColorPicker.h</header>
    <container>1</container>

--- a/src/widgets/ColorThemeListView.cpp
+++ b/src/widgets/ColorThemeListView.cpp
@@ -350,10 +350,10 @@ void ColorSettingsModel::updateTheme()
 QJsonDocument ColorSettingsModel::getTheme() const
 {
     QJsonObject obj;
-    int r, g, b;
+    int r, g, b, a;
     for (auto &it : theme) {
-        it.color.getRgb(&r, &g, &b);
-        obj.insert(it.optionName, QJsonArray({r, g, b}));
+        it.color.getRgb(&r, &g, &b, &a);
+        obj.insert(it.optionName, QJsonArray({r, g, b, a}));
     }
     return QJsonDocument(obj);
 }

--- a/src/widgets/ColorThemeListView.cpp
+++ b/src/widgets/ColorThemeListView.cpp
@@ -739,13 +739,13 @@ const QMap<QString, OptionInfo> optionInfoMap__ = {
     }
 },
 {
-    "hlline", {
+    "lineHighlight", {
         QObject::tr("Selected line background color"),
         QObject::tr("Line highlight")
     }
 },
 {
-    "hlword", {
+    "wordHighlight", {
         QObject::tr("Background color of selected word"),
         QObject::tr("Word higlight")
     }

--- a/src/widgets/ColorThemeListView.cpp
+++ b/src/widgets/ColorThemeListView.cpp
@@ -336,10 +336,10 @@ void ColorSettingsModel::updateTheme()
 
     for (auto it = obj.constBegin(); it != obj.constEnd(); it++) {
         QJsonArray rgb = it.value().toArray();
-        if (rgb.size() != 3) {
+        if (rgb.size() != 4) {
             continue;
         }
-        theme.push_back({it.key(), QColor(rgb[0].toInt(), rgb[1].toInt(), rgb[2].toInt()), false});
+        theme.push_back({it.key(), QColor(rgb[0].toInt(), rgb[1].toInt(), rgb[2].toInt(), rgb[3].toInt()), false});
     }
 
     if (!theme.isEmpty()) {
@@ -739,13 +739,13 @@ const QMap<QString, OptionInfo> optionInfoMap__ = {
     }
 },
 {
-    "linehl", {
+    "hlline", {
         QObject::tr("Selected line background color"),
         QObject::tr("Line highlight")
     }
 },
 {
-    "wordhl", {
+    "hlword", {
         QObject::tr("Background color of selected word"),
         QObject::tr("Word higlight")
     }

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -511,7 +511,7 @@ void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block)
                     highlightWidth = block.width - widthBefore - (10 +  2 * padding);
                 }
 
-                QColor selectionColor = ConfigColor("wordhl");
+                QColor selectionColor = ConfigColor("hlword");
 
                 p.fillRect(QRectF(blockX + charWidth * 3 + widthBefore, y, highlightWidth,
                                  charHeight), selectionColor);
@@ -718,7 +718,7 @@ void DisassemblerGraphView::colorsUpdatedSlot()
     mDisabledBreakpointColor = disassemblyBackgroundColor;
     graphNodeColor = ConfigColor("gui.border");
     backgroundColor = ConfigColor("gui.background");
-    disassemblySelectionColor = ConfigColor("linehl");
+    disassemblySelectionColor = ConfigColor("hlline");
     PCSelectionColor = ConfigColor("highlightPC");
 
     jmpColor = ConfigColor("graph.trufae");

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -511,7 +511,7 @@ void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block)
                     highlightWidth = block.width - widthBefore - (10 +  2 * padding);
                 }
 
-                QColor selectionColor = ConfigColor("hlword");
+                QColor selectionColor = ConfigColor("wordHighlight");
 
                 p.fillRect(QRectF(blockX + charWidth * 3 + widthBefore, y, highlightWidth,
                                  charHeight), selectionColor);
@@ -718,7 +718,7 @@ void DisassemblerGraphView::colorsUpdatedSlot()
     mDisabledBreakpointColor = disassemblyBackgroundColor;
     graphNodeColor = ConfigColor("gui.border");
     backgroundColor = ConfigColor("gui.background");
-    disassemblySelectionColor = ConfigColor("hlline");
+    disassemblySelectionColor = ConfigColor("lineHighlight");
     PCSelectionColor = ConfigColor("highlightPC");
 
     jmpColor = ConfigColor("graph.trufae");

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -121,10 +121,17 @@ DisassemblerGraphView::DisassemblerGraphView(QWidget *parent)
     highlightBB->setText(tr("Highlight block"));
     connect(highlightBB, &QAction::triggered, this, [this]() {
         auto bbh = Core()->getBBHighlighter();
-        QColor c = QColorDialog::getColor(disassemblySelectedBackgroundColor, this, QString(),
+        RVA currBlockEntry = blockForAddress(this->seekable->getOffset())->entry;
+
+        QColor background = disassemblyBackgroundColor;
+        if (auto block = bbh->getBasicBlock(currBlockEntry)) {
+            background = block->color;
+        }
+
+        QColor c = QColorDialog::getColor(background, this, QString(),
                                           QColorDialog::DontUseNativeDialog);
         if (c.isValid()) {
-            bbh->highlight(blockForAddress(this->seekable->getOffset())->entry, c);
+            bbh->highlight(currBlockEntry, c);
         }
         Config()->colorsUpdated();
     });

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -116,6 +116,8 @@ DisassemblerGraphView::DisassemblerGraphView(QWidget *parent)
 
 
     QAction *highlightBB = new QAction(this);
+    actionUnhighlight.setVisible(false);
+
     highlightBB->setText(tr("Highlight block"));
     connect(highlightBB, &QAction::triggered, this, [this]() {
         auto bbh = Core()->getBBHighlighter();
@@ -123,17 +125,18 @@ DisassemblerGraphView::DisassemblerGraphView(QWidget *parent)
         if (c.isValid()) {
             bbh->highlight(blockForAddress(seekable->getOffset())->entry, c);
         }
+        Config()->colorsUpdated();
     });
 
-    QAction *unhighlight = new QAction(this);
-    unhighlight->setText(tr("Unhighlight block"));
-    connect(unhighlight, &QAction::triggered, this, [this]() {
+    actionUnhighlight.setText(tr("Unhighlight block"));
+    connect(&actionUnhighlight, &QAction::triggered, this, [this]() {
         auto bbh = Core()->getBBHighlighter();
         bbh->clear(blockForAddress(seekable->getOffset())->entry);
+        Config()->colorsUpdated();
     });
 
     blockMenu->addAction(highlightBB);
-    blockMenu->addAction(unhighlight);
+    blockMenu->addAction(&actionUnhighlight);
 
 
     // Include all actions from generic context menu in block specific menu
@@ -948,6 +951,7 @@ void DisassemblerGraphView::blockClicked(GraphView::GraphBlock &block, QMouseEve
         blockMenu->setCurHighlightedWord(highlight_token->content);
     }
     if (event->button() == Qt::RightButton) {
+        actionUnhighlight.setVisible(Core()->getBBHighlighter()->getBasicBlock(block.entry));
         event->accept();
         blockMenu->exec(event->globalPos());
     }

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -123,7 +123,7 @@ DisassemblerGraphView::DisassemblerGraphView(QWidget *parent)
         auto bbh = Core()->getBBHighlighter();
         QColor c = QColorDialog::getColor(disassemblySelectedBackgroundColor);
         if (c.isValid()) {
-            bbh->highlight(blockForAddress(seekable->getOffset())->entry, c);
+            bbh->highlight(blockForAddress(this->seekable->getOffset())->entry, c);
         }
         Config()->colorsUpdated();
     });
@@ -131,7 +131,7 @@ DisassemblerGraphView::DisassemblerGraphView(QWidget *parent)
     actionUnhighlight.setText(tr("Unhighlight block"));
     connect(&actionUnhighlight, &QAction::triggered, this, [this]() {
         auto bbh = Core()->getBBHighlighter();
-        bbh->clear(blockForAddress(seekable->getOffset())->entry);
+        bbh->clear(blockForAddress(this->seekable->getOffset())->entry);
         Config()->colorsUpdated();
     });
 

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -121,7 +121,8 @@ DisassemblerGraphView::DisassemblerGraphView(QWidget *parent)
     highlightBB->setText(tr("Highlight block"));
     connect(highlightBB, &QAction::triggered, this, [this]() {
         auto bbh = Core()->getBBHighlighter();
-        QColor c = QColorDialog::getColor(disassemblySelectedBackgroundColor);
+        QColor c = QColorDialog::getColor(disassemblySelectedBackgroundColor, this, QString(),
+                                          QColorDialog::DontUseNativeDialog);
         if (c.isValid()) {
             bbh->highlight(blockForAddress(this->seekable->getOffset())->entry, c);
         }

--- a/src/widgets/DisassemblerGraphView.h
+++ b/src/widgets/DisassemblerGraphView.h
@@ -203,6 +203,7 @@ private:
     QColor mDisabledBreakpointColor;
 
     QAction actionExportGraph;
+    QAction actionUnhighlight;
     QAction actionSyncOffset;
 
     QLabel *emptyText = nullptr;

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -354,7 +354,7 @@ void DisassemblyWidget::highlightCurrentLine()
 {
     QList<QTextEdit::ExtraSelection> extraSelections;
 
-    QColor highlightColor = ConfigColor("hlline");
+    QColor highlightColor = ConfigColor("lineHighlight");
     QColor highlightPCColor = ConfigColor("highlightPC");
 
     // Highlight the current word
@@ -600,7 +600,7 @@ QList<QTextEdit::ExtraSelection> DisassemblyWidget::getSameWordsSelections()
     QList<QTextEdit::ExtraSelection> selections;
     QTextEdit::ExtraSelection highlightSelection;
     QTextDocument *document = mDisasTextEdit->document();
-    QColor highlightWordColor = ConfigColor("hlword");
+    QColor highlightWordColor = ConfigColor("wordHighlight");
 
     if (curHighlightedWord.isNull()) {
         return QList<QTextEdit::ExtraSelection>();

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -354,7 +354,7 @@ void DisassemblyWidget::highlightCurrentLine()
 {
     QList<QTextEdit::ExtraSelection> extraSelections;
 
-    QColor highlightColor = ConfigColor("linehl");
+    QColor highlightColor = ConfigColor("hlline");
     QColor highlightPCColor = ConfigColor("highlightPC");
 
     // Highlight the current word
@@ -600,7 +600,7 @@ QList<QTextEdit::ExtraSelection> DisassemblyWidget::getSameWordsSelections()
     QList<QTextEdit::ExtraSelection> selections;
     QTextEdit::ExtraSelection highlightSelection;
     QTextDocument *document = mDisasTextEdit->document();
-    QColor highlightWordColor = ConfigColor("wordhl");
+    QColor highlightWordColor = ConfigColor("hlword");
 
     if (curHighlightedWord.isNull()) {
         return QList<QTextEdit::ExtraSelection>();


### PR DESCRIPTION
 <!-- Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request. -->


**Detailed description**
Adds basic block highlight and adds alpha channel for color of word and line highlight.
Graph overview honors the color of basic block as well.
Alpha channel bar appears only when word or line highlight option is selected.
"Unhighlight block" action appears only when user right clicks on highlighted block.

![screen_1](https://user-images.githubusercontent.com/42874998/57729475-ef1bd600-769e-11e9-9902-14f1e1d06552.png)
![screen2](https://user-images.githubusercontent.com/42874998/57729476-ef1bd600-769e-11e9-970c-1d48d7084b05.png)
![image](https://user-images.githubusercontent.com/42874998/57729552-2094a180-769f-11e9-9804-7efb6684e6f2.png)


<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
