### PR TITLE
Refresh overview even when function doesn't change

### DIFF
--- a/src/widgets/OverviewWidget.cpp
+++ b/src/widgets/OverviewWidget.cpp
@@ -118,9 +118,6 @@ void OverviewWidget::updateGraphData()
         return;
     }
     if (targetGraphWidget && !targetGraphWidget->getGraphView()->isGraphEmpty()) {
-        if (targetGraphWidget->getGraphView()->currentFcnAddr == graphView->currentFcnAddr) {
-            return;
-        }
         graphView->currentFcnAddr = targetGraphWidget->getGraphView()->currentFcnAddr;
         auto &mainGraphView = *targetGraphWidget->getGraphView();
         graphView->setData(mainGraphView.getWidth(), mainGraphView.getHeight(),


### PR DESCRIPTION
**Detailed description**

It may be necessary to update data after changes in graph layout or
other properties.

At least currently DisassemblerGraphView::viewRefreshed doesn't get emitted excessively so the check for function change isn't necessary. 

**Test plan (required)**

* Open graph+overview
* Add long comment and observe that overview gets updated
* Change color theme, observe that edge color in overview gets updated

**Closing issues**

Closes #1536
Fixes a regression causing  #1496 to reappear.
