### PR TITLE
Remove tab style modifications in native style sheet.

### DIFF
--- a/src/core/MainWindow.ui
+++ b/src/core/MainWindow.ui
@@ -24,7 +24,7 @@
 </string>
   </property>
   <property name="documentMode">
-   <bool>false</bool>
+   <bool>true</bool>
   </property>
   <property name="dockNestingEnabled">
    <bool>true</bool>

--- a/src/themes/native/native.qss
+++ b/src/themes/native/native.qss
@@ -9,28 +9,6 @@ QHeaderView::section {
 /*     border: 2px solid white;*/
 }
 
-
-QMainWindow > QTabBar::tab {
-    border-bottom-color: #2180a9;
-    border-top-left-radius: 0px;
-    border-top-right-radius: 0px;
-    min-width: 8px;
-    max-width: 200px;
-    padding: 5px;
-    margin-bottom: 3px;
-    margin-top: 3px;
-}
-
-QMainWindow > QTabBar::tab:selected {
-    background: #2180a9;
-    color: #FFFFFF;
-}
-
-QMainWindow > QTabBar::tab:hover {
-    background: #2180a9;      /* #3C879E; */
-    color: #FFFFFF;
-}
-
 QDockWidget::title {
     text-align: center;
 }


### PR DESCRIPTION
**Detailed description**

Don't modify the look of tabs in native style sheet.

Split in separate PR because Qt 5.12.3 contains a bugfix for look of tabs in macOS dark mode.

**Test plan (required)**
See screenshots in #1562