### PR TITLE
Improve Graph Overview Fill and node Colors

### DIFF
--- a/src/common/ColorThemeWorker.cpp
+++ b/src/common/ColorThemeWorker.cpp
@@ -24,6 +24,8 @@ const QStringList ColorThemeWorker::cutterSpecificOptions = {
     "gui.disass_selected",
     "gui.breakpoint_background",
     "gui.overview.node",
+    "gui.overview.fill",
+    "gui.overview.border",
     "gui.border",
     "gui.background",
     "gui.alt_background",

--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -254,6 +254,8 @@ void Configuration::loadNativeTheme()
         setColor("gui.tooltip.background", QColor(42, 44, 46));
         setColor("gui.tooltip.foreground", QColor(250, 252, 254));
         setColor("gui.dataoffset", QColor(255, 255, 255));
+        setColor("gui.overview.fill",  QColor(255, 255, 255, 40));
+        setColor("gui.overview.border",  QColor(99, 218, 232, 50));
     } else {
         setColor("gui.border", QColor(0, 0, 0));
         setColor("gui.background", QColor(255, 255, 255));
@@ -263,6 +265,8 @@ void Configuration::loadNativeTheme()
         setColor("wordHighlight", QColor(179, 119, 214, 60));
         setColor("highlightPC", QColor(214, 255, 210));
         setColor("gui.dataoffset", QColor(0, 0, 0));
+        setColor("gui.overview.fill",  QColor(175, 217, 234, 65));
+        setColor("gui.overview.border",  QColor(99, 218, 232, 50)); 
     }
 }
 
@@ -298,6 +302,11 @@ void Configuration::loadLightTheme()
     setColor("gui.navbar.err", QColor(3, 170, 245));
     setColor("gui.tooltip.background", QColor(250, 252, 254));
     setColor("gui.tooltip.foreground", QColor(42, 44, 46));
+
+    // Graph Overview
+    setColor("gui.overview.node", QColor(245, 250, 255));
+    setColor("gui.overview.fill",  QColor(175, 217, 234, 65));
+    setColor("gui.overview.border",  QColor(99, 218, 232, 50));
 }
 
 void Configuration::loadBaseThemeDark()
@@ -347,7 +356,10 @@ void Configuration::loadBaseThemeDark()
     setColor("highlightPC", QColor(87, 26, 7));
     setColor("gui.breakpoint_background", QColor(140, 76, 76));
 
+    // Graph Overview
     setColor("gui.overview.node",  QColor(100, 100, 100));
+    setColor("gui.overview.fill",  QColor(255, 255, 255, 40));
+    setColor("gui.overview.border",  QColor(99, 218, 232, 50));
 }
 
 void Configuration::loadDarkTheme()

--- a/src/widgets/ColorThemeListView.cpp
+++ b/src/widgets/ColorThemeListView.cpp
@@ -703,6 +703,18 @@ const QMap<QString, OptionInfo> optionInfoMap__ = {
     }
 },
 {
+    "gui.overview.fill", {
+        QObject::tr("Fill color of Graph Overview's selection"),
+        QObject::tr("Graph Overview fill")
+    }
+},
+{
+    "gui.overview.border", {
+        QObject::tr("Border color of Graph Overview's selection"),
+        QObject::tr("Graph Overview border")
+    }
+},
+{
     "gui.cflow", {
         "",
         "gui.cflow"

--- a/src/widgets/OverviewView.cpp
+++ b/src/widgets/OverviewView.cpp
@@ -78,7 +78,8 @@ void OverviewView::paintEvent(QPaintEvent *event)
         return;
     }
     QPainter p(viewport());
-    p.setPen(Qt::red);
+    p.setPen(graphSelectionBorder);
+    p.setBrush(graphSelectionFill);
     p.drawRect(rangeRect);
 }
 
@@ -138,6 +139,8 @@ void OverviewView::colorsUpdatedSlot()
     disassemblyBackgroundColor = ConfigColor("gui.overview.node");
     graphNodeColor = ConfigColor("gui.border");
     backgroundColor = ConfigColor("gui.background");
+    graphSelectionFill = ConfigColor("gui.overview.fill");
+    graphSelectionBorder = ConfigColor("gui.overview.border");
     setCacheDirty();
     refreshView();
 }

--- a/src/widgets/OverviewView.h
+++ b/src/widgets/OverviewView.h
@@ -116,6 +116,16 @@ private:
     QColor graphNodeColor;
 
     /**
+     * @brief fill color of the selection rectangle
+     */
+    QColor graphSelectionFill;
+
+    /**
+     * @brief border color of the selection rectangle
+     */
+    QColor graphSelectionBorder;
+
+    /**
      * @brief edgeConfigurations edge styles computed by DisassemblerGraphView
      */
     DisassemblerGraphView::EdgeConfigurationMapping edgeConfigurations;


### PR DESCRIPTION


**Detailed description**

This pull request fills the Graph Overview's rectangle with configurable color. This will give a better look and feel to the Graph Overview widget.

The color can be specified by editing a theme.

This PR will also set a node color for Light theme

**Before:**

![image](https://user-images.githubusercontent.com/20182642/58950220-eba7d600-8796-11e9-8bf8-589a9c507f3d.png)

![image](https://user-images.githubusercontent.com/20182642/58950239-fb271f00-8796-11e9-93c7-dd10de5b23a0.png)


**After:**

![2019-06-05_13-33-49](https://user-images.githubusercontent.com/20182642/58950262-05e1b400-8797-11e9-8c5f-19cd67432e02.gif)



![2019-06-05_13-34-28](https://user-images.githubusercontent.com/20182642/58950258-0417f080-8797-11e9-87cb-dd8eb9e3d034.gif)



**Test plan (required)**

Open A binary in Cutter, make sure Graph overview is open.
Notice that now it looks better and filled with color.


**Closing issues**

<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
