### PR TITLE
Use KSyntaxHighlighting

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,12 +7,14 @@ endif()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(DisallowInSource)
+include(Utils)
 
 set(CUTTER_PYTHON_MIN 3.5)
 
 option(CUTTER_ENABLE_PYTHON "Enable Python integration. Requires Python >= ${CUTTER_PYTHON_MIN}." OFF)
 option(CUTTER_ENABLE_PYTHON_BINDINGS "Enable generating Python bindings with Shiboken2. Unused if CUTTER_ENABLE_PYTHON=OFF." OFF)
 option(CUTTER_ENABLE_CRASH_REPORTS "Enable crash report system. Unused if CUTTER_ENABLE_CRASH_REPORTS=OFF" OFF)
+tri_option(CUTTER_ENABLE_KSYNTAXHIGHLIGHTING "Use KSyntaxHighlighting" AUTO)
 
 if(NOT CUTTER_ENABLE_PYTHON)
     set(CUTTER_ENABLE_PYTHON_BINDINGS OFF)
@@ -95,6 +97,22 @@ if(CUTTER_ENABLE_PYTHON)
     endif()
 endif()
 
+if(CUTTER_ENABLE_KSYNTAXHIGHLIGHTING)
+    if(CUTTER_ENABLE_KSYNTAXHIGHLIGHTING STREQUAL AUTO)
+        find_package(KF5SyntaxHighlighting)
+        if(KF5SyntaxHighlighting_FOUND)
+            set(KSYNTAXHIGHLIGHTING_STATUS ON)
+        else()
+            set(KSYNTAXHIGHLIGHTING_STATUS "OFF (KSyntaxHighlighting not found)")
+        endif()
+    else()
+        find_package(KF5SyntaxHighlighting REQUIRED)
+        set(KSYNTAXHIGHLIGHTING_STATUS ON)
+    endif()
+else()
+    set(KSYNTAXHIGHLIGHTING_STATUS OFF)
+endif()
+
 
 
 message(STATUS "")
@@ -103,6 +121,7 @@ message(STATUS "Options:")
 message(STATUS "- Python: ${CUTTER_ENABLE_PYTHON}")
 message(STATUS "- Python Bindings: ${CUTTER_ENABLE_PYTHON_BINDINGS}")
 message(STATUS "- Crash Handling: ${CUTTER_ENABLE_CRASH_REPORTS}")
+message(STATUS "- KSyntaxHighlighting: ${KSYNTAXHIGHLIGHTING_STATUS}")
 message(STATUS "")
 
 
@@ -184,4 +203,8 @@ if(CUTTER_ENABLE_PYTHON)
     endif()
 endif()
 
+if(TARGET KF5::SyntaxHighlighting)
+    target_link_libraries(Cutter KF5::SyntaxHighlighting)
+    target_compile_definitions(Cutter PRIVATE CUTTER_ENABLE_KSYNTAXHIGHLIGHTING)
+endif()
 

--- a/src/cmake/Utils.cmake
+++ b/src/cmake/Utils.cmake
@@ -1,0 +1,6 @@
+
+# Like option(), but the value can also be AUTO
+macro(tri_option name desc default)
+    set("${name}" "${default}" CACHE STRING "${desc}")
+    set_property(CACHE "${name}" PROPERTY STRINGS AUTO ON OFF)
+endmacro()

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -8,6 +8,16 @@
 #define Config() (Configuration::instance())
 #define ConfigColor(x) Config()->getColor(x)
 
+#ifdef CUTTER_ENABLE_KSYNTAXHIGHLIGHTING
+namespace KSyntaxHighlighting {
+    class Repository;
+    class Theme;
+}
+#endif
+
+class QSyntaxHighlighter;
+class QTextDocument;
+
 enum ColorFlags {
     LightFlag = 1,
     DarkFlag = 2
@@ -26,6 +36,10 @@ private:
     QPalette nativePalette;
     QSettings s;
     static Configuration *mPtr;
+
+#ifdef CUTTER_ENABLE_KSYNTAXHIGHLIGHTING
+    KSyntaxHighlighting::Repository *kSyntaxHighlightingRepository;
+#endif
 
     // Colors
     void loadBaseThemeNative();
@@ -76,6 +90,12 @@ public:
     }
 
     const CutterInterfaceTheme *getCurrentTheme();
