### PR TITLE
Initial refactoring and improvement for Assembly Options Dialog

### DIFF
--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -116,6 +116,7 @@ static const QHash<QString, QVariant> asmOptions = {
     { "asm.tabs",           5 },
     { "asm.tabs.off",       5 },
     { "asm.marks",          false },
+    { "asm.refptr",          false },
     { "esil.breakoninvalid",   true },
     { "graph.offset",       false}
 };

--- a/src/dialogs/preferences/AsmOptionsWidget.cpp
+++ b/src/dialogs/preferences/AsmOptionsWidget.cpp
@@ -21,9 +21,43 @@ AsmOptionsWidget::AsmOptionsWidget(PreferencesDialog *dialog)
         ui->syntaxComboBox->addItem(syntax, syntax);
     ui->syntaxComboBox->blockSignals(false);
 
+    checkboxes = {
+        { ui->describeCheckBox,     "asm.descirbe" },
+        { ui->refptrCheckBox,       "asm.refptr" },
+        { ui->xrefCheckBox,         "asm.xrefs" },
+        { ui->bblineCheckBox,       "asm.bb.line" },
+        { ui->varsubCheckBox,       "asm.var.sub" },
+        { ui->varsubOnlyCheckBox,   "asm.var.subonly" },
+        { ui->lbytesCheckBox,       "asm.lbytes" },
+        { ui->bytespaceCheckBox,    "asm.bytespace" },
+        { ui->bytesCheckBox,        "asm.bytes" },
+        { ui->xrefCheckBox,         "asm.xrefs" },
+        { ui->indentCheckBox,       "asm.indent" },
+        { ui->offsetCheckBox,       "asm.offset" },
+        { ui->slowCheckBox,         "asm.slow" },
+        { ui->linesCheckBox,        "asm.lines" },
+        { ui->fcnlinesCheckBox,     "asm.lines.fcn" },
+        { ui->flgoffCheckBox,       "asm.flags.offset" },
+        { ui->emuCheckBox,          "asm.emu" },
+        { ui->emuStrCheckBox,       "emu.str" },
+        { ui->varsumCheckBox,       "asm.var.summary" },
+        { ui->sizeCheckBox,         "asm.size" },
+    };
+
+
+    QList<ConfigCheckbox>::iterator confCheckbox;
+
+    for (confCheckbox = checkboxes.begin(); confCheckbox != checkboxes.end(); ++confCheckbox) {
+        QString val = confCheckbox->config;
+        QCheckBox &cb = *confCheckbox->checkBox;
+        connect(confCheckbox->checkBox, &QCheckBox::stateChanged, [this, val, &cb]() { checkboxEnabler(&cb, val) ;});
+    }
+
+    connect(ui->commentsComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,                                              &AsmOptionsWidget::commentsComboBoxChanged);
+    connect(ui->asmComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,                                        &AsmOptionsWidget::asmComboBoxChanged);
+    connect(Core(), SIGNAL(asmOptionsChanged()), this, SLOT(updateAsmOptionsFromVars()));
     updateAsmOptionsFromVars();
 
-    connect(Core(), SIGNAL(asmOptionsChanged()), this, SLOT(updateAsmOptionsFromVars()));
 }
 
 AsmOptionsWidget::~AsmOptionsWidget() {}
@@ -77,43 +111,11 @@ void AsmOptionsWidget::updateAsmOptionsFromVars()
     ui->asmTabsOffSpinBox->blockSignals(false);
 
 
-    QList<ConfigCheckbox> checkboxes = {
-        { ui->describeCheckBox,     "asm.descirbe" },
-        { ui->refptrCheckBox,       "asm.refptr" },
-        { ui->xrefCheckBox,         "asm.xrefs" },
-        { ui->bblineCheckBox,       "asm.bb.line" },
-        { ui->varsubCheckBox,       "asm.var.sub" },
-        { ui->varsubOnlyCheckBox,   "asm.var.subonly" },
-        { ui->lbytesCheckBox,       "asm.lbytes" },
-        { ui->bytespaceCheckBox,    "asm.bytespace" },
-        { ui->bytesCheckBox,        "asm.bytes" },
-        { ui->xrefCheckBox,         "asm.xrefs" },
-        { ui->indentCheckBox,       "asm.indent" },
-        { ui->offsetCheckBox,       "asm.offset" },
-        { ui->slowCheckBox,         "asm.slow" },
-        { ui->linesCheckBox,        "asm.lines" },
-        { ui->fcnlinesCheckBox,     "asm.lines.fcn" },
-        { ui->flgoffCheckBox,       "asm.flags.offset" },
-        { ui->emuCheckBox,          "asm.emu" },
-        { ui->emuStrCheckBox,       "emu.str" },
-        { ui->varsumCheckBox,       "asm.var.summary" },
-        { ui->sizeCheckBox,         "asm.size" },
-    };
-
-
     QList<ConfigCheckbox>::iterator confCheckbox;
+
     for (confCheckbox = checkboxes.begin(); confCheckbox != checkboxes.end(); ++confCheckbox) {
         qhelpers::setCheckedWithoutSignals(confCheckbox->checkBox,  Config()->getConfigBool(confCheckbox->config));
-
-        QString val = confCheckbox->config;
-        QCheckBox &cb = *confCheckbox->checkBox;
-        connect(confCheckbox->checkBox, &QCheckBox::stateChanged, [this, val, &cb]() { checkboxEnabler(&cb, val) ;});
     }
