### PR TITLE
Implement Seek to start/end of function Shortcuts

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -828,37 +828,40 @@ RAnalFunction *CutterCore::functionAt(ut64 addr)
 
 
 /**
- * @brief return the address of the first instruction of a given function
- * @param fcn - the function to get its first address
- * @returns the address of the first instruction in the function
+ * @brief finds the start address of a function in a given address
+ * @param addr - an address which belongs to a function
+ * @returns if function exists, return its start address. Otherwise return RVA_INVALID
  */
-RVA CutterCore::getFunctionStart(RAnalFunction *fcn)
+RVA CutterCore::getFunctionStart(RVA addr)
 {
     CORE_LOCK();
-    return fcn ? fcn->addr : 0;
+    RAnalFunction *fcn = Core()->functionAt(addr);
+    return fcn ? fcn->addr : RVA_INVALID;
 }
 
 /**
- * @brief return the end address of a given function
- * @param fcn - the function to get its last address
- * @returns the last address of fcn
+ * @brief finds the end address of a function in a given address
+ * @param addr - an address which belongs to a function
+ * @returns if function exists, return its end address. Otherwise return RVA_INVALID
  */
-RVA CutterCore::getFunctionEnd(RAnalFunction *fcn)
+RVA CutterCore::getFunctionEnd(RVA addr)
 {
     CORE_LOCK();
-    return fcn ? fcn->addr + r_anal_fcn_size(fcn) : 0;
+    RAnalFunction *fcn = Core()->functionAt(addr);
+    return fcn ? fcn->addr : RVA_INVALID;
 }
 
 /**
- * @brief return the address of the last instruction of a given function
- * @param fcn - the function to get its last instruction address
- * @returns the address of the last instruction in the function
+ * @brief finds the last instruction of a function in a given address
+ * @param addr - an address which belongs to a function
+ * @returns if function exists, return the address of its last instruction. Otherwise return RVA_INVALID
  */
-RVA CutterCore::getLastFunctionInstruction(RAnalFunction *fcn)
+RVA CutterCore::getLastFunctionInstruction(RVA addr)
 {
     CORE_LOCK();
+    RAnalFunction *fcn = Core()->functionAt(addr);
     if (!fcn) {
-        return 0;
+        return RVA_INVALID;
     }
     RAnalBlock *lastBB = (RAnalBlock *)r_list_last(fcn->bbs);
     return lastBB ? lastBB->addr + r_anal_bb_offset_inst(lastBB, lastBB->ninstr-1) : 0;

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -864,7 +864,7 @@ RVA CutterCore::getLastFunctionInstruction(RVA addr)
         return RVA_INVALID;
     }
     RAnalBlock *lastBB = (RAnalBlock *)r_list_last(fcn->bbs);
-    return lastBB ? lastBB->addr + r_anal_bb_offset_inst(lastBB, lastBB->ninstr-1) : 0;
+    return lastBB ? lastBB->addr + r_anal_bb_offset_inst(lastBB, lastBB->ninstr-1) : RVA_INVALID;
 }
 
 QString CutterCore::cmdFunctionAt(QString addr)

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -826,6 +826,44 @@ RAnalFunction *CutterCore::functionAt(ut64 addr)
     return r_anal_get_fcn_in(core_->anal, addr, 0);
 }
 
+
+/**
+ * @brief return the address of the first instruction of a given function
+ * @param fcn - the function to get its first address
+ * @returns the address of the first instruction in the function
+ */
+RVA CutterCore::getFunctionStart(RAnalFunction *fcn)
+{
+    CORE_LOCK();
+    return fcn ? fcn->addr : 0;
+}
+
+/**
+ * @brief return the end address of a given function
+ * @param fcn - the function to get its last address
+ * @returns the last address of fcn
+ */
+RVA CutterCore::getFunctionEnd(RAnalFunction *fcn)
+{
+    CORE_LOCK();
+    return fcn ? fcn->addr + r_anal_fcn_size(fcn) : 0;
+}
+
+/**
+ * @brief return the address of the last instruction of a given function
+ * @param fcn - the function to get its last instruction address
+ * @returns the address of the last instruction in the function
+ */
+RVA CutterCore::getLastFunctionInstruction(RAnalFunction *fcn)
+{
+    CORE_LOCK();
+    if (!fcn) {
+        return 0;
+    }
+    RAnalBlock *lastBB = (RAnalBlock *)r_list_last(fcn->bbs);
+    return lastBB ? lastBB->addr + r_anal_bb_offset_inst(lastBB, lastBB->ninstr-1) : 0;
+}
+
 QString CutterCore::cmdFunctionAt(QString addr)
 {
     QString ret;

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -77,9 +77,9 @@ public:
     void delFunction(RVA addr);
     void renameFlag(QString old_name, QString new_name);
     RAnalFunction *functionAt(ut64 addr);
-    RVA getFunctionStart(RAnalFunction *fcn);
-    RVA getFunctionEnd(RAnalFunction *fcn);
-    RVA getLastFunctionInstruction(RAnalFunction *fcn);
+    RVA getFunctionStart(RVA addr);
+    RVA getFunctionEnd(RVA addr);
+    RVA getLastFunctionInstruction(RVA addr);
     QString cmdFunctionAt(QString addr);
     QString cmdFunctionAt(RVA addr);
     QString createFunctionAt(RVA addr, QString name);

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -77,6 +77,9 @@ public:
     void delFunction(RVA addr);
     void renameFlag(QString old_name, QString new_name);
     RAnalFunction *functionAt(ut64 addr);
+    RVA getFunctionStart(RAnalFunction *fcn);
+    RVA getFunctionEnd(RAnalFunction *fcn);
+    RVA getLastFunctionInstruction(RAnalFunction *fcn);
     QString cmdFunctionAt(QString addr);
     QString cmdFunctionAt(RVA addr);
     QString createFunctionAt(RVA addr, QString name);

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -141,7 +141,7 @@ void MainWindow::initUI()
     QShortcut *seek_shortcut = new QShortcut(QKeySequence(Qt::Key_S), this);
     connect(seek_shortcut, SIGNAL(activated()), this->omnibar, SLOT(setFocus()));
     QShortcut *seek_to_func_end_shortcut = new QShortcut(QKeySequence(Qt::Key_Dollar), this);
-    connect(seek_to_func_end_shortcut, SIGNAL(activated()), SLOT(seekToFunctionEnd()));
+    connect(seek_to_func_end_shortcut, SIGNAL(activated()), SLOT(seekToFunctionLastInstruction()));
     QShortcut *seek_to_func_start_shortcut = new QShortcut(QKeySequence(Qt::Key_AsciiCircum), this);
     connect(seek_to_func_start_shortcut, SIGNAL(activated()), SLOT(seekToFunctionStart()));
 
@@ -1145,20 +1145,14 @@ void MainWindow::on_actionGrouped_dock_dragging_triggered(bool checked)
     setDockOptions(options);
 }
 
