### PR TITLE
Disable asm.movlea by default

### DIFF
--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -109,15 +109,16 @@ static const QHash<QString, QVariant> asmOptions = {
     { "asm.nbytes",         10 },
     { "asm.syntax",         "intel" },
     { "asm.ucase",          false },
-    { "asm.bb.line",         false },
+    { "asm.bb.line",        false },
     { "asm.capitalize",     false },
     { "asm.var.sub",        true },
     { "asm.var.subonly",    true },
     { "asm.tabs",           5 },
     { "asm.tabs.off",       5 },
     { "asm.marks",          false },
-    { "asm.refptr",          false },
-    { "esil.breakoninvalid",   true },
+    { "asm.refptr",         false },
+    { "asm.movlea",         false },
+    { "esil.breakoninvalid",true },
     { "graph.offset",       false}
 };
 


### PR DESCRIPTION

**Detailed description**

This pull request simply disables `asm.movlea` by default. This feature will probably be dropped in the next r2 release so meantime we disable it.

The comments can be shown here and looks like "; MOV <REG> = [VAL]"

![image](https://user-images.githubusercontent.com/20182642/60394296-9ad39500-9b2a-11e9-9535-c3acbc03f386.png)


**Test plan (required)**

Open almost any binary and observe that the comments are now gone. For example

```
$ r2 /bin/true
aa
pdf @ main
```