-
-    connect(ui->commentsComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
-                                                    &AsmOptionsWidget::commentsComboBoxChanged);
-    connect(ui->asmComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
-                                                    &AsmOptionsWidget::asmComboBoxChanged);
 
 }
 

--- a/src/dialogs/preferences/AsmOptionsWidget.cpp
+++ b/src/dialogs/preferences/AsmOptionsWidget.cpp
@@ -47,7 +47,7 @@ AsmOptionsWidget::AsmOptionsWidget(PreferencesDialog *dialog)
 
     QList<ConfigCheckbox>::iterator confCheckbox;
 
-    // Connect each checbox from "checboxes" to the generic signal "checkboxEnabler"
+    // Connect each checkbox from "checkboxes" to the generic signal "checkboxEnabler"
     for (confCheckbox = checkboxes.begin(); confCheckbox != checkboxes.end(); ++confCheckbox) {
         QString val = confCheckbox->config;
         QCheckBox &cb = *confCheckbox->checkBox;
@@ -237,7 +237,7 @@ void AsmOptionsWidget::commentsComboBoxChanged(int index)
 
     // Show\Hide comments in disassembly based on whether "Off" is selected
     Config()->setConfig("asm.comments", index != 2);
-    // Enable comments-related checboxes only if Comments are enabled
+    // Enable comments-related checkboxes only if Comments are enabled
     ui->xrefCheckBox->setEnabled(index != 2);
     ui->refptrCheckBox->setEnabled(index != 2);
     ui->describeCheckBox->setEnabled(index != 2);
@@ -258,7 +258,7 @@ void AsmOptionsWidget::asmComboBoxChanged(int index)
 /**
  * @brief A generic signal to handle the simple cases where a checkbox is toggled
  * while it only responsible for a single independent boolean configuration eval.
- * @param checkBox - The checbox which is responsible for the siganl
+ * @param checkBox - The checkbox which is responsible for the siganl
  * @param config - the configuration string to be toggled
  */
 void AsmOptionsWidget::checkboxEnabler(QCheckBox* checkBox, QString config)

--- a/src/dialogs/preferences/AsmOptionsWidget.cpp
+++ b/src/dialogs/preferences/AsmOptionsWidget.cpp
@@ -31,40 +31,22 @@ AsmOptionsWidget::~AsmOptionsWidget() {}
 
 void AsmOptionsWidget::updateAsmOptionsFromVars()
 {
-    qhelpers::setCheckedWithoutSignals(ui->esilCheckBox, Config()->getConfigBool("asm.esil"));
-    qhelpers::setCheckedWithoutSignals(ui->pseudoCheckBox, Config()->getConfigBool("asm.pseudo"));
-    qhelpers::setCheckedWithoutSignals(ui->offsetCheckBox, Config()->getConfigBool("asm.offset"));
-    qhelpers::setCheckedWithoutSignals(ui->xrefCheckBox, Config()->getConfigBool("asm.xrefs"));
-    qhelpers::setCheckedWithoutSignals(ui->indentCheckBox, Config()->getConfigBool("asm.indent"));
-    qhelpers::setCheckedWithoutSignals(ui->describeCheckBox, Config()->getConfigBool("asm.describe"));
-    qhelpers::setCheckedWithoutSignals(ui->slowCheckBox, Config()->getConfigBool("asm.slow"));
-    qhelpers::setCheckedWithoutSignals(ui->linesCheckBox, Config()->getConfigBool("asm.lines"));
-    qhelpers::setCheckedWithoutSignals(ui->fcnlinesCheckBox, Config()->getConfigBool("asm.lines.fcn"));
-    qhelpers::setCheckedWithoutSignals(ui->flgoffCheckBox, Config()->getConfigBool("asm.flags.offset"));
-    qhelpers::setCheckedWithoutSignals(ui->emuCheckBox, Config()->getConfigBool("asm.emu"));
-    qhelpers::setCheckedWithoutSignals(ui->emuStrCheckBox, Config()->getConfigBool("emu.str"));
-    qhelpers::setCheckedWithoutSignals(ui->varsumCheckBox, Config()->getConfigBool("asm.var.summary"));
-    qhelpers::setCheckedWithoutSignals(ui->sizeCheckBox, Config()->getConfigBool("asm.size"));
-
     bool cmtRightEnabled = Config()->getConfigBool("asm.cmt.right");
-    qhelpers::setCheckedWithoutSignals(ui->cmtrightCheckBox, cmtRightEnabled);
     ui->cmtcolSpinBox->blockSignals(true);
     ui->cmtcolSpinBox->setValue(Config()->getConfigInt("asm.cmt.col"));
     ui->cmtcolSpinBox->blockSignals(false);
     ui->cmtcolSpinBox->setEnabled(cmtRightEnabled);
 
     bool bytesEnabled = Config()->getConfigBool("asm.bytes");
-    qhelpers::setCheckedWithoutSignals(ui->bytesCheckBox, bytesEnabled);
-    qhelpers::setCheckedWithoutSignals(ui->bytespaceCheckBox, Config()->getConfigBool("asm.bytespace"));
     ui->bytespaceCheckBox->setEnabled(bytesEnabled);
-    qhelpers::setCheckedWithoutSignals(ui->lbytesCheckBox, Config()->getConfigBool("asm.lbytes"));
     ui->lbytesCheckBox->setEnabled(bytesEnabled);
     ui->nbytesSpinBox->blockSignals(true);
     ui->nbytesSpinBox->setValue(Config()->getConfigInt("asm.nbytes"));
     ui->nbytesSpinBox->blockSignals(false);
     ui->nbytesLabel->setEnabled(bytesEnabled);
     ui->nbytesSpinBox->setEnabled(bytesEnabled);
-
+    bool varsubEnabled = Config()->getConfigBool("asm.var.sub");
+    ui->varsubOnlyCheckBox->setEnabled(varsubEnabled);
 
     QString currentSyntax = Config()->getConfigString("asm.syntax");
     for (int i = 0; i < ui->syntaxComboBox->count(); i++) {
@@ -94,13 +76,45 @@ void AsmOptionsWidget::updateAsmOptionsFromVars()
     ui->asmTabsOffSpinBox->setValue(Config()->getConfigInt("asm.tabs.off"));
     ui->asmTabsOffSpinBox->blockSignals(false);
 
-    qhelpers::setCheckedWithoutSignals(ui->bblineCheckBox, Config()->getConfigBool("asm.bb.line"));
 
-    bool varsubEnabled = Config()->getConfigBool("asm.var.sub");
-    qhelpers::setCheckedWithoutSignals(ui->varsubCheckBox, varsubEnabled);
-    qhelpers::setCheckedWithoutSignals(ui->varsubOnlyCheckBox,
-                                       Config()->getConfigBool("asm.var.subonly"));
-    ui->varsubOnlyCheckBox->setEnabled(varsubEnabled);
+    QList<ConfigCheckbox> checkboxes = {
+        { ui->describeCheckBox,     "asm.descirbe" },
+        { ui->refptrCheckBox,       "asm.refptr" },
+        { ui->xrefCheckBox,         "asm.xrefs" },
+        { ui->bblineCheckBox,       "asm.bb.line" },
+        { ui->varsubCheckBox,       "asm.var.sub" },
+        { ui->varsubOnlyCheckBox,   "asm.var.subonly" },
+        { ui->lbytesCheckBox,       "asm.lbytes" },
+        { ui->bytespaceCheckBox,    "asm.bytespace" },
+        { ui->bytesCheckBox,        "asm.bytes" },
+        { ui->xrefCheckBox,         "asm.xrefs" },
+        { ui->indentCheckBox,       "asm.indent" },
+        { ui->offsetCheckBox,       "asm.offset" },
+        { ui->slowCheckBox,         "asm.slow" },
+        { ui->linesCheckBox,        "asm.lines" },
+        { ui->fcnlinesCheckBox,     "asm.lines.fcn" },
+        { ui->flgoffCheckBox,       "asm.flags.offset" },
+        { ui->emuCheckBox,          "asm.emu" },
+        { ui->emuStrCheckBox,       "emu.str" },
+        { ui->varsumCheckBox,       "asm.var.summary" },
+        { ui->sizeCheckBox,         "asm.size" },
+    };
+
+
+    QList<ConfigCheckbox>::iterator confCheckbox;
+    for (confCheckbox = checkboxes.begin(); confCheckbox != checkboxes.end(); ++confCheckbox) {
+        qhelpers::setCheckedWithoutSignals(confCheckbox->checkBox,  Config()->getConfigBool(confCheckbox->config));
+
+        QString val = confCheckbox->config;
+        QCheckBox &cb = *confCheckbox->checkBox;
+        connect(confCheckbox->checkBox, &QCheckBox::stateChanged, [this, val, &cb]() { checkboxEnabler(&cb, val) ;});
+    }
+
+    connect(ui->commentsComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+                                                    &AsmOptionsWidget::commentsComboBoxChanged);
+    connect(ui->asmComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+                                                    &AsmOptionsWidget::asmComboBoxChanged);
+
 }
 
 void AsmOptionsWidget::resetToDefault()
@@ -117,97 +131,12 @@ void AsmOptionsWidget::triggerAsmOptionsChanged()
     connect(Core(), SIGNAL(asmOptionsChanged()), this, SLOT(updateAsmOptionsFromVars()));
 }
 
-
-void AsmOptionsWidget::on_esilCheckBox_toggled(bool checked)
-{
-    Config()->setConfig("asm.esil", checked);
-    triggerAsmOptionsChanged();
-}
-
-void AsmOptionsWidget::on_pseudoCheckBox_toggled(bool checked)
-{
-    Config()->setConfig("asm.pseudo", checked);
-    triggerAsmOptionsChanged();
-}
-
-void AsmOptionsWidget::on_offsetCheckBox_toggled(bool checked)
-{
-    Config()->setConfig("asm.offset", checked);
-    triggerAsmOptionsChanged();
-}
-
-void AsmOptionsWidget::on_xrefCheckBox_toggled(bool checked)
-{
-    Config()->setConfig("asm.xrefs", checked);
-    triggerAsmOptionsChanged();
-}
-
-void AsmOptionsWidget::on_indentCheckBox_toggled(bool checked)
-{
-    Config()->setConfig("asm.indent", checked);
-    triggerAsmOptionsChanged();
-}
-
-void AsmOptionsWidget::on_describeCheckBox_toggled(bool checked)
-{
-    Config()->setConfig("asm.describe", checked);
-    triggerAsmOptionsChanged();
-}
-
-void AsmOptionsWidget::on_slowCheckBox_toggled(bool checked)
-{
-    Config()->setConfig("asm.slow", checked);
-    triggerAsmOptionsChanged();
-}
-
-void AsmOptionsWidget::on_linesCheckBox_toggled(bool checked)
-{
-    Config()->setConfig("asm.lines", checked);
-    triggerAsmOptionsChanged();
-}
-
-void AsmOptionsWidget::on_fcnlinesCheckBox_toggled(bool checked)
-{
-    Config()->setConfig("asm.lines.fcn", checked);
-    triggerAsmOptionsChanged();
-}
-
-void AsmOptionsWidget::on_flgoffCheckBox_toggled(bool checked)
-{
-    Config()->setConfig("asm.flags.off", checked);
-    triggerAsmOptionsChanged();
-}
-
-void AsmOptionsWidget::on_emuCheckBox_toggled(bool checked)
-{
-    Config()->setConfig("asm.emu", checked);
-    triggerAsmOptionsChanged();
-}
-
-void AsmOptionsWidget::on_emuStrCheckBox_toggled(bool checked)
-{
-    Config()->setConfig("emu.str", checked);
-    triggerAsmOptionsChanged();
-}
-
-void AsmOptionsWidget::on_cmtrightCheckBox_toggled(bool checked)
-{
-    Config()->setConfig("asm.cmt.right", checked);
-    ui->cmtcolSpinBox->setEnabled(checked);
-    triggerAsmOptionsChanged();
-}
-
 void AsmOptionsWidget::on_cmtcolSpinBox_valueChanged(int value)
 {
     Config()->setConfig("asm.cmt.col", value);
     triggerAsmOptionsChanged();
 }
 
-void AsmOptionsWidget::on_varsumCheckBox_toggled(bool checked)
-{
-    Config()->setConfig("asm.var.summary", checked);
-    triggerAsmOptionsChanged();
-}
 
 void AsmOptionsWidget::on_bytesCheckBox_toggled(bool checked)
 {
@@ -216,24 +145,6 @@ void AsmOptionsWidget::on_bytesCheckBox_toggled(bool checked)
     ui->lbytesCheckBox->setEnabled(checked);
     ui->nbytesLabel->setEnabled(checked);
     ui->nbytesSpinBox->setEnabled(checked);
-    triggerAsmOptionsChanged();
-}
-
-void AsmOptionsWidget::on_sizeCheckBox_toggled(bool checked)
-{
-    Config()->setConfig("asm.size", checked);
-    triggerAsmOptionsChanged();
-}
-
-void AsmOptionsWidget::on_bytespaceCheckBox_toggled(bool checked)
-{
-    Config()->setConfig("asm.bytespace", checked);
-    triggerAsmOptionsChanged();
-}
-
-void AsmOptionsWidget::on_lbytesCheckBox_toggled(bool checked)
-{
-    Config()->setConfig("asm.lbytes", checked);
     triggerAsmOptionsChanged();
 }
 
@@ -293,11 +204,6 @@ void AsmOptionsWidget::on_asmTabsOffSpinBox_valueChanged(int value)
     triggerAsmOptionsChanged();
 }
 
