### PR TITLE
Improve Color Theme Copy Feature

### DIFF
--- a/src/dialogs/preferences/AppearanceOptionsWidget.cpp
+++ b/src/dialogs/preferences/AppearanceOptionsWidget.cpp
@@ -62,7 +62,10 @@ AppearanceOptionsWidget::AppearanceOptionsWidget(PreferencesDialog *dialog)
 
     connect(ui->colorComboBox, &QComboBox::currentTextChanged,
             this, [this](const QString &str) {
-        ui->editButton->setEnabled(ThemeWorker().isCustomTheme(str));
+        bool editable = ThemeWorker().isCustomTheme(str);
+        ui->editButton->setEnabled(editable);
+        ui->deleteButton->setEnabled(editable);
+        ui->renameButton->setEnabled(editable);
     });
 }
 
@@ -126,12 +129,19 @@ void AppearanceOptionsWidget::on_copyButton_clicked()
     do {
         newThemeName = QInputDialog::getText(this, tr("Enter theme name"),
                                              tr("Name:"), QLineEdit::Normal,
-                                             currColorTheme + tr(" - copy"));
-    } while (!newThemeName.isEmpty() && ThemeWorker().isThemeExist(newThemeName));
+                                             currColorTheme + tr(" - copy"))
+                       .trimmed();
+        if (newThemeName.isEmpty()) {
+            return;
+        }
+        if (ThemeWorker().isThemeExist(newThemeName)) {
+            QMessageBox::information(this, tr("Theme Copy"),
+                                     tr("Theme named %1 already exists.").arg(newThemeName));
+        } else {
+            break;
+        }
+    } while (true);
 
-    if (newThemeName.isEmpty()) {
-        return;
-    }
     ThemeWorker().copy(currColorTheme, newThemeName);
     Config()->setColorTheme(newThemeName);
     updateThemeFromConfig(false);

--- a/src/dialogs/preferences/AppearanceOptionsWidget.cpp
+++ b/src/dialogs/preferences/AppearanceOptionsWidget.cpp
@@ -62,10 +62,7 @@ AppearanceOptionsWidget::AppearanceOptionsWidget(PreferencesDialog *dialog)
 
     connect(ui->colorComboBox, &QComboBox::currentTextChanged,
             this, [this](const QString &str) {
-        bool editable = ThemeWorker().isCustomTheme(str);
-        ui->editButton->setEnabled(editable);
-        ui->deleteButton->setEnabled(editable);
-        ui->renameButton->setEnabled(editable);
+        ui->editButton->setEnabled(ThemeWorker().isCustomTheme(str));
     });
 }
 


### PR DESCRIPTION
 <!-- Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request. -->


**Detailed description**
Before this PR user could place spaces in the start and the end of the theme name(and maybe he could name theme using only spaces, I did not test, but it seems so), I removed this behavior. Plus now when user types name that exists, message box tells that. 

<!-- Explain the **details** for making this change. What existing problem does the pull request solve? Please provide enough information so that others can review your pull request -->


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**
closes #1559

<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
