### PR TITLE
Sync hex.pairs eval to "Bytes as pairs" in Hexdump

### DIFF
--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -94,7 +94,6 @@ HexWidget::HexWidget(QWidget *parent) :
 
     actionHexPairs = new QAction(tr("Bytes as pairs"), this);
     actionHexPairs->setCheckable(true);
-    actionHexPairs->setEnabled(Core()->getConfigb("hex.pairs"));
     connect(actionHexPairs, &QAction::triggered, this, &HexWidget::onHexPairsModeEnabled);
 
     actionCopy = new QAction(tr("Copy"), this);
@@ -552,13 +551,13 @@ void HexWidget::onCursorBlinked()
 
 void HexWidget::onHexPairsModeEnabled(bool enable)
 {
+    // Sync configuration
+    Core()->setConfig("hex.pairs", enable);
     if (enable) {
         setItemGroupSize(2);
     } else {
         setItemGroupSize(1);
     }
-    // Sync configuration
-    Core()->setConfig("hex.pairs", enable);
 }
 
 void HexWidget::copy()

--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -94,6 +94,7 @@ HexWidget::HexWidget(QWidget *parent) :
 
     actionHexPairs = new QAction(tr("Bytes as pairs"), this);
     actionHexPairs->setCheckable(true);
+    actionHexPairs->setEnabled(Core()->getConfigb("hex.pairs"));
     connect(actionHexPairs, &QAction::triggered, this, &HexWidget::onHexPairsModeEnabled);
 
     actionCopy = new QAction(tr("Copy"), this);
@@ -209,6 +210,7 @@ void HexWidget::updateCounts()
 {
     actionHexPairs->setEnabled(rowSizeBytes > 1 && itemByteLen == 1
                                && itemFormat == ItemFormat::ItemFormatHex);
+    actionHexPairs->setChecked(Core()->getConfigb("hex.pairs"));
     if (actionHexPairs->isChecked() && actionHexPairs->isEnabled()) {
         itemGroupSize = 2;
     } else {
@@ -555,6 +557,8 @@ void HexWidget::onHexPairsModeEnabled(bool enable)
     } else {
         setItemGroupSize(1);
     }
+    // Sync configuration
+    Core()->setConfig("hex.pairs", enable);
 }
 
 void HexWidget::copy()


### PR DESCRIPTION
**Detailed description**

This PR will make sure the `hex.pairs` setting is synced with the Hex Pairs action in the Hex Dump widget.


**Test plan (required)**
Enable "Bytes as pairs" in hex widget
Execute "e hex.pairs" in Console and verify it is true
Disable "Bytes as pairs" in hex widget
Execute "e hex.pairs" in Console and verify it is false

![hex_pairs](https://user-images.githubusercontent.com/20182642/58366349-92f45580-7ed9-11e9-9b4e-d874eed00003.gif)


**Closing issues**

closes #1060 