-void AsmOptionsWidget::on_bblineCheckBox_toggled(bool checked)
-{
-    Config()->setConfig("asm.bb.line", checked);
-    triggerAsmOptionsChanged();
-}
 
 void AsmOptionsWidget::on_varsubCheckBox_toggled(bool checked)
 {
@@ -305,13 +211,6 @@ void AsmOptionsWidget::on_varsubCheckBox_toggled(bool checked)
     ui->varsubOnlyCheckBox->setEnabled(checked);
     triggerAsmOptionsChanged();
 }
-
-void AsmOptionsWidget::on_varsubOnlyCheckBox_toggled(bool checked)
-{
-    Config()->setConfig("asm.var.subonly", checked);
-    triggerAsmOptionsChanged();
-}
-
 
 void AsmOptionsWidget::on_buttonBox_clicked(QAbstractButton *button)
 {
@@ -322,4 +221,41 @@ void AsmOptionsWidget::on_buttonBox_clicked(QAbstractButton *button)
     default:
         break;
     }
+}
+
+void AsmOptionsWidget::commentsComboBoxChanged(int index)
+{
+    // Check if comments should be set to right
+    Config()->setConfig("asm.cmt.right", index != 1);
+    // Check if comments are disabled
+    ui->cmtcolSpinBox->setEnabled(index != 1);
+
+    Config()->setConfig("asm.comments", index != 2);
+    ui->xrefCheckBox->setEnabled(index != 2);
+    ui->refptrCheckBox->setEnabled(index != 2);
+    ui->describeCheckBox->setEnabled(index != 2);
+
+    triggerAsmOptionsChanged();
+}
+
+void AsmOptionsWidget::asmComboBoxChanged(int index)
+{
+    // Check if ESIL enabled
+    Config()->setConfig("asm.esil", index == 1);
+
+    // Check if Pseudocode enabled
+    Config()->setConfig("asm.pseudo", index == 2);
+    triggerAsmOptionsChanged();
+}
+
+/**
+ * @brief A generic signal to handle the simple cases where a checkbox is toggled
+ * while it only responsible for a single independent boolean configuration eval.
+ * @param checkBox - The checbox which is responsible for the siganl
+ * @param config - the configuration string to be toggled
+ */
+void AsmOptionsWidget::checkboxEnabler(QCheckBox* checkBox, QString config)
+{
+    Config()->setConfig(config, checkBox->isChecked());
+    triggerAsmOptionsChanged();
 }