-void MainWindow::seekToFunctionEnd()
+void MainWindow::seekToFunctionLastInstruction()
 {
-    RAnalFunction *fcn = Core()->functionAt(Core()->getOffset());
-    if (fcn) {
-        Core()->seek(Core()->getLastFunctionInstruction(fcn));
-    }
+    Core()->seek(Core()->getLastFunctionInstruction(Core()->getOffset()));
 }
 
 void MainWindow::seekToFunctionStart()
 {
-    RAnalFunction *fcn = Core()->functionAt(Core()->getOffset());
-    if (fcn) {
-        Core()->seek(Core()->getFunctionStart(fcn));
-    }
+    Core()->seek(Core()->getFunctionStart(Core()->getOffset()));
 }
 
 void MainWindow::projectSaved(bool successfully, const QString &name)

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -140,6 +140,10 @@ void MainWindow::initUI()
     connect(goto_shortcut, SIGNAL(activated()), this->omnibar, SLOT(setFocus()));
     QShortcut *seek_shortcut = new QShortcut(QKeySequence(Qt::Key_S), this);
     connect(seek_shortcut, SIGNAL(activated()), this->omnibar, SLOT(setFocus()));
+    QShortcut *seek_to_func_end_shortcut = new QShortcut(QKeySequence(Qt::Key_Dollar), this);
+    connect(seek_to_func_end_shortcut, SIGNAL(activated()), SLOT(seekToFunctionEnd()));
+    QShortcut *seek_to_func_start_shortcut = new QShortcut(QKeySequence(Qt::Key_AsciiCircum), this);
+    connect(seek_to_func_start_shortcut, SIGNAL(activated()), SLOT(seekToFunctionStart()));
 
     QShortcut *refresh_shortcut = new QShortcut(QKeySequence(QKeySequence::Refresh), this);
     connect(refresh_shortcut, SIGNAL(activated()), this, SLOT(refreshAll()));
@@ -1141,6 +1145,21 @@ void MainWindow::on_actionGrouped_dock_dragging_triggered(bool checked)
     setDockOptions(options);
 }
 
+void MainWindow::seekToFunctionEnd()
+{
+    RAnalFunction *fcn = Core()->functionAt(Core()->getOffset());
+    if (fcn) {
+        Core()->seek(Core()->getLastFunctionInstruction(fcn));
+    }
+}
+
+void MainWindow::seekToFunctionStart()
+{
+    RAnalFunction *fcn = Core()->functionAt(Core()->getOffset());
+    if (fcn) {
+        Core()->seek(Core()->getFunctionStart(fcn));
+    }
+}
 
 void MainWindow::projectSaved(bool successfully, const QString &name)
 {

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -115,7 +115,7 @@ public slots:
     void finalizeOpen();
 
     void refreshAll();
-    void seekToFunctionEnd();
+    void seekToFunctionLastInstruction();
     void seekToFunctionStart();
     void setPanelLock();
     void setTabLocation();

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -115,7 +115,8 @@ public slots:
     void finalizeOpen();
 
     void refreshAll();
-
+    void seekToFunctionEnd();
+    void seekToFunctionStart();
     void setPanelLock();
     void setTabLocation();
 

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -182,7 +182,11 @@ DisassemblyWidget::DisassemblyWidget(MainWindow *main, QAction *action)
     ADD_ACTION(QKeySequence::MoveToPreviousPage, Qt::WidgetWithChildrenShortcut, [this]() {
         moveCursorRelative(true, true);
     })
+    
+    // Plus sign in num-bar considered "Qt::Key_Equal"
     ADD_ACTION(QKeySequence(Qt::CTRL + Qt::Key_Equal), Qt::WidgetWithChildrenShortcut, &DisassemblyWidget::zoomIn)
+    // Plus sign in numpad
+    ADD_ACTION(QKeySequence(Qt::CTRL + Qt::Key_Plus), Qt::WidgetWithChildrenShortcut, &DisassemblyWidget::zoomIn)
     ADD_ACTION(QKeySequence(Qt::CTRL + Qt::Key_Minus), Qt::WidgetWithChildrenShortcut, &DisassemblyWidget::zoomOut)
 #undef ADD_ACTION
 }


### PR DESCRIPTION

**Detailed description**

This pull request implements the following two new shortcuts as requested in #1343:
<kbd>^</kbd> - Seek to the begining of the current function
<kbd>$</kbd> -  Seek to the last instruction in the current function

Also, it fixes the <kbd>CTRL</kbd>+<kbd>+</kbd> shortcut to increase font size in disassembly widget

<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**
closes #1343 

