### PR TITLE
Always enter mouse drag mode when clicking on overview widget.

### DIFF
--- a/src/widgets/OverviewView.cpp
+++ b/src/widgets/OverviewView.cpp
@@ -82,29 +82,21 @@ void OverviewView::paintEvent(QPaintEvent *event)
     p.drawRect(rangeRect);
 }
 
-bool OverviewView::mouseContainsRect(QMouseEvent *event)
-{
-    if (rangeRect.contains(event->pos())) {
-        mouseActive = true;
-        initialDiff = QPointF(event->localPos().x() - rangeRect.x(), event->localPos().y() - rangeRect.y());
-        return true;
-    }
-    return false;
-}
-
 void OverviewView::mousePressEvent(QMouseEvent *event)
 {
-    if (mouseContainsRect(event)) {
-        return;
+    mouseActive = true;
+    if (rangeRect.contains(event->pos())) {
+        initialDiff = QPointF(event->localPos().x() - rangeRect.x(), event->localPos().y() - rangeRect.y());
+    } else {
+        qreal w = rangeRect.width();
+        qreal h = rangeRect.height();
+        qreal x = event->localPos().x() - w / 2;
+        qreal y = event->localPos().y() - h / 2;
+        rangeRect = QRectF(x, y, w, h);
+        initialDiff = QPointF(w / 2,  h / 2);
+        viewport()->update();
+        emit mouseMoved();
     }
-    qreal w = rangeRect.width();
-    qreal h = rangeRect.height();
-    qreal x = event->localPos().x() - w / 2;
-    qreal y = event->localPos().y() - h / 2;
-    rangeRect = QRectF(x, y, w, h);
-    viewport()->update();
-    emit mouseMoved();
-    mouseContainsRect(event);
 }
 
 void OverviewView::mouseReleaseEvent(QMouseEvent *event)

--- a/src/widgets/OverviewView.h
+++ b/src/widgets/OverviewView.h
@@ -106,11 +106,6 @@ private:
                                                            GraphView::GraphBlock *to) override;
 
     /**
-     * @brief if the mouse is in the rect in Overview.
-     */
-    bool mouseContainsRect(QMouseEvent *event);
-
-    /**
      * @brief base background color changing depending on the theme
      */
     QColor disassemblyBackgroundColor;


### PR DESCRIPTION
**Detailed description**

Old overview mouse drag code worked something like this
```
if (mouse_in_rectangle) {
    start_mouse_drag();
    return;
} 
move rectangle on top of mouse
if (mouse_in_rectangle) {
    start_mouse_drag();
    return;
} 
```
Assumption was that after trying to move rectangle on top of mouse the second if will succeed.  It didn't happen  in two situations:
* aspect ratio of graph view and overview are different and mouse was clicked on the part that would be in the "void" of main graph view
* view rectangle in overview is very small because of large graph and or small overview widget

I reordered the code so that clicking on overview widget always triggers mouse drag mode.

**Test plan (required)**

* click mouse on the part of overview for which the matching graph part would be clipped, drag mouse around
* zoom in the graph view so that red rectangle in overview is few pixels big, try click and drag in the overview
* perform steps above before and after the fix


**Closing issues**

Closes #1503.