--- a/src/dialogs/preferences/AsmOptionsWidget.cpp
+++ b/src/dialogs/preferences/AsmOptionsWidget.cpp
@@ -54,8 +54,10 @@ AsmOptionsWidget::AsmOptionsWidget(PreferencesDialog *dialog)
         connect(confCheckbox->checkBox, &QCheckBox::stateChanged, [this, val, &cb]() { checkboxEnabler(&cb, val) ;});
     }
 
-    connect(ui->commentsComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,                                              &AsmOptionsWidget::commentsComboBoxChanged);
-    connect(ui->asmComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,                                        &AsmOptionsWidget::asmComboBoxChanged);
+    connect(ui->commentsComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+                &AsmOptionsWidget::commentsComboBoxChanged);
+    connect(ui->asmComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+                &AsmOptionsWidget::asmComboBoxChanged);
     connect(Core(), SIGNAL(asmOptionsChanged()), this, SLOT(updateAsmOptionsFromVars()));
     updateAsmOptionsFromVars();
 }

--- a/src/dialogs/preferences/AsmOptionsWidget.cpp
+++ b/src/dialogs/preferences/AsmOptionsWidget.cpp
@@ -47,6 +47,7 @@ AsmOptionsWidget::AsmOptionsWidget(PreferencesDialog *dialog)
 
     QList<ConfigCheckbox>::iterator confCheckbox;
 
