### PR TITLE
Combine Set-As menu items in Disassembly context menu

### DIFF
--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -64,7 +64,7 @@ DisassemblyContextMenu::DisassemblyContextMenu(QWidget *parent)
                SLOT(on_actionDeleteFunction_triggered()));
     addAction(&actionDeleteFunction);
 
-    initAction(&actionAnalyzeFunction, tr("Define function here..."),
+    initAction(&actionAnalyzeFunction, tr("Define function here"),
                SLOT(on_actionAnalyzeFunction_triggered()));
     addAction(&actionAnalyzeFunction);
 
@@ -82,15 +82,7 @@ DisassemblyContextMenu::DisassemblyContextMenu(QWidget *parent)
                SLOT(on_actionLinkType_triggered()), getLinkTypeSequence());
     addAction(&actionLinkType);
 
-    initAction(&actionSetToCode, tr("Set as Code"),
-               SLOT(on_actionSetToCode_triggered()), getSetToCodeSequence());
-    addAction(&actionSetToCode);
-
-    initAction(&actionSetAsString, tr("Set as String"),
-               SLOT(on_actionSetAsString_triggered()), getSetAsStringSequence());
-    addAction(&actionSetAsString);
-
-    addSetToDataMenu();
+    addSetAsMenu();
 
     addSeparator();
 
@@ -174,9 +166,25 @@ void DisassemblyContextMenu::addSetBitsMenu()
     connect(&actionSetBits64, &QAction::triggered, this, [this] { setBits(64); });
 }
 
+
+void DisassemblyContextMenu::addSetAsMenu()
+{
+    setAsMenu = addMenu(tr("Set as..."));
+
+    initAction(&actionSetToCode, tr("Code"),
+               SLOT(on_actionSetToCode_triggered()), getSetToCodeSequence());
+    setAsMenu->addAction(&actionSetToCode);
+
+    initAction(&actionSetAsString, tr("String"),
+               SLOT(on_actionSetAsString_triggered()), getSetAsStringSequence());
+    setAsMenu->addAction(&actionSetAsString);
+
+    addSetToDataMenu();
+}
+
 void DisassemblyContextMenu::addSetToDataMenu()
 {
-    setToDataMenu = addMenu(tr("Set to Data..."));
+    setToDataMenu = setAsMenu->addMenu(tr("Data..."));
 
     initAction(&actionSetToDataByte, tr("Byte"));
     setToDataMenu->addAction(&actionSetToDataByte);

--- a/src/menus/DisassemblyContextMenu.h
+++ b/src/menus/DisassemblyContextMenu.h
@@ -157,6 +157,7 @@ private:
     QAction actionSetAsString;
 
     QMenu *setToDataMenu;
+    QMenu *setAsMenu;
     QAction actionSetToDataEx;
     QAction actionSetToDataByte;
     QAction actionSetToDataWord;
@@ -176,6 +177,7 @@ private:
 
     void addSetBaseMenu();
     void addSetBitsMenu();
+    void addSetAsMenu();
     void addSetToDataMenu();
     void addEditMenu();
     void addDebugMenu();


### PR DESCRIPTION
**Detailed description**

There was now way for Set As (code, string, data) to be single items in the main disassembly context menu. So I put them together under a sub-menu of "Set as..." as can be shown in the pictures below.
This will allow the menu to be more readable and not as busy as it is used to

**Before:**
Set to code, data and string are in the main menu

![image](https://user-images.githubusercontent.com/20182642/59326697-02e34800-8cf0-11e9-9612-f75da901de06.png)


**After:**
All these actions are now under "Set as..." menu
![image](https://user-images.githubusercontent.com/20182642/59326622-c6175100-8cef-11e9-93b7-6243c72af7cc.png)


**Test plan (required)**

1. Right click on instruction in Disassembly \ Graph
2. Observe that these items are now combined under "Set as..." submenu.




