### PR TITLE
Make the shadow selection wider in hex

### DIFF
--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -680,6 +680,7 @@ void HexWidget::drawCursor(QPainter &painter, bool shadow)
         QPen pen(Qt::gray);
         pen.setStyle(Qt::DashLine);
         painter.setPen(pen);
+        shadowCursor.screenPos.setWidth(cursorOnAscii ? itemWidth() : charWidth);
         painter.drawRect(shadowCursor.screenPos);
         painter.setPen(Qt::SolidLine);
     }
@@ -863,7 +864,6 @@ void HexWidget::updateMetrics()
         shadowCursor.screenPos.moveTopLeft(itemArea.topLeft());
     } else {
         cursor.screenPos.moveTopLeft(itemArea.topLeft());
-
         shadowCursor.screenPos.setWidth(charWidth);
         shadowCursor.screenPos.moveTopLeft(asciiArea.topLeft());
     }


### PR DESCRIPTION
**Detailed description**
This PR will highlight a while item (byte\ word\ ...) in the hexdump view instead of only one char


**Test plan (required)**
Open hexdump widget an single click on a character in the ascii column. This will highlight the whole byte in the hex column.


**Before:**
![image](https://user-images.githubusercontent.com/20182642/58365049-3ab45800-7ec7-11e9-88fa-be8ef4bcd958.png)


![image](https://user-images.githubusercontent.com/20182642/58365045-2cfed280-7ec7-11e9-9271-3486b63be913.png)


**After:**

![image](https://user-images.githubusercontent.com/20182642/58365036-f7f28000-7ec6-11e9-8a5d-ba6aa239298b.png)


make the shadow selection wider
![image](https://user-images.githubusercontent.com/20182642/58365037-00e35180-7ec7-11e9-9977-cc14d2536017.png)