+    // Connect each checbox from "checboxes" to the generic signal "checkboxEnabler"
     for (confCheckbox = checkboxes.begin(); confCheckbox != checkboxes.end(); ++confCheckbox) {
         QString val = confCheckbox->config;
         QCheckBox &cb = *confCheckbox->checkBox;
@@ -57,7 +58,6 @@ AsmOptionsWidget::AsmOptionsWidget(PreferencesDialog *dialog)
     connect(ui->asmComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,                                        &AsmOptionsWidget::asmComboBoxChanged);
     connect(Core(), SIGNAL(asmOptionsChanged()), this, SLOT(updateAsmOptionsFromVars()));
     updateAsmOptionsFromVars();
-
 }
 
 AsmOptionsWidget::~AsmOptionsWidget() {}
@@ -113,6 +113,7 @@ void AsmOptionsWidget::updateAsmOptionsFromVars()
 
     QList<ConfigCheckbox>::iterator confCheckbox;
 
+    // Set the value for each checkbox in "checkboxes" as it exists in the configuration
     for (confCheckbox = checkboxes.begin(); confCheckbox != checkboxes.end(); ++confCheckbox) {
         qhelpers::setCheckedWithoutSignals(confCheckbox->checkBox,  Config()->getConfigBool(confCheckbox->config));
     }
@@ -232,7 +233,9 @@ void AsmOptionsWidget::commentsComboBoxChanged(int index)
     // Check if comments are disabled
     ui->cmtcolSpinBox->setEnabled(index != 1);
 
+    // Show\Hide comments in disassembly based on whether "Off" is selected
     Config()->setConfig("asm.comments", index != 2);
+    // Enable comments-related checboxes only if Comments are enabled
     ui->xrefCheckBox->setEnabled(index != 2);
     ui->refptrCheckBox->setEnabled(index != 2);
     ui->describeCheckBox->setEnabled(index != 2);

--- a/src/dialogs/preferences/AsmOptionsWidget.h
+++ b/src/dialogs/preferences/AsmOptionsWidget.h
@@ -24,6 +24,10 @@ public:
 
 private:
     std::unique_ptr<Ui::AsmOptionsWidget> ui;
+    struct ConfigCheckbox {
+        QCheckBox *checkBox;
+        QString config;
+    };
 
     void triggerAsmOptionsChanged();
 
@@ -32,35 +36,23 @@ private slots:
 
     void updateAsmOptionsFromVars();
 
-    void on_esilCheckBox_toggled(bool checked);
-    void on_pseudoCheckBox_toggled(bool checked);
-    void on_offsetCheckBox_toggled(bool checked);
-    void on_xrefCheckBox_toggled(bool checked);
-    void on_indentCheckBox_toggled(bool checked);
-    void on_describeCheckBox_toggled(bool checked);
-    void on_slowCheckBox_toggled(bool checked);
-    void on_linesCheckBox_toggled(bool checked);
-    void on_fcnlinesCheckBox_toggled(bool checked);
-    void on_flgoffCheckBox_toggled(bool checked);
-    void on_emuCheckBox_toggled(bool checked);
-    void on_emuStrCheckBox_toggled(bool checked);
-    void on_cmtrightCheckBox_toggled(bool checked);
+
     void on_cmtcolSpinBox_valueChanged(int value);
