### PR TITLE
Don't raise unsynced widgets.

### DIFF
--- a/src/widgets/MemoryDockWidget.cpp
+++ b/src/widgets/MemoryDockWidget.cpp
@@ -13,6 +13,9 @@ MemoryDockWidget::MemoryDockWidget(CutterCore::MemoryWidgetType type, MainWindow
 
 void MemoryDockWidget::handleRaiseMemoryWidget(CutterCore::MemoryWidgetType raiseType)
 {
+    if (!seekable->isSynchronized()) {
+        return;
+    }
     bool raisingEmptyGraph = (raiseType == CutterCore::MemoryWidgetType::Graph && Core()->isGraphEmpty());
     if (raisingEmptyGraph) {
         raiseType = CutterCore::MemoryWidgetType::Disassembly;


### PR DESCRIPTION
**Detailed description**

Don't raise unsynced widgets when seeking.

**Test plan (required)**
* open two graph widgets
* switch to non memory widget like imports and strings
* select function to seek and observe that both graph widgets were raised
* unsync one of them
* switch to non memory widgets
* select function to seek and observe that only synced graph was raised

**Closing issues**

Closes #1455