### PR TITLE
Fix asm.describe typo

### DIFF
--- a/src/dialogs/preferences/AsmOptionsWidget.cpp
+++ b/src/dialogs/preferences/AsmOptionsWidget.cpp
@@ -22,7 +22,7 @@ AsmOptionsWidget::AsmOptionsWidget(PreferencesDialog *dialog)
     ui->syntaxComboBox->blockSignals(false);
 
     checkboxes = {
-        { ui->describeCheckBox,     "asm.descirbe" },
+        { ui->describeCheckBox,     "asm.describe" },
         { ui->refptrCheckBox,       "asm.refptr" },
         { ui->xrefCheckBox,         "asm.xrefs" },
         { ui->bblineCheckBox,       "asm.bb.line" },


### PR DESCRIPTION
 <!-- Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request. -->


**Detailed description**

A simple typo that caused the checkbox for `asm.describe` not to work.

<!-- Explain the **details** for making this change. What existing problem does the pull request solve? Please provide enough information so that others can review your pull request -->