-    void on_varsumCheckBox_toggled(bool checked);
-    void on_bytesCheckBox_toggled(bool checked);
-    void on_sizeCheckBox_toggled(bool checked);
-    void on_bytespaceCheckBox_toggled(bool checked);
-    void on_lbytesCheckBox_toggled(bool checked);
+
     void on_syntaxComboBox_currentIndexChanged(int index);
     void on_caseComboBox_currentIndexChanged(int index);
     void on_asmTabsSpinBox_valueChanged(int value);
     void on_asmTabsOffSpinBox_valueChanged(int value);
     void on_nbytesSpinBox_valueChanged(int value);
-    void on_bblineCheckBox_toggled(bool checked);
+
+    void on_bytesCheckBox_toggled(bool checked);
     void on_varsubCheckBox_toggled(bool checked);
-    void on_varsubOnlyCheckBox_toggled(bool checked);
 
     void on_buttonBox_clicked(QAbstractButton *button);
+
+    void commentsComboBoxChanged(int index);
+    void asmComboBoxChanged(int index);
+    void checkboxEnabler(QCheckBox *checkbox, QString config);
 };
 
 

--- a/src/dialogs/preferences/AsmOptionsWidget.h
+++ b/src/dialogs/preferences/AsmOptionsWidget.h
@@ -28,6 +28,7 @@ private:
         QCheckBox *checkBox;
         QString config;
     };
+    QList<ConfigCheckbox> checkboxes;
 
     void triggerAsmOptionsChanged();
 

--- a/src/dialogs/preferences/AsmOptionsWidget.ui
+++ b/src/dialogs/preferences/AsmOptionsWidget.ui
@@ -28,7 +28,7 @@
         </sizepolicy>
        </property>
        <property name="currentIndex">
-        <number>1</number>
+        <number>0</number>
        </property>
        <widget class="QWidget" name="asmStyleTab">
         <attribute name="title">

--- a/src/dialogs/preferences/AsmOptionsWidget.ui
+++ b/src/dialogs/preferences/AsmOptionsWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>545</width>
-    <height>526</height>
+    <width>616</width>
+    <height>664</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,306 +15,413 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QTabWidget" name="asmOptionsTab">
-     <property name="currentIndex">
-      <number>1</number>
-     </property>
-     <widget class="QWidget" name="asmStyleTab">
-      <attribute name="title">
-       <string>Style</string>
-      </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_4">
-       <item>
-        <widget class="QCheckBox" name="esilCheckBox">
-         <property name="text">
-          <string>Show ESIL instead of assembly (asm.esil)</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="pseudoCheckBox">
-         <property name="text">
-          <string>Show pseudocode instead of assembly (asm.pseudo)</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="offsetCheckBox">
-         <property name="text">
-          <string>Show offsets (asm.offset)</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="xrefCheckBox">
-         <property name="text">
-          <string>Show xrefs (asm.xrefs)</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="indentCheckBox">
-         <property name="text">
-          <string>Indent disassembly based on reflines depth (asm.indent)</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="describeCheckBox">
-         <property name="text">
-          <string>Show opcode description (asm.describe)</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <layout class="QGridLayout" name="gridLayout">
-         <item row="0" column="1">
-          <widget class="QComboBox" name="syntaxComboBox"/>
-         </item>
-         <item row="0" column="0">
-          <widget class="QLabel" name="syntaxLabel">
-           <property name="text">
-            <string>Syntax (asm.syntax):</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QComboBox" name="caseComboBox">
-           <item>
-            <property name="text">
-             <string>Lowercase</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Uppercase (asm.ucase)</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Capitalize (asm.capitalize)</string>
-            </property>
-           </item>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QVBoxLayout" name="verticalLayout_2">
-         <property name="leftMargin">
-          <number>16</number>
-         </property>
-         <item>
-          <widget class="QCheckBox" name="bytespaceCheckBox">
-           <property name="text">
-            <string>Separate bytes with whitespace (asm.bytespace)</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="lbytesCheckBox">
-           <property name="text">
-            <string>Align bytes to the left (asm.lbytes)</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QGridLayout" name="gridLayout_2">
-         <item row="0" column="0">
-          <widget class="QLabel" name="asmTabsLabel">
-           <property name="text">
-            <string>Tabs in assembly (asm.tabs):</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QSpinBox" name="asmTabsSpinBox">
-           <property name="maximum">
-            <number>100</number>
-           </property>
-           <property name="singleStep">
-            <number>5</number>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QGridLayout" name="gridLayout_4">
-         <item row="0" column="0">
-          <widget class="QLabel" name="asmTabsOffLabel">
-           <property name="text">
-            <string>Tabs before assembly (asm.tabs.off):</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QSpinBox" name="asmTabsOffSpinBox">
-           <property name="maximum">
-            <number>100</number>
-           </property>
-           <property name="singleStep">
-            <number>5</number>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="bblineCheckBox">
-         <property name="text">
-          <string>Show empty line after every basic block (asm.bb.line)</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="cmtrightCheckBox">
-         <property name="text">
-          <string>Show comments at right of assembly (asm.cmt.right)</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <layout class="QGridLayout" name="gridLayout_5">
-         <item row="0" column="0">
-          <widget class="QLabel" name="cmtcolLabel">
-           <property name="text">
-            <string>Column to align comments (asm.cmt.col):</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QSpinBox" name="cmtcolSpinBox">
-           <property name="maximum">
-            <number>100</number>
-           </property>
-           <property name="singleStep">
-            <number>5</number>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="tab_2">
-      <attribute name="title">
-       <string>Metadata</string>
-      </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_5">
-       <item>
-        <widget class="QCheckBox" name="slowCheckBox">
-         <property name="text">
-          <string>Slow Analysis (asm.slow)</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="linesCheckBox">
-         <property name="text">
-          <string>Show jump lines (asm.lines)</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="fcnlinesCheckBox">
-         <property name="text">
-          <string>Show function boundary lines (asm.lines.fcn)</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="flgoffCheckBox">
-         <property name="text">
-          <string>Show offset before flags (asm.flags.off)</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="emuCheckBox">
-         <property name="text">
-          <string>Run ESIL emulation analysis (asm.emu)</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="emuStrCheckBox">
-         <property name="text">
-          <string>Show only strings if any in the asm.emu output (emu.str)</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="sizeCheckBox">
-         <property name="text">
-          <string>Show size of opcodes in disassembly (asm.size)</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="bytesCheckBox">
-         <property name="text">
-          <string>Show bytes (asm.bytes)</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="varsumCheckBox">
-         <property name="text">
-          <string>Show variables summary instead of full list (asm.var.summary)</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <layout class="QGridLayout" name="gridLayout_3">
-         <property name="leftMargin">
-          <number>16</number>
-         </property>
-         <item row="0" column="0">
-          <widget class="QLabel" name="nbytesLabel">
-           <property name="enabled">
-            <bool>true</bool>
-           </property>
-           <property name="text">
-            <string>Number of bytes to display (asm.nbytes):</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QSpinBox" name="nbytesSpinBox">
-           <property name="enabled">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="varsubCheckBox">
-         <property name="text">
-          <string>Substitute variables (asm.var.sub)</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="varsubOnlyCheckBox">
-         <property name="text">
-          <string>Substitute entire variable expressions with names (asm.var.subonly)</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-    </widget>
-   </item>
-   <item>
     <layout class="QVBoxLayout" name="verticalLayout_3">
      <property name="leftMargin">
       <number>16</number>
      </property>
