### PR TITLE
Enable brew update until travis image gets updated.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,7 @@ dist: xenial
 addons:
   homebrew:
     brewfile: scripts/Brewfile
+    update: true
 
 install:
   - scripts/fetch_deps.sh


### PR DESCRIPTION

**Detailed description**

Temporarily enable brew update for travis until their virtual machines get updated. It will make the build somewhat slower, but hopefully it will not fail. Changes can be remove once travis update their stuff, no Idea how often that happens.

**Test plan (required)**

* If the testing on travis pass it's good.
