### PR TITLE
Hide duplicate and cross-function edges.

### DIFF
--- a/src/widgets/DisassemblerGraphView.h
+++ b/src/widgets/DisassemblerGraphView.h
@@ -158,6 +158,7 @@ private:
 
     void initFont();
     void prepareGraphNode(GraphBlock &block);
+    void cleanupEdges();
     void prepareHeader();
     Token *getToken(Instr *instr, int x);
     QPoint getTextOffset(int line) const;


### PR DESCRIPTION


**Detailed description**

Don't display edges going to different function function and duplicate edges.

**Test plan (required)**

Edge to different function
Before:
![Ekrānattēls no 2019-05-22 23-06-36](https://user-images.githubusercontent.com/7101031/58205267-d470df00-7ce6-11e9-933f-fdd0a7191685.png)
After:
![Ekrānattēls no 2019-05-22 23-07-46](https://user-images.githubusercontent.com/7101031/58205271-d9359300-7ce6-11e9-9f9e-04e34ff0bda0.png)

Duplicate edge
Before:
![Ekrānattēls no 2019-05-22 23-07-14](https://user-images.githubusercontent.com/7101031/58205283-df2b7400-7ce6-11e9-8a38-bc0e712ba3d6.png)
After:
![Ekrānattēls no 2019-05-22 23-08-03](https://user-images.githubusercontent.com/7101031/58205296-e3579180-7ce6-11e9-9304-0c1732e98b96.png)

Duplicate edge extreme case
Before:
![Ekrānattēls no 2019-05-22 23-13-25](https://user-images.githubusercontent.com/7101031/58205522-6678e780-7ce7-11e9-94d6-e481038198e9.png)
After:
![Ekrānattēls no 2019-05-22 23-13-34](https://user-images.githubusercontent.com/7101031/58205533-6c6ec880-7ce7-11e9-9ee7-d3eb81bf0615.png)


**Closing issues**
Closes  #1416