+     <item>
+      <widget class="QTabWidget" name="asmOptionsTab">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="currentIndex">
+        <number>1</number>
+       </property>
+       <widget class="QWidget" name="asmStyleTab">
+        <attribute name="title">
+         <string>Style</string>
+        </attribute>
+        <layout class="QVBoxLayout" name="verticalLayout_4">
+         <item>
+          <widget class="QGroupBox" name="disassemblyGroupBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="title">
+            <string>Disassembly</string>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_2">
+            <item row="1" column="0">
+             <layout class="QGridLayout" name="gridLayout">
+              <item row="7" column="0" colspan="2">
+               <widget class="QCheckBox" name="indentCheckBox">
+                <property name="text">
+                 <string>Indent disassembly based on reflines depth (asm.indent)</string>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="0" colspan="2">
+               <widget class="QCheckBox" name="bblineCheckBox">
+                <property name="text">
+                 <string>Show empty line after every basic block (asm.bb.line)</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="1">
+               <widget class="QComboBox" name="caseComboBox">
+                <item>
+                 <property name="text">
+                  <string>Lowercase</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Uppercase (asm.ucase)</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Capitalize (asm.capitalize)</string>
+                 </property>
+                </item>
+               </widget>
+              </item>
+              <item row="0" column="0">
+               <widget class="QLabel" name="label">
+                <property name="text">
+                 <string>Show Disassembly as:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="syntaxLabel">
+                <property name="text">
+                 <string>Syntax (asm.syntax):</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QComboBox" name="asmComboBox">
+                <item>
+                 <property name="text">
+                  <string>Normal</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>ESIL (asm.esil)</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Pseudocode (asm.pseudo)</string>
+                 </property>
+                </item>
+               </widget>
+              </item>
+              <item row="5" column="0">
+               <widget class="QLabel" name="asmTabsLabel">
+                <property name="text">
+                 <string>Tabs in assembly (asm.tabs):</string>
+                </property>
+               </widget>
+              </item>
+              <item row="6" column="1">
+               <widget class="QSpinBox" name="asmTabsOffSpinBox">
+                <property name="maximum">
+                 <number>100</number>
+                </property>
+                <property name="singleStep">
+                 <number>5</number>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="0" colspan="2">
+               <widget class="QCheckBox" name="offsetCheckBox">
+                <property name="text">
+                 <string>Show offsets (asm.offset)</string>
+                </property>
+               </widget>
+              </item>
+              <item row="6" column="0">
+               <widget class="QLabel" name="asmTabsOffLabel">
+                <property name="text">
+                 <string>Tabs before assembly (asm.tabs.off):</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QComboBox" name="syntaxComboBox"/>
+              </item>
+              <item row="5" column="1">
+               <widget class="QSpinBox" name="asmTabsSpinBox">
+                <property name="maximum">
+                 <number>100</number>
+                </property>
+                <property name="singleStep">
+                 <number>5</number>
+                </property>
+               </widget>
+              </item>
+              <item row="9" column="0" colspan="2">
+               <widget class="QCheckBox" name="bytespaceCheckBox">
+                <property name="text">
+                 <string>Separate bytes with whitespace (asm.bytespace)</string>
+                </property>
+               </widget>
+              </item>
+              <item row="8" column="0" colspan="2">
+               <widget class="QCheckBox" name="lbytesCheckBox">
+                <property name="text">
+                 <string>Align bytes to the left (asm.lbytes)</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item row="0" column="0">
+             <spacer name="verticalSpacer_3">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Fixed</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>10</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QGroupBox" name="commentsGroupBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+             <horstretch>0</horstretch>
+             <verstretch>1</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="title">
+            <string>Comments</string>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_6">
+            <item row="1" column="0">
+             <layout class="QGridLayout" name="gridLayout_5" columnminimumwidth="0,0">
+              <item row="1" column="0" colspan="2">
+               <widget class="QCheckBox" name="describeCheckBox">
+                <property name="text">
+                 <string>Show opcode description (asm.describe)</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QComboBox" name="commentsComboBox">
+                <item>
+                 <property name="text">
+                  <string>Normal</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Above instructions</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Off</string>
+                 </property>
+                </item>
+               </widget>
+              </item>
+              <item row="0" column="0">
+               <widget class="QLabel" name="label_2">
+                <property name="text">
+                 <string>Show comments:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="1">
+               <widget class="QSpinBox" name="cmtcolSpinBox">
+                <property name="maximum">
+                 <number>100</number>
+                </property>
+                <property name="singleStep">
+                 <number>5</number>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="0">
+               <widget class="QLabel" name="cmtcolLabel">
+                <property name="text">
+                 <string>Column to align comments (asm.cmt.col):</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="0">
+               <widget class="QCheckBox" name="xrefCheckBox">
+                <property name="text">
+                 <string>Show x-refs (asm.xrefs)</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="0" colspan="2">
+               <widget class="QCheckBox" name="refptrCheckBox">
+                <property name="text">
+                 <string>Show refpointer information (asm.refptr)</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item row="0" column="0">
+             <spacer name="verticalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Fixed</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>10</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+       <widget class="QWidget" name="tab_2">
+        <attribute name="title">
+         <string>Metadata</string>
+        </attribute>
+        <layout class="QVBoxLayout" name="verticalLayout_5">
+         <item>
+          <widget class="QCheckBox" name="slowCheckBox">
+           <property name="text">
+            <string>Slow Analysis (asm.slow)</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="linesCheckBox">
+           <property name="text">
+            <string>Show jump lines (asm.lines)</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="fcnlinesCheckBox">
+           <property name="text">
+            <string>Show function boundary lines (asm.lines.fcn)</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="flgoffCheckBox">
+           <property name="text">
+            <string>Show offset before flags (asm.flags.off)</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="emuCheckBox">
+           <property name="text">
+            <string>Run ESIL emulation analysis (asm.emu)</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="emuStrCheckBox">
+           <property name="text">
+            <string>Show only strings if any in the asm.emu output (emu.str)</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="sizeCheckBox">
+           <property name="text">
+            <string>Show size of opcodes in disassembly (asm.size)</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="varsumCheckBox">
+           <property name="text">
+            <string>Show variables summary instead of full list (asm.var.summary)</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="bytesCheckBox">
+           <property name="text">
+            <string>Show bytes (asm.bytes)</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <layout class="QGridLayout" name="gridLayout_3">
+           <property name="leftMargin">
+            <number>16</number>
+           </property>
+           <item row="0" column="0">
+            <widget class="QLabel" name="nbytesLabel">
+             <property name="enabled">
+              <bool>true</bool>
+             </property>
+             <property name="text">
+              <string>Number of bytes to display (asm.nbytes):</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QSpinBox" name="nbytesSpinBox">
+             <property name="enabled">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="varsubCheckBox">
+           <property name="text">
+            <string>Substitute variables (asm.var.sub)</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="varsubOnlyCheckBox">
+           <property name="text">
+            <string>Substitute entire variable expressions with names (asm.var.subonly)</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </widget>
+     </item>
     </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">


