### PR TITLE
Remove unnecesarry native theme modifications.

### DIFF
--- a/src/themes/native/native.qss
+++ b/src/themes/native/native.qss
@@ -1,7 +1,4 @@
- 
-
-
-/* QMainWindow */
+ /* QMainWindow */
 
 QHeaderView::section {
      padding: 3px;
@@ -42,37 +39,10 @@ QToolTip {
 	font: 11pt "Monaco";
 }
 
-
 /* CutterTreeView */
 
 CutterTreeView::item
 {
    padding-top: 1px;
    padding-bottom: 1px;
-}
-
-
-/* QFilterView */
-
-QToolButton { /* all types of tool button */
-    border: 2px solid #333;
-    border-left: 2px solid #333;
-    border-right: 2px solid #333;
-    background-color: #333;
-    color: rgb(255, 255, 255)
-}
-
-QToolButton:hover {
-    border: 2px solid rgb(128, 128, 128);
-    border-left: 2px solid rgb(128, 128, 128);
-    border-right: 2px solid rgb(128, 128, 128);
-    background-color: rgb(128, 128, 128);
-    color: rgb(255, 255, 255)
-}
-
-QToolButton:pressed {
-    border: 2px solid #2180a9;
-    border-left: 2px solid #2180a9;
-    border-right: 2px solid #2180a9;
-    background-color: #2180a9;
 }


### PR DESCRIPTION
**Detailed description**

<!-- Explain the **details** for making this change. What existing problem does the pull request solve? Please provide enough information so that others can review your pull request -->


**Test plan (required)**

Tested with the qt themes I had available on my system.

Adwaita-dark
![Ekrānattēls no 2019-05-19 23-15-20](https://user-images.githubusercontent.com/7101031/57987609-89f42600-7a8c-11e9-8904-2e7951c3d16d.png)
Fusion
![Ekrānattēls no 2019-05-19 23-17-54](https://user-images.githubusercontent.com/7101031/57987610-89f42600-7a8c-11e9-98db-33a80c0144ab.png)
Adwaita
![Ekrānattēls no 2019-05-19 23-14-53](https://user-images.githubusercontent.com/7101031/57987608-89f42600-7a8c-11e9-9d93-849758678692.png)

It would be good if someone on macOS could test if documentMode setting worked and the dock widget tab bar looks reasonable.

**Closing issues**
Solves 80% of #1555. Doesn't fix start emulation button in light theme.
