### PR TITLE
Move graph header to GraphWidget.

### DIFF
--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -157,19 +157,9 @@ DisassemblerGraphView::DisassemblerGraphView(QWidget *parent, CutterSeekable* se
 
     connect(blockMenu, &DisassemblyContextMenu::copy, this, &DisassemblerGraphView::copySelection);
 
-    header = new QTextEdit();
-    header->setFixedHeight(30);
-    header->setReadOnly(true);
-    header->setLineWrapMode(QTextEdit::NoWrap);
-
     // Add header as widget to layout so it stretches to the layout width
     layout->setContentsMargins(0, 0, 0, 0);
     layout->setAlignment(Qt::AlignTop);
-    layout->addWidget(header);
-
-    prepareHeader();
-
-    highlighter = new SyntaxHighlighter(header->document());
 }
 
 void DisassemblerGraphView::connectSeekChanged(bool disconn)
@@ -393,17 +383,6 @@ void DisassemblerGraphView::cleanupEdges()
         }
         block.edges.erase(outIt, block.edges.end());
     }
-}
-
-void DisassemblerGraphView::prepareHeader()
-{
-    QString afcf = Core()->cmd("afcf").trimmed();
-    if (afcf.isEmpty()) {
-        header->hide();
-        return;
-    }
-    header->show();
-    header->setPlainText(afcf);
 }
 
 void DisassemblerGraphView::initFont()
@@ -783,9 +762,6 @@ void DisassemblerGraphView::onSeekChanged(RVA addr)
         transition_dont_seek = true;
         showBlock(&blocks[db->entry], !switchFunction);
         showInstruction(blocks[db->entry], addr);
-        prepareHeader();
-    } else {
-        header->hide();
     }
 }
 

--- a/src/widgets/DisassemblerGraphView.h
+++ b/src/widgets/DisassemblerGraphView.h
@@ -102,7 +102,6 @@ public:
 
     void loadCurrentGraph();
     QString windowTitle;
-    QTextEdit *header = nullptr;
 
     int getWidth() { return width; }
     int getHeight() { return height; }
@@ -157,7 +156,6 @@ private:
     void initFont();
     void prepareGraphNode(GraphBlock &block);
     void cleanupEdges();
-    void prepareHeader();
     Token *getToken(Instr *instr, int x);
     QPoint getTextOffset(int line) const;
     QPoint getInstructionOffset(const DisassemblyBlock &block, int line) const;
@@ -206,8 +204,6 @@ private:
     QAction actionSyncOffset;
 
     QLabel *emptyText = nullptr;
-    SyntaxHighlighter *highlighter = nullptr;
-
 signals:
     void viewRefreshed();
     void viewZoomed();

--- a/src/widgets/GraphView.cpp
+++ b/src/widgets/GraphView.cpp
@@ -424,10 +424,14 @@ void GraphView::showRectangle(const QRect &block, bool anywhere)
     if (height * current_scale <= viewport()->height()) {
         centerY(false);
     } else {
-        static const int HEADER_HEIGHT = 35; // this could be handled better
-        if (!anywhere || block.y() < offset.y() + HEADER_HEIGHT
+        if (!anywhere || block.y() < offset.y()
                 || block.bottom() > offset.y() + renderSize.height()) {
-            offset.ry() = block.y() - HEADER_HEIGHT / current_scale;
+            offset.ry() = block.y();
+            // Leave some space at top if possible
+            const qreal topPadding = 10 / current_scale;
+            if (block.height() + topPadding < renderSize.height()) {
+                offset.ry() -= topPadding;
+            }
         }
     }
     clampViewOffset();

--- a/src/widgets/GraphWidget.h
+++ b/src/widgets/GraphWidget.h
@@ -2,6 +2,7 @@
 #define GRAPHWIDGET_H
 
 #include "MemoryDockWidget.h"
+#include <QLineEdit>
 
 class MainWindow;
 class DisassemblerGraphView;
@@ -28,8 +29,10 @@ private:
     void closeEvent(QCloseEvent *event) override;
 
     QString getWindowTitle() const override;
+    void prepareHeader();
 
     DisassemblerGraphView *graphView;
+    QLineEdit *header = nullptr;
 };
 
 #endif // GRAPHWIDGET_H


### PR DESCRIPTION
* prevents layout problems
* fix header change when doubleclicking in unsynchronized function



**Detailed description**

Tried a few different approaches for displaying header,
* QLabel with mouse selection enabled - more suitable resizing behavior, can only wordwrap. Causes window to expand there is long function name.
* QTextEdit + size policy - doesn't seem like it's possible to get good vertical resizing behavior using size policy settings.
* QTextEdit - looks like most solution require either a bunch of code for dynamically adjusting height or doesn't work in case of DPI or default font size changes.

In the end I chose using LineEdit. It doesn't require any extra code and doesn't look completely broken in case of long text, whole text can be selected and copied. Only downside is that whole text not fitting isn't as clearly indicated as in QTextEdit.

**Test plan (required)**

* test in highdpi mode
* test with modified default font size
* change function name to something long
![Ekrānattēls no 2019-06-28 00-22-46](https://user-images.githubusercontent.com/7101031/60302362-6a2e0880-993c-11e9-8a24-de488e083886.png)


**Closing issues**

<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Closes #1623