### PR TITLE
Added natural registers sorting in RegistersWidget

### DIFF
--- a/src/widgets/RegistersWidget.cpp
+++ b/src/widgets/RegistersWidget.cpp
@@ -4,6 +4,7 @@
 
 #include "core/MainWindow.h"
 
+#include <QCollator>
 #include <QLabel>
 #include <QLineEdit>
 
@@ -45,6 +46,11 @@ void RegistersWidget::setRegisterGrid()
     QJsonObject registerValues = Core()->getRegisterValues().object();
     QJsonObject registerRefs = Core()->getRegisterJson();
     QStringList registerNames = registerValues.keys();
+
+    QCollator collator;
+    collator.setNumericMode(true);
+    std::sort(registerNames.begin(), registerNames.end(), collator);
+
     registerLen = registerValues.size();
     for (const QString &key : registerNames) {
         regValue = RAddressString(registerValues[key].toVariant().toULongLong());


### PR DESCRIPTION
**Detailed description**

This PR implements natural sorting for register names in RegistersWidget.  Previously registers were sorted in alphabetical way and this could mislead, because, for example, when debugging ARM binary, R10 register followed R1 register and not R9.

**Test plan**
This example demonstrates changes for ARM64 registers.
Before PR:
<img width="383" alt="before" src="https://user-images.githubusercontent.com/619735/58386996-86264d80-8010-11e9-89a0-1a240763df66.png">

After PR:
<img width="382" alt="after" src="https://user-images.githubusercontent.com/619735/58386999-a1915880-8010-11e9-8daf-7b8d070ce7fe.png">