### PR DESCRIPTION

**Detailed description**
1. Disable `asm.refptr` by default (see #1260 )
2. Logic changes to the UI as partially described in the "After" picture.
3. Partial refactoring of the signal-slot connections. Previously there was tons of duplicate code to the same things as well as duplicate functions. Now I made a more generic way to connect all the checkboxes to a single Slot that will handle the toggling of the related radare2 config variable.
4. Fix issues of multiple connections of same signale to a Slot which causes redundant execution of the same slot over and over again.
5. Made a more efficient loop to update the value of the checkboxes based on the configuration


**Before:**
![image](https://user-images.githubusercontent.com/20182642/60294210-84122000-9929-11e9-99f9-6f00e79bbc52.png)



**After:**
0. Create a "Disassembly" group box to combine together related components. Before, they were not in order nor intuitive to find.
1. Merge 3 conflicting checboxes into a combo box that now contains "Normal", "ESIL" and "Pseudocode".
2.  Create a "Comments" group box to combine together comments related components.
3. Merge several conflicting checkboxes into a Combo box that now contains "Normal", "Off", "to the Right"
4. Probably some more minor tweaks

![image](https://user-images.githubusercontent.com/20182642/60294392-ee2ac500-9929-11e9-8c5e-71bf133638f9.png)



<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**

closes #1260 