+
+#ifdef CUTTER_ENABLE_KSYNTAXHIGHLIGHTING
+    KSyntaxHighlighting::Repository *getKSyntaxHighlightingRepository();
+    KSyntaxHighlighting::Theme getKSyntaxHighlightingTheme();
+#endif
+    QSyntaxHighlighter *createSyntaxHighlighter(QTextDocument *document);
 
     QString getDirProjects();
     void setDirProjects(const QString &dir);

--- a/src/dialogs/TypesInteractionDialog.cpp
+++ b/src/dialogs/TypesInteractionDialog.cpp
@@ -15,7 +15,7 @@ TypesInteractionDialog::TypesInteractionDialog(QWidget *parent, bool readOnly) :
 {
     ui->setupUi(this);
     ui->plainTextEdit->setPlainText("");
-    syntaxHighLighter = new SyntaxHighlighter(ui->plainTextEdit->document());
+    syntaxHighLighter = Config()->createSyntaxHighlighter(ui->plainTextEdit->document());
     ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
     ui->plainTextEdit->setReadOnly(readOnly);
 }

--- a/src/dialogs/TypesInteractionDialog.h
+++ b/src/dialogs/TypesInteractionDialog.h
@@ -7,7 +7,8 @@
 namespace Ui {
 class TypesInteractionDialog;
 }
-class SyntaxHighlighter;
+
+class QSyntaxHighlighter;
 
 class TypesInteractionDialog : public QDialog
 {
@@ -48,7 +49,7 @@ private slots:
 
 private:
     std::unique_ptr<Ui::TypesInteractionDialog> ui;
-    SyntaxHighlighter *syntaxHighLighter;
+    QSyntaxHighlighter *syntaxHighLighter;
 
 signals:
     /**

--- a/src/widgets/PseudocodeWidget.cpp
+++ b/src/widgets/PseudocodeWidget.cpp
@@ -1,12 +1,11 @@
 #include "PseudocodeWidget.h"
 #include "ui_PseudocodeWidget.h"
 
-#include <QTextEdit>
-
 #include "common/Configuration.h"
 #include "common/Helpers.h"
-#include "common/SyntaxHighlighter.h"
 #include "common/TempConfig.h"
+
+#include <QTextEdit>
 
 PseudocodeWidget::PseudocodeWidget(MainWindow *main, QAction *action) :
     MemoryDockWidget(CutterCore::MemoryWidgetType::Pseudocode, main, action),
@@ -14,7 +13,7 @@ PseudocodeWidget::PseudocodeWidget(MainWindow *main, QAction *action) :
 {
     ui->setupUi(this);
 
-    syntaxHighLighter = new SyntaxHighlighter(ui->textEdit->document());
+    syntaxHighlighter = Config()->createSyntaxHighlighter(ui->textEdit->document());
 
     setupFonts();
     colorsUpdatedSlot();

--- a/src/widgets/PseudocodeWidget.h
+++ b/src/widgets/PseudocodeWidget.h
@@ -11,7 +11,7 @@ class PseudocodeWidget;
 }
 
 class QTextEdit;
-class SyntaxHighlighter;
+class QSyntaxHighlighter;
 
 class PseudocodeWidget : public MemoryDockWidget
 {
@@ -30,7 +30,7 @@ private:
     enum DecompilerComboBoxValues { DecompilerCBR2Dec, DecompilerCBPdc };
     std::unique_ptr<Ui::PseudocodeWidget> ui;
 
-    SyntaxHighlighter *syntaxHighLighter;
+    QSyntaxHighlighter *syntaxHighlighter;
 
     void doRefresh(RVA addr);
     void setupFonts();


### PR DESCRIPTION
Only supported in CMake for now, set `CUTTER_ENABLE_KSYNTAXHIGHLIGHTING` to `AUTO` (enable if found) or `ON` (required) to use it.

![Bildschirmfoto vom 2019-07-11 14-13-57](https://user-images.githubusercontent.com/1460997/61050181-a22a5680-a3e6-11e9-8e18-6d38c9c29059.png)
