### PR TITLE
Rewrite raise memory widget

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -629,21 +629,21 @@ void CutterCore::seek(ut64 offset)
     // cmd already does emit seekChanged(core_->offset);
 }
 
-void CutterCore::show(ut64 offset)
+void CutterCore::showMemoryWidget()
 {
-    seek(offset);
     emit showMemoryWidgetRequested();
 }
 
-void CutterCore::show(QString offset)
+void CutterCore::seekAndShow(ut64 offset)
 {
     seek(offset);
-    emit showMemoryWidgetRequested();
+    showMemoryWidget();
 }
 
-void CutterCore::show()
+void CutterCore::seekAndShow(QString offset)
 {
-    emit showMemoryWidgetRequested();
+    seek(offset);
+    showMemoryWidget();
 }
 
 void CutterCore::seek(QString thing)
@@ -1163,7 +1163,7 @@ void CutterCore::attachDebug(int pid)
     // attach to process with dbg plugin
     cmd("o-*; e cfg.debug = true; o+ dbg://" + QString::number(pid));
     QString programCounterValue = cmd("dr?`drn PC`").trimmed();
-    show(programCounterValue);
+    seekAndShow(programCounterValue);
     emit registersChanged();
     if (!currentlyDebugging || !currentlyEmulating) {
         // prevent register flags from appearing during debug/emul
@@ -1188,7 +1188,7 @@ void CutterCore::stopDebug()
         } else {
             cmd("dk 9; oo; .ar-");
         }
-        show(offsetPriorDebugging);
+        seekAndShow(offsetPriorDebugging);
         setConfig("asm.flags", true);
         setConfig("io.cache", false);
         currentlyDebugging = false;
@@ -1232,7 +1232,7 @@ void CutterCore::continueUntilCall()
             cmd("dcc");
         }
         QString programCounterValue = cmd("dr?`drn PC`").trimmed();
-        show(programCounterValue);
+        seekAndShow(programCounterValue);
         emit registersChanged();
     }
 }
@@ -1246,7 +1246,7 @@ void CutterCore::continueUntilSyscall()
             cmd("dcs");
         }
         QString programCounterValue = cmd("dr?`drn PC`").trimmed();
-        show(programCounterValue);
+        seekAndShow(programCounterValue);
         emit registersChanged();
     }
 }
@@ -1256,7 +1256,7 @@ void CutterCore::stepDebug()
     if (currentlyDebugging) {
         cmdEsil("ds");
         QString programCounterValue = cmd("dr?`drn PC`").trimmed();
-        show(programCounterValue);
+        seekAndShow(programCounterValue);
         emit registersChanged();
     }
 }
@@ -1266,7 +1266,7 @@ void CutterCore::stepOverDebug()
     if (currentlyDebugging) {
         cmdEsil("dso");
         QString programCounterValue = cmd("dr?`drn PC`").trimmed();
-        show(programCounterValue);
+        seekAndShow(programCounterValue);
         emit registersChanged();
     }
 }
@@ -1276,7 +1276,7 @@ void CutterCore::stepOutDebug()
     if (currentlyDebugging) {
         cmd("dsf");
         QString programCounterValue = cmd("dr?`drn PC`").trimmed();
-        show(programCounterValue);
+        seekAndShow(programCounterValue);
         emit registersChanged();
     }
 }

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -627,25 +627,38 @@ void CutterCore::seek(ut64 offset)
     }
     cmd(QString("s %1").arg(offset));
     // cmd already does emit seekChanged(core_->offset);
+}
+
+void CutterCore::show(ut64 offset)
+{
+    seek(offset);
+    triggerRaisePrioritizedMemoryWidget();
+}
+
+void CutterCore::show(QString offset)
+{
+    seek(offset);
+    triggerRaisePrioritizedMemoryWidget();
+}
+
+void CutterCore::show()
+{
     triggerRaisePrioritizedMemoryWidget();
 }
 
 void CutterCore::seek(QString thing)
 {
     cmdRaw(QString("s %1").arg(thing));
-    triggerRaisePrioritizedMemoryWidget();
 }
 
 void CutterCore::seekPrev()
 {
     cmd("s-");
-    triggerRaisePrioritizedMemoryWidget();
 }
 
 void CutterCore::seekNext()
 {
     cmd("s+");
-    triggerRaisePrioritizedMemoryWidget();
 }
 
 void CutterCore::updateSeek()
@@ -1150,7 +1163,7 @@ void CutterCore::attachDebug(int pid)
     // attach to process with dbg plugin
     cmd("o-*; e cfg.debug = true; o+ dbg://" + QString::number(pid));
     QString programCounterValue = cmd("dr?`drn PC`").trimmed();
-    seek(programCounterValue);
+    show(programCounterValue);
     emit registersChanged();
     if (!currentlyDebugging || !currentlyEmulating) {
         // prevent register flags from appearing during debug/emul
@@ -1175,7 +1188,7 @@ void CutterCore::stopDebug()
         } else {
             cmd("dk 9; oo; .ar-");
         }
-        seek(offsetPriorDebugging);
+        show(offsetPriorDebugging);
         setConfig("asm.flags", true);
         setConfig("io.cache", false);
         currentlyDebugging = false;
@@ -1219,7 +1232,7 @@ void CutterCore::continueUntilCall()
             cmd("dcc");
         }
         QString programCounterValue = cmd("dr?`drn PC`").trimmed();
-        seek(programCounterValue);
+        show(programCounterValue);
         emit registersChanged();
     }
 }
@@ -1233,7 +1246,7 @@ void CutterCore::continueUntilSyscall()
             cmd("dcs");
         }
         QString programCounterValue = cmd("dr?`drn PC`").trimmed();
-        seek(programCounterValue);
+        show(programCounterValue);
         emit registersChanged();
     }
 }
@@ -1243,7 +1256,7 @@ void CutterCore::stepDebug()
     if (currentlyDebugging) {
         cmdEsil("ds");
         QString programCounterValue = cmd("dr?`drn PC`").trimmed();
-        seek(programCounterValue);
+        show(programCounterValue);
         emit registersChanged();
     }
 }
@@ -1253,7 +1266,7 @@ void CutterCore::stepOverDebug()
     if (currentlyDebugging) {
         cmdEsil("dso");
         QString programCounterValue = cmd("dr?`drn PC`").trimmed();
-        seek(programCounterValue);
+        show(programCounterValue);
         emit registersChanged();
     }
 }
@@ -1263,7 +1276,7 @@ void CutterCore::stepOutDebug()
     if (currentlyDebugging) {
         cmd("dsf");
         QString programCounterValue = cmd("dr?`drn PC`").trimmed();
-        seek(programCounterValue);
+        show(programCounterValue);
         emit registersChanged();
     }
 }

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -632,18 +632,18 @@ void CutterCore::seek(ut64 offset)
 void CutterCore::show(ut64 offset)
 {
     seek(offset);
-    triggerRaisePrioritizedMemoryWidget();
+    emit showMemoryWidgetRequested();
 }
 
 void CutterCore::show(QString offset)
 {
     seek(offset);
-    triggerRaisePrioritizedMemoryWidget();
+    emit showMemoryWidgetRequested();
 }
 
 void CutterCore::show()
 {
-    triggerRaisePrioritizedMemoryWidget();
+    emit showMemoryWidgetRequested();
 }
 
 void CutterCore::seek(QString thing)

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -162,15 +162,7 @@ public:
     {
         return memoryWidgetPriority;
     }
-    void setMemoryWidgetPriority(MemoryWidgetType type) //TODO: replace
-    {
-        memoryWidgetPriority = type;
-    }
-    void triggerShowMemoryWidget(MemoryWidgetType type)
-    {
-        //TOOD: implement this
-    }
-    void triggerRaisePrioritizedMemoryWidget() // TODO: replace
+    void triggerRaisePrioritizedMemoryWidget()
     {
         emit showMemoryWidgetRequested();
     }
@@ -441,7 +433,6 @@ signals:
      */
     void seekChanged(RVA offset);
 
-    void raisePrioritizedMemoryWidget(CutterCore::MemoryWidgetType type);
     void changeDefinedView();
     void changeDebugView();
 

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -144,12 +144,24 @@ public:
     /* Seek functions */
     void seek(QString thing);
     void seek(ut64 offset);
-    void show();
-    void show(ut64 offset); // seek and raise memory widget
-    void show(QString thing);
     void seekPrev();
     void seekNext();
     void updateSeek();
+    /**
+     * @brief Raise a memory widget showing current offset, prefer last active
+     * memory widget.
+     */
+    void show();
+    /**
+     * @brief Seek to \p offset and raise a memory widget showing it.
+     * @param offset
+     */
+    void show(ut64 offset);
+    /**
+     * @brief \see CutterCore::show(ut64)
+     * @param thing - addressable expression
+     */
+    void show(QString thing);
     RVA getOffset();
     RVA prevOpAddr(RVA startAddr, int count);
     RVA nextOpAddr(RVA startAddr, int count);

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -145,6 +145,9 @@ public:
     /* Seek functions */
     void seek(QString thing);
     void seek(ut64 offset);
+    void show();
+    void show(ut64 offset); // seek and raise memory widget
+    void show(QString thing);
     void seekPrev();
     void seekNext();
     void updateSeek();

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -151,17 +151,17 @@ public:
      * @brief Raise a memory widget showing current offset, prefer last active
      * memory widget.
      */
-    void show();
+    void showMemoryWidget();
     /**
      * @brief Seek to \p offset and raise a memory widget showing it.
      * @param offset
      */
-    void show(ut64 offset);
+    void seekAndShow(ut64 offset);
     /**
      * @brief \see CutterCore::show(ut64)
      * @param thing - addressable expression
      */
-    void show(QString thing);
+    void seekAndShow(QString thing);
     RVA getOffset();
     RVA prevOpAddr(RVA startAddr, int count);
     RVA nextOpAddr(RVA startAddr, int count);

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -33,8 +33,6 @@ public:
     RCore *operator->() const;
 };
 
-class MemoryDockWidget;
-
 class CutterCore: public QObject
 {
     Q_OBJECT
@@ -155,17 +153,6 @@ public:
     RVA getOffset();
     RVA prevOpAddr(RVA startAddr, int count);
     RVA nextOpAddr(RVA startAddr, int count);
-
-    /* Disassembly/Graph/Hexdump/Pseudocode view priority */
-    enum class MemoryWidgetType { Disassembly, Graph, Hexdump, Pseudocode };
-    MemoryWidgetType getMemoryWidgetPriority() const
-    {
-        return memoryWidgetPriority;
-    }
-    void triggerRaisePrioritizedMemoryWidget()
-    {
-        emit showMemoryWidgetRequested();
-    }
 
     /* Math functions */
     ut64 math(const QString &expr);
@@ -442,8 +429,6 @@ signals:
     void showMemoryWidgetRequested();
 
 private:
-    MemoryWidgetType memoryWidgetPriority;
-
     QString notes;
     RCore *core_ = nullptr;
     AsyncTaskManager *asyncTaskManager;

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -33,6 +33,7 @@ public:
     RCore *operator->() const;
 };
 
+class MemoryDockWidget;
 
 class CutterCore: public QObject
 {
@@ -161,13 +162,17 @@ public:
     {
         return memoryWidgetPriority;
     }
-    void setMemoryWidgetPriority(MemoryWidgetType type)
+    void setMemoryWidgetPriority(MemoryWidgetType type) //TODO: replace
     {
         memoryWidgetPriority = type;
     }
-    void triggerRaisePrioritizedMemoryWidget()
+    void triggerShowMemoryWidget(MemoryWidgetType type)
     {
-        emit raisePrioritizedMemoryWidget(memoryWidgetPriority);
+        //TOOD: implement this
+    }
+    void triggerRaisePrioritizedMemoryWidget() // TODO: replace
+    {
+        emit showMemoryWidgetRequested();
     }
 
     /* Math functions */
@@ -442,6 +447,8 @@ signals:
 
     void newMessage(const QString &msg);
     void newDebugMessage(const QString &msg);
+
+    void showMemoryWidgetRequested();
 
 private:
     MemoryWidgetType memoryWidgetPriority;

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -928,7 +928,9 @@ QMenu *MainWindow::createShowInMenu(QWidget *parent, RVA address)
 
 void MainWindow::setCurrentMemoryWidget(MemoryDockWidget *memoryWidget)
 {
-    lastMemoryWidget = memoryWidget;
+    if (memoryWidget->getSeekable()->isSynchronized()) {
+        lastMemoryWidget = memoryWidget;
+    }
 }
 
 MemoryDockWidget *MainWindow::addNewMemoryWidget(MemoryWidgetType type, RVA address,

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -926,6 +926,11 @@ QMenu *MainWindow::createShowInMenu(QWidget *parent, RVA address)
     return menu;
 }
 
+void MainWindow::setCurrentMemoryWidget(MemoryDockWidget *memoryWidget)
+{
+    lastMemoryWidget = memoryWidget;
+}
+
 MemoryDockWidget *MainWindow::addNewMemoryWidget(MemoryWidgetType type, RVA address,
                                                  bool synchronized)
 {
@@ -984,7 +989,7 @@ void MainWindow::addMemoryDockWidget(MemoryDockWidget *widget)
 {
     connect(widget, &QDockWidget::visibilityChanged, this, [this, widget](bool visibility) {
         if (visibility) {
-            lastMemoryWidget = widget;
+            setCurrentMemoryWidget(widget);
         }
     });
 }

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -903,7 +903,7 @@ QMenu *MainWindow::createShowInMenu(QWidget *parent, RVA address)
     QMenu *menu = new QMenu(parent);
     for (auto &dock : dockWidgets) {
         if (auto memoryWidget = qobject_cast<MemoryDockWidget *>(dock)) {
-            QAction *action = new QAction(memoryWidget->objectName(), menu);
+            QAction *action = new QAction(memoryWidget->windowTitle(), menu);
             connect(action, &QAction::triggered, this, [this, memoryWidget, address](){
                 memoryWidget->getSeekable()->seek(address);
                 memoryWidget->raiseMemoryWidget();

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -171,6 +171,8 @@ void MainWindow::initUI()
     connect(core, SIGNAL(newDebugMessage(const QString &)),
             this->consoleDock, SLOT(addDebugOutput(const QString &)));
 
+    connect(core, &CutterCore::showMemoryWidgetRequested, this, &MainWindow::showMemoryWidget);
+
     updateTasksIndicator();
     connect(core->getAsyncTaskManager(), &AsyncTaskManager::tasksChanged, this,
             &MainWindow::updateTasksIndicator);
@@ -863,6 +865,16 @@ QString MainWindow::getUniqueObjectName(const QString &widgetType) const
     return widgetType + ";"  + QString::number(id);
 }
 
+void MainWindow::showMemoryWidget()
+{
+    if (lastMemoryWidget) {
+        if (lastMemoryWidget->tryRaiseMemoryWidget()) {
+            return;
+        }
+    }
+    //TODO: raise somethig else
+}
+
 void MainWindow::initCorners()
 {
     // TODO: Allow the user to select this option visually in the GUI settings
@@ -889,12 +901,24 @@ void MainWindow::addWidget(QDockWidget* widget)
             }
             updateDockActionsChecked();
         });
-    }
+    }    
+}
+
+void MainWindow::addMemoryDockWidget(MemoryDockWidget *widget)
+{
+    connect(widget, &QDockWidget::visibilityChanged, this, [this, widget](bool visibility) {
+        if (visibility) {
+           lastMemoryWidget = widget;
+        }
+    });
 }
 
 void MainWindow::removeWidget(QDockWidget *widget)
 {
     dockWidgets.removeAll(widget);
+    if (lastMemoryWidget == widget) {
+        lastMemoryWidget = nullptr;
+    }
 }
 
 void MainWindow::updateDockActionChecked(QAction *action)

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -98,6 +98,8 @@ public:
     void addMemoryDockWidget(MemoryDockWidget *widget);
     void removeWidget(QDockWidget *widget);
     void addExtraWidget(CutterDockWidget *extraDock);
+    MemoryDockWidget *addNewMemoryWidget(CutterCore::MemoryWidgetType type, RVA address, bool synchronized = true);
+
 
     void addPluginDockWidget(QDockWidget *dockWidget, QAction *action);
     enum class MenuType { File, Edit, View, Windows, Debug, Help, Plugins };
@@ -114,6 +116,9 @@ public:
 
     QString getUniqueObjectName(const QString &widgetType) const;
     void showMemoryWidget();
+    void showMemoryWidget(CutterCore::MemoryWidgetType type);
+
+    QMenu *createShowInMenu(QWidget *parent, RVA address);
 
 public slots:
     void finalizeOpen();

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -119,6 +119,7 @@ public:
     void showMemoryWidget(MemoryWidgetType type);
 
     QMenu *createShowInMenu(QWidget *parent, RVA address);
+    void setCurrentMemoryWidget(MemoryDockWidget* memoryWidget);
 
 public slots:
     void finalizeOpen();

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -6,6 +6,7 @@
 #include "dialogs/WelcomeDialog.h"
 #include "common/Configuration.h"
 #include "common/InitialOptions.h"
+#include "MemoryDockWidget.h"
 
 #include <memory>
 
@@ -54,7 +55,6 @@ namespace Ui {
 class MainWindow;
 }
 
-
 class MainWindow : public QMainWindow
 {
     Q_OBJECT
@@ -98,7 +98,7 @@ public:
     void addMemoryDockWidget(MemoryDockWidget *widget);
     void removeWidget(QDockWidget *widget);
     void addExtraWidget(CutterDockWidget *extraDock);
-    MemoryDockWidget *addNewMemoryWidget(CutterCore::MemoryWidgetType type, RVA address, bool synchronized = true);
+    MemoryDockWidget *addNewMemoryWidget(MemoryWidgetType type, RVA address, bool synchronized = true);
 
 
     void addPluginDockWidget(QDockWidget *dockWidget, QAction *action);
@@ -116,7 +116,7 @@ public:
 
     QString getUniqueObjectName(const QString &widgetType) const;
     void showMemoryWidget();
-    void showMemoryWidget(CutterCore::MemoryWidgetType type);
+    void showMemoryWidget(MemoryWidgetType type);
 
     QMenu *createShowInMenu(QWidget *parent, RVA address);
 
@@ -277,6 +277,8 @@ private:
     void updateDockActionsChecked();
     void setOverviewData();
     bool isOverviewActive();
+
+    MemoryWidgetType getMemoryWidgetTypeToRestore();
 
     /**
      * @brief Map from a widget type (e.g. DisassemblyWidget::getWidgetType()) to the respective contructor of the widget

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -95,6 +95,7 @@ public:
     void refreshOmniBar(const QStringList &flags);
 
     void addWidget(QDockWidget *widget);
+    void addMemoryDockWidget(MemoryDockWidget *widget);
     void removeWidget(QDockWidget *widget);
     void addExtraWidget(CutterDockWidget *extraDock);
 
@@ -112,6 +113,7 @@ public:
     void messageBoxWarning(QString title, QString message);
 
     QString getUniqueObjectName(const QString &widgetType) const;
+    void showMemoryWidget();
 
 public slots:
     void finalizeOpen();
@@ -275,6 +277,8 @@ private:
      * @brief Map from a widget type (e.g. DisassemblyWidget::getWidgetType()) to the respective contructor of the widget
      */
     QMap<QString, std::function<CutterDockWidget*(MainWindow*, QAction*)>> widgetTypeToConstructorMap;
+
+    MemoryDockWidget* lastMemoryWidget = nullptr;
 };
 
 #endif // MAINWINDOW_H

--- a/src/dialogs/LinkTypeDialog.cpp
+++ b/src/dialogs/LinkTypeDialog.cpp
@@ -67,7 +67,7 @@ void LinkTypeDialog::done(int r)
             QDialog::done(r);
 
             // Seek to the specified address
-            Core()->show(address);
+            Core()->seekAndShow(address);
 
             // Refresh the views
             emit Core()->refreshCodeViews();

--- a/src/dialogs/LinkTypeDialog.cpp
+++ b/src/dialogs/LinkTypeDialog.cpp
@@ -67,7 +67,7 @@ void LinkTypeDialog::done(int r)
             QDialog::done(r);
 
             // Seek to the specified address
-            Core()->seek(address);
+            Core()->show(address);
 
             // Refresh the views
             emit Core()->refreshCodeViews();

--- a/src/dialogs/XrefsDialog.cpp
+++ b/src/dialogs/XrefsDialog.cpp
@@ -75,7 +75,7 @@ void XrefsDialog::on_fromTreeWidget_itemDoubleClicked(QTreeWidgetItem *item, int
     Q_UNUSED(column);
 
     XrefDescription xref = item->data(0, Qt::UserRole).value<XrefDescription>();
-    Core()->seek(xref.to);
+    Core()->show(xref.to);
     this->close();
 }
 
@@ -84,7 +84,7 @@ void XrefsDialog::on_toTreeWidget_itemDoubleClicked(QTreeWidgetItem *item, int c
     Q_UNUSED(column);
 
     XrefDescription xref = item->data(0, Qt::UserRole).value<XrefDescription>();
-    Core()->seek(xref.from);
+    Core()->show(xref.from);
     this->close();
 }
 

--- a/src/dialogs/XrefsDialog.cpp
+++ b/src/dialogs/XrefsDialog.cpp
@@ -75,7 +75,7 @@ void XrefsDialog::on_fromTreeWidget_itemDoubleClicked(QTreeWidgetItem *item, int
     Q_UNUSED(column);
 
     XrefDescription xref = item->data(0, Qt::UserRole).value<XrefDescription>();
-    Core()->show(xref.to);
+    Core()->seekAndShow(xref.to);
     this->close();
 }
 
@@ -84,7 +84,7 @@ void XrefsDialog::on_toTreeWidget_itemDoubleClicked(QTreeWidgetItem *item, int c
     Q_UNUSED(column);
 
     XrefDescription xref = item->data(0, Qt::UserRole).value<XrefDescription>();
-    Core()->show(xref.from);
+    Core()->seekAndShow(xref.from);
     this->close();
 }
 

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -9,6 +9,7 @@
 #include "dialogs/SetToDataDialog.h"
 #include "dialogs/EditFunctionDialog.h"
 #include "dialogs/LinkTypeDialog.h"
+#include "MainWindow.h"
 
 #include <QtCore>
 #include <QShortcut>
@@ -17,16 +18,20 @@
 #include <QApplication>
 #include <QPushButton>
 
-DisassemblyContextMenu::DisassemblyContextMenu(QWidget *parent)
+DisassemblyContextMenu::DisassemblyContextMenu(QWidget *parent, MainWindow* mainWindow)
     :   QMenu(parent),
         offset(0),
-        canCopy(false)
+        canCopy(false),
+        mainWindow(mainWindow)
 {
     initAction(&actionCopy, tr("Copy"), SLOT(on_actionCopy_triggered()), getCopySequence());
     addAction(&actionCopy);
 
     initAction(&actionCopyAddr, tr("Copy address"), SLOT(on_actionCopyAddr_triggered()), getCopyAddressSequence());
     addAction(&actionCopyAddr);
+
+    initAction(&showInSubmenu, tr("Show in"), nullptr);
+    addAction(&showInSubmenu);
 
     copySeparator = addSeparator();
 
@@ -378,6 +383,11 @@ void DisassemblyContextMenu::aboutToShowSlot()
 
     // Decide to show Reverse jmp option
     showReverseJmpQuery();
+
+    if (showInSubmenu.menu() != nullptr) {
+        showInSubmenu.menu()->deleteLater();
+    }
+    showInSubmenu.setMenu(mainWindow->createShowInMenu(this, offset));
 
     // Only show debug options if we are currently debugging
     debugMenu->menuAction()->setVisible(Core()->currentlyDebugging);

--- a/src/menus/DisassemblyContextMenu.h
+++ b/src/menus/DisassemblyContextMenu.h
@@ -10,7 +10,7 @@ class DisassemblyContextMenu : public QMenu
     Q_OBJECT
 
 public:
-    DisassemblyContextMenu(QWidget *parent = nullptr);
+    DisassemblyContextMenu(QWidget *parent, MainWindow* mainWindow);
     ~DisassemblyContextMenu();
 
 signals:
@@ -101,6 +101,7 @@ private:
     RVA offset;
     bool canCopy;
     QString curHighlightedWord; // The current highlighted word
+    MainWindow* mainWindow;
 
     QList<QAction *> anonymousActions;
 
@@ -163,6 +164,8 @@ private:
     QAction actionSetToDataWord;
     QAction actionSetToDataDword;
     QAction actionSetToDataQword;
+
+    QAction showInSubmenu;
 
     // For creating anonymous entries (that are always visible)
     QAction *addAnonymousAction(QString name, const char *slot, QKeySequence shortcut);

--- a/src/widgets/BreakpointWidget.cpp
+++ b/src/widgets/BreakpointWidget.cpp
@@ -168,7 +168,7 @@ void BreakpointWidget::on_breakpointTreeView_doubleClicked(const QModelIndex &in
 {
     BreakpointDescription item = index.data(
                                      BreakpointModel::BreakpointDescriptionRole).value<BreakpointDescription>();
-    Core()->seek(item.addr);
+    Core()->show(item.addr);
 }
 
 void BreakpointWidget::showBreakpointContextMenu(const QPoint &pt)

--- a/src/widgets/BreakpointWidget.cpp
+++ b/src/widgets/BreakpointWidget.cpp
@@ -168,7 +168,7 @@ void BreakpointWidget::on_breakpointTreeView_doubleClicked(const QModelIndex &in
 {
     BreakpointDescription item = index.data(
                                      BreakpointModel::BreakpointDescriptionRole).value<BreakpointDescription>();
-    Core()->show(item.addr);
+    Core()->seekAndShow(item.addr);
 }
 
 void BreakpointWidget::showBreakpointContextMenu(const QPoint &pt)

--- a/src/widgets/ClassesWidget.cpp
+++ b/src/widgets/ClassesWidget.cpp
@@ -634,7 +634,7 @@ void ClassesWidget::on_classesTreeView_doubleClicked(const QModelIndex &index)
         return;
     }
     RVA offset = offsetData.value<RVA>();
-    Core()->show(offset);
+    Core()->seekAndShow(offset);
 }
 
 void ClassesWidget::showContextMenu(const QPoint &pt)
@@ -696,7 +696,7 @@ void ClassesWidget::on_seekToVTableAction_triggered()
         return;
     }
 
-    Core()->show(vtables[0].addr + desc.vtableOffset);
+    Core()->seekAndShow(vtables[0].addr + desc.vtableOffset);
 }
 
 void ClassesWidget::on_addMethodAction_triggered()

--- a/src/widgets/ClassesWidget.cpp
+++ b/src/widgets/ClassesWidget.cpp
@@ -634,7 +634,7 @@ void ClassesWidget::on_classesTreeView_doubleClicked(const QModelIndex &index)
         return;
     }
     RVA offset = offsetData.value<RVA>();
-    Core()->seek(offset);
+    Core()->show(offset);
 }
 
 void ClassesWidget::showContextMenu(const QPoint &pt)
@@ -696,7 +696,7 @@ void ClassesWidget::on_seekToVTableAction_triggered()
         return;
     }
 
-    Core()->seek(vtables[0].addr + desc.vtableOffset);
+    Core()->show(vtables[0].addr + desc.vtableOffset);
 }
 
 void ClassesWidget::on_addMethodAction_triggered()

--- a/src/widgets/CommentsWidget.cpp
+++ b/src/widgets/CommentsWidget.cpp
@@ -272,7 +272,7 @@ void CommentsWidget::on_commentsTreeView_doubleClicked(const QModelIndex &index)
         return;
 
     auto comment = index.data(CommentsModel::CommentDescriptionRole).value<CommentDescription>();
-    Core()->seek(comment.offset);
+    Core()->show(comment.offset);
 }
 
 void CommentsWidget::on_actionHorizontal_triggered()

--- a/src/widgets/CommentsWidget.cpp
+++ b/src/widgets/CommentsWidget.cpp
@@ -272,7 +272,7 @@ void CommentsWidget::on_commentsTreeView_doubleClicked(const QModelIndex &index)
         return;
 
     auto comment = index.data(CommentsModel::CommentDescriptionRole).value<CommentDescription>();
-    Core()->show(comment.offset);
+    Core()->seekAndShow(comment.offset);
 }
 
 void CommentsWidget::on_actionHorizontal_triggered()

--- a/src/widgets/CutterDockWidget.cpp
+++ b/src/widgets/CutterDockWidget.cpp
@@ -86,3 +86,15 @@ QAction *CutterDockWidget::getBoundAction() const
     return action;
 }
 
+QString CutterDockWidget::getDockNumber()
+{
+    auto name = this->objectName();
+    if (name.contains(';')) {
+        auto parts = name.split(';');
+        if (parts.size() >= 2) {
+            return parts[1];
+        }
+    }
+    return QString();
+}
+

--- a/src/widgets/CutterDockWidget.h
+++ b/src/widgets/CutterDockWidget.h
@@ -68,8 +68,9 @@ protected:
     void closeEvent(QCloseEvent *event) override;
     QAction *getBoundAction() const;
 
-private:
     MainWindow *mainWindow;
+
+private:
     QAction *action;
 
     bool isTransient = false;

--- a/src/widgets/CutterDockWidget.h
+++ b/src/widgets/CutterDockWidget.h
@@ -67,6 +67,7 @@ protected:
 
     void closeEvent(QCloseEvent *event) override;
     QAction *getBoundAction() const;
+    QString getDockNumber();
 
     MainWindow *mainWindow;
 

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -29,10 +29,10 @@
 
 #include <cmath>
 
-DisassemblerGraphView::DisassemblerGraphView(QWidget *parent, CutterSeekable* seekable)
+DisassemblerGraphView::DisassemblerGraphView(QWidget *parent, CutterSeekable* seekable, MainWindow* mainWindow)
     : GraphView(parent),
       mFontMetrics(nullptr),
-      blockMenu(new DisassemblyContextMenu(this)),
+      blockMenu(new DisassemblyContextMenu(this, mainWindow)),
       contextMenu(new QMenu(this)),
       seekable(seekable)
 {

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -55,14 +55,6 @@ DisassemblerGraphView::DisassemblerGraphView(QWidget *parent, CutterSeekable* se
     connect(Config(), SIGNAL(fontsUpdated()), this, SLOT(fontsUpdatedSlot()));
     connectSeekChanged(false);
 
-    // Space to switch to disassembly
-    QShortcut *shortcut_disassembly = new QShortcut(QKeySequence(Qt::Key_Space), this);
-    shortcut_disassembly->setContext(Qt::WidgetShortcut);
-    connect(shortcut_disassembly, &QShortcut::activated, this, [] {
-        Core()->triggerShowMemoryWidget(CutterCore::MemoryWidgetType::Disassembly);
-        //Core()->setMemoryWidgetPriority(CutterCore::MemoryWidgetType::Disassembly); // TODO:[#1616] cleanup this
-        //Core()->triggerRaisePrioritizedMemoryWidget();
-    });
     // ESC for previous
     QShortcut *shortcut_escape = new QShortcut(QKeySequence(Qt::Key_Escape), this);
     shortcut_escape->setContext(Qt::WidgetShortcut);
@@ -96,7 +88,6 @@ DisassemblerGraphView::DisassemblerGraphView(QWidget *parent, CutterSeekable* se
     QShortcut *shortcut_prev_instr = new QShortcut(QKeySequence(Qt::Key_K), this);
     shortcut_prev_instr->setContext(Qt::WidgetShortcut);
     connect(shortcut_prev_instr, SIGNAL(activated()), this, SLOT(prevInstr()));
-    shortcuts.append(shortcut_disassembly);
     shortcuts.append(shortcut_escape);
     shortcuts.append(shortcut_zoom_in);
     shortcuts.append(shortcut_zoom_out);

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -59,8 +59,9 @@ DisassemblerGraphView::DisassemblerGraphView(QWidget *parent, CutterSeekable* se
     QShortcut *shortcut_disassembly = new QShortcut(QKeySequence(Qt::Key_Space), this);
     shortcut_disassembly->setContext(Qt::WidgetShortcut);
     connect(shortcut_disassembly, &QShortcut::activated, this, [] {
-        Core()->setMemoryWidgetPriority(CutterCore::MemoryWidgetType::Disassembly);
-        Core()->triggerRaisePrioritizedMemoryWidget();
+        Core()->triggerShowMemoryWidget(CutterCore::MemoryWidgetType::Disassembly);
+        //Core()->setMemoryWidgetPriority(CutterCore::MemoryWidgetType::Disassembly); // TODO:[#1616] cleanup this
+        //Core()->triggerRaisePrioritizedMemoryWidget();
     });
     // ESC for previous
     QShortcut *shortcut_escape = new QShortcut(QKeySequence(Qt::Key_Escape), this);

--- a/src/widgets/DisassemblerGraphView.h
+++ b/src/widgets/DisassemblerGraphView.h
@@ -87,7 +87,7 @@ class DisassemblerGraphView : public GraphView
     };
 
 public:
-    DisassemblerGraphView(QWidget *parent, CutterSeekable* seekable);
+    DisassemblerGraphView(QWidget *parent, CutterSeekable* seekable, MainWindow* mainWindow);
     ~DisassemblerGraphView() override;
     std::unordered_map<ut64, DisassemblyBlock> disassembly_blocks;
     virtual void drawBlock(QPainter &p, GraphView::GraphBlock &block) override;

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -193,8 +193,9 @@ DisassemblyWidget::DisassemblyWidget(MainWindow *main, QAction *action)
 
     // Space to switch to graph
     ADD_ACTION(Qt::Key_Space, Qt::WidgetWithChildrenShortcut, [] {
-        Core()->setMemoryWidgetPriority(CutterCore::MemoryWidgetType::Graph);
-        Core()->triggerRaisePrioritizedMemoryWidget();
+        Core()->triggerShowMemoryWidget(CutterCore::MemoryWidgetType::Graph);
+        //Core()->setMemoryWidgetPriority(CutterCore::MemoryWidgetType::Graph); //TODO:[#1616] cleanup this
+        //Core()->triggerRaisePrioritizedMemoryWidget();
     })
 
     ADD_ACTION(Qt::Key_Escape, Qt::WidgetWithChildrenShortcut, &DisassemblyWidget::seekPrev)

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -161,14 +161,6 @@ DisassemblyWidget::DisassemblyWidget(MainWindow *main, QAction *action)
     connect(Config(), SIGNAL(fontsUpdated()), this, SLOT(fontsUpdatedSlot()));
     connect(Config(), SIGNAL(colorsUpdated()), this, SLOT(colorsUpdatedSlot()));
 
-    connect(this, &QDockWidget::visibilityChanged, this, [](bool visibility) {
-        bool emptyGraph = (Core()->getMemoryWidgetPriority() == CutterCore::MemoryWidgetType::Graph
-                           && Core()->isGraphEmpty());
-        if (visibility && !emptyGraph) {
-            Core()->setMemoryWidgetPriority(CutterCore::MemoryWidgetType::Disassembly);
-        }
-    });
-
     connect(Core(), &CutterCore::refreshAll, this, [this]() {
         refreshDisasm(seekable->getOffset());
     });
@@ -192,10 +184,8 @@ DisassemblyWidget::DisassemblyWidget(MainWindow *main, QAction *action)
     connect(a, &QAction::triggered, this, (slot)); }
 
     // Space to switch to graph
-    ADD_ACTION(Qt::Key_Space, Qt::WidgetWithChildrenShortcut, [] {
-        Core()->triggerShowMemoryWidget(CutterCore::MemoryWidgetType::Graph);
-        //Core()->setMemoryWidgetPriority(CutterCore::MemoryWidgetType::Graph); //TODO:[#1616] cleanup this
-        //Core()->triggerRaisePrioritizedMemoryWidget();
+    ADD_ACTION(Qt::Key_Space, Qt::WidgetWithChildrenShortcut, [this] {
+        mainWindow->showMemoryWidget(CutterCore::MemoryWidgetType::Graph);
     })
 
     ADD_ACTION(Qt::Key_Escape, Qt::WidgetWithChildrenShortcut, &DisassemblyWidget::seekPrev)

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -40,7 +40,7 @@ static DisassemblyTextBlockUserData *getUserData(const QTextBlock &block)
 
 DisassemblyWidget::DisassemblyWidget(MainWindow *main, QAction *action)
     :   MemoryDockWidget(MemoryWidgetType::Disassembly, main, action)
-    ,   mCtxMenu(new DisassemblyContextMenu(this))
+    ,   mCtxMenu(new DisassemblyContextMenu(this, main))
     ,   mDisasScrollArea(new DisassemblyScrollArea(this))
     ,   mDisasTextEdit(new DisassemblyTextEdit(this))
 {
@@ -168,7 +168,6 @@ DisassemblyWidget::DisassemblyWidget(MainWindow *main, QAction *action)
 
     connect(mCtxMenu, SIGNAL(copy()), mDisasTextEdit, SLOT(copy()));
 
-    showInMenu = mCtxMenu->addAction(tr("Show in"));
     mCtxMenu->addSeparator();
     syncIt.setText(tr("Sync/unsync offset"));
     mCtxMenu->addAction(&syncIt);
@@ -456,7 +455,6 @@ void DisassemblyWidget::highlightCurrentLine()
 
 void DisassemblyWidget::showDisasContextMenu(const QPoint &pt)
 {
-    showInMenu->setMenu(mainWindow->createShowInMenu(this, seekable->getOffset()));
     mCtxMenu->exec(mDisasTextEdit->mapToGlobal(pt));
 }
 

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -168,6 +168,7 @@ DisassemblyWidget::DisassemblyWidget(MainWindow *main, QAction *action)
 
     connect(mCtxMenu, SIGNAL(copy()), mDisasTextEdit, SLOT(copy()));
 
+    showInMenu = mCtxMenu->addAction(tr("Show in"));
     mCtxMenu->addSeparator();
     syncIt.setText(tr("Sync/unsync offset"));
     mCtxMenu->addAction(&syncIt);
@@ -455,6 +456,7 @@ void DisassemblyWidget::highlightCurrentLine()
 
 void DisassemblyWidget::showDisasContextMenu(const QPoint &pt)
 {
+    showInMenu->setMenu(mainWindow->createShowInMenu(this, seekable->getOffset()));
     mCtxMenu->exec(mDisasTextEdit->mapToGlobal(pt));
 }
 

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -39,7 +39,7 @@ static DisassemblyTextBlockUserData *getUserData(const QTextBlock &block)
 }
 
 DisassemblyWidget::DisassemblyWidget(MainWindow *main, QAction *action)
-    :   MemoryDockWidget(CutterCore::MemoryWidgetType::Disassembly, main, action)
+    :   MemoryDockWidget(MemoryWidgetType::Disassembly, main, action)
     ,   mCtxMenu(new DisassemblyContextMenu(this))
     ,   mDisasScrollArea(new DisassemblyScrollArea(this))
     ,   mDisasTextEdit(new DisassemblyTextEdit(this))
@@ -185,7 +185,7 @@ DisassemblyWidget::DisassemblyWidget(MainWindow *main, QAction *action)
 
     // Space to switch to graph
     ADD_ACTION(Qt::Key_Space, Qt::WidgetWithChildrenShortcut, [this] {
-        mainWindow->showMemoryWidget(CutterCore::MemoryWidgetType::Graph);
+        mainWindow->showMemoryWidget(MemoryWidgetType::Graph);
     })
 
     ADD_ACTION(Qt::Key_Escape, Qt::WidgetWithChildrenShortcut, &DisassemblyWidget::seekPrev)

--- a/src/widgets/DisassemblyWidget.h
+++ b/src/widgets/DisassemblyWidget.h
@@ -54,7 +54,6 @@ protected:
     DisassemblyScrollArea *mDisasScrollArea;
     DisassemblyTextEdit *mDisasTextEdit;
     DisassemblyLeftPanel *leftPanel;
-    QAction* showInMenu;
     QList<DisassemblyLine> lines;
 
 private:

--- a/src/widgets/DisassemblyWidget.h
+++ b/src/widgets/DisassemblyWidget.h
@@ -54,6 +54,7 @@ protected:
     DisassemblyScrollArea *mDisasScrollArea;
     DisassemblyTextEdit *mDisasTextEdit;
     DisassemblyLeftPanel *leftPanel;
+    QAction* showInMenu;
     QList<DisassemblyLine> lines;
 
 private:

--- a/src/widgets/EntrypointWidget.cpp
+++ b/src/widgets/EntrypointWidget.cpp
@@ -51,5 +51,5 @@ void EntrypointWidget::on_entrypointTreeWidget_itemDoubleClicked(QTreeWidgetItem
         return;
 
     EntrypointDescription ep = item->data(0, Qt::UserRole).value<EntrypointDescription>();
-    Core()->seek(ep.vaddr);
+    Core()->show(ep.vaddr);
 }

--- a/src/widgets/EntrypointWidget.cpp
+++ b/src/widgets/EntrypointWidget.cpp
@@ -51,5 +51,5 @@ void EntrypointWidget::on_entrypointTreeWidget_itemDoubleClicked(QTreeWidgetItem
         return;
 
     EntrypointDescription ep = item->data(0, Qt::UserRole).value<EntrypointDescription>();
-    Core()->show(ep.vaddr);
+    Core()->seekAndShow(ep.vaddr);
 }

--- a/src/widgets/ExportsWidget.cpp
+++ b/src/widgets/ExportsWidget.cpp
@@ -183,5 +183,5 @@ void ExportsWidget::on_exportsTreeView_doubleClicked(const QModelIndex &index)
         return;
 
     ExportDescription exp = index.data(ExportsModel::ExportDescriptionRole).value<ExportDescription>();
-    Core()->seek(exp.vaddr);
+    Core()->show(exp.vaddr);
 }

--- a/src/widgets/ExportsWidget.cpp
+++ b/src/widgets/ExportsWidget.cpp
@@ -183,5 +183,5 @@ void ExportsWidget::on_exportsTreeView_doubleClicked(const QModelIndex &index)
         return;
 
     ExportDescription exp = index.data(ExportsModel::ExportDescriptionRole).value<ExportDescription>();
-    Core()->show(exp.vaddr);
+    Core()->seekAndShow(exp.vaddr);
 }

--- a/src/widgets/FlagsWidget.cpp
+++ b/src/widgets/FlagsWidget.cpp
@@ -174,7 +174,7 @@ void FlagsWidget::on_flagsTreeView_doubleClicked(const QModelIndex &index)
         return;
 
     FlagDescription flag = index.data(FlagsModel::FlagDescriptionRole).value<FlagDescription>();
-    Core()->show(flag.offset);
+    Core()->seekAndShow(flag.offset);
 }
 
 void FlagsWidget::on_flagspaceCombo_currentTextChanged(const QString &arg1)

--- a/src/widgets/FlagsWidget.cpp
+++ b/src/widgets/FlagsWidget.cpp
@@ -174,7 +174,7 @@ void FlagsWidget::on_flagsTreeView_doubleClicked(const QModelIndex &index)
         return;
 
     FlagDescription flag = index.data(FlagsModel::FlagDescriptionRole).value<FlagDescription>();
-    Core()->seek(flag.offset);
+    Core()->show(flag.offset);
 }
 
 void FlagsWidget::on_flagspaceCombo_currentTextChanged(const QString &arg1)

--- a/src/widgets/FunctionsWidget.cpp
+++ b/src/widgets/FunctionsWidget.cpp
@@ -522,7 +522,7 @@ void FunctionsWidget::onFunctionsDoubleClicked(const QModelIndex &index)
 
     FunctionDescription function = index.data(
                                        FunctionModel::FunctionDescriptionRole).value<FunctionDescription>();
-    Core()->seek(function.offset);
+    Core()->show(function.offset);
 }
 
 void FunctionsWidget::showFunctionsContextMenu(const QPoint &pt)
@@ -556,7 +556,7 @@ void FunctionsWidget::on_actionDisasAdd_comment_triggered()
         // Rename function in r2 core
         Core()->setComment(function.offset, comment);
         // Seek to new renamed function
-        Core()->seek(function.offset);
+        Core()->show(function.offset);
         // TODO: Refresh functions tree widget
     }
 }
@@ -581,7 +581,7 @@ void FunctionsWidget::on_actionFunctionsRename_triggered()
         Core()->renameFunction(function.name, new_name);
 
         // Seek to new renamed function
-        Core()->seek(function.offset);
+        Core()->show(function.offset);
     }
 }
 

--- a/src/widgets/FunctionsWidget.cpp
+++ b/src/widgets/FunctionsWidget.cpp
@@ -522,7 +522,7 @@ void FunctionsWidget::onFunctionsDoubleClicked(const QModelIndex &index)
 
     FunctionDescription function = index.data(
                                        FunctionModel::FunctionDescriptionRole).value<FunctionDescription>();
-    Core()->show(function.offset);
+    Core()->seekAndShow(function.offset);
 }
 
 void FunctionsWidget::showFunctionsContextMenu(const QPoint &pt)
@@ -556,7 +556,7 @@ void FunctionsWidget::on_actionDisasAdd_comment_triggered()
         // Rename function in r2 core
         Core()->setComment(function.offset, comment);
         // Seek to new renamed function
-        Core()->show(function.offset);
+        Core()->seekAndShow(function.offset);
         // TODO: Refresh functions tree widget
     }
 }
@@ -581,7 +581,7 @@ void FunctionsWidget::on_actionFunctionsRename_triggered()
         Core()->renameFunction(function.name, new_name);
 
         // Seek to new renamed function
-        Core()->show(function.offset);
+        Core()->seekAndShow(function.offset);
     }
 }
 

--- a/src/widgets/GraphWidget.cpp
+++ b/src/widgets/GraphWidget.cpp
@@ -5,7 +5,7 @@
 #include <QVBoxLayout>
 
 GraphWidget::GraphWidget(MainWindow *main, QAction *action) :
-    MemoryDockWidget(CutterCore::MemoryWidgetType::Graph, main, action)
+    MemoryDockWidget(MemoryWidgetType::Graph, main, action)
 {
     setObjectName(main
                   ? main->getUniqueObjectName(getWidgetType())
@@ -49,7 +49,7 @@ GraphWidget::GraphWidget(MainWindow *main, QAction *action) :
     switchAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     addAction(switchAction);
     connect(switchAction, &QAction::triggered, this, [this] {
-        mainWindow->showMemoryWidget(CutterCore::MemoryWidgetType::Disassembly);
+        mainWindow->showMemoryWidget(MemoryWidgetType::Disassembly);
     });
 
     connect(graphView, &DisassemblerGraphView::graphMoved, this, [ = ]() {

--- a/src/widgets/GraphWidget.cpp
+++ b/src/widgets/GraphWidget.cpp
@@ -57,6 +57,7 @@ GraphWidget::GraphWidget(MainWindow *main, QAction *action) :
     });
     connect(seekable, &CutterSeekable::seekableSeekChanged, this, &GraphWidget::prepareHeader);
     connect(Core(), &CutterCore::functionRenamed, this, &GraphWidget::prepareHeader);
+    graphView->installEventFilter(this);
 }
 
 QWidget *GraphWidget::widgetToFocusOnRaise()

--- a/src/widgets/GraphWidget.cpp
+++ b/src/widgets/GraphWidget.cpp
@@ -23,7 +23,7 @@ GraphWidget::GraphWidget(MainWindow *main, QAction *action) :
     header->setReadOnly(true);
     layout->addWidget(header);
 
-    graphView = new DisassemblerGraphView(layoutWidget, seekable);
+    graphView = new DisassemblerGraphView(layoutWidget, seekable, main);
     layout->addWidget(graphView);
 
     // getting the name of the class is implementation defined, and cannot be

--- a/src/widgets/GraphWidget.cpp
+++ b/src/widgets/GraphWidget.cpp
@@ -40,9 +40,16 @@ GraphWidget::GraphWidget(MainWindow *main, QAction *action) :
     connect(this, &QDockWidget::visibilityChanged, this, [ = ](bool visibility) {
         main->toggleOverview(visibility, this);
         if (visibility) {
-            Core()->setMemoryWidgetPriority(CutterCore::MemoryWidgetType::Graph);
             graphView->onSeekChanged(Core()->getOffset());
         }
+    });
+
+    QAction *switchAction = new QAction(this);
+    switchAction->setShortcut(Qt::Key_Space);
+    switchAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+    addAction(switchAction);
+    connect(switchAction, &QAction::triggered, this, [this] {
+        mainWindow->showMemoryWidget(CutterCore::MemoryWidgetType::Disassembly);
     });
 
     connect(graphView, &DisassemblerGraphView::graphMoved, this, [ = ]() {

--- a/src/widgets/HeadersWidget.cpp
+++ b/src/widgets/HeadersWidget.cpp
@@ -134,5 +134,5 @@ void HeadersWidget::setScrollMode()
 void HeadersWidget::on_headersTreeView_doubleClicked(const QModelIndex &index)
 {
     HeaderDescription item = index.data(HeadersModel::HeaderDescriptionRole).value<HeaderDescription>();
-    Core()->show(item.vaddr);
+    Core()->seekAndShow(item.vaddr);
 }

--- a/src/widgets/HeadersWidget.cpp
+++ b/src/widgets/HeadersWidget.cpp
@@ -134,5 +134,5 @@ void HeadersWidget::setScrollMode()
 void HeadersWidget::on_headersTreeView_doubleClicked(const QModelIndex &index)
 {
     HeaderDescription item = index.data(HeadersModel::HeaderDescriptionRole).value<HeaderDescription>();
-    Core()->seek(item.vaddr);
+    Core()->show(item.vaddr);
 }

--- a/src/widgets/HexdumpWidget.cpp
+++ b/src/widgets/HexdumpWidget.cpp
@@ -17,7 +17,7 @@
 #include <QShortcut>
 
 HexdumpWidget::HexdumpWidget(MainWindow *main, QAction *action) :
-    MemoryDockWidget(CutterCore::MemoryWidgetType::Hexdump, main, action),
+    MemoryDockWidget(MemoryWidgetType::Hexdump, main, action),
     ui(new Ui::HexdumpWidget)
 {
     ui->setupUi(this);

--- a/src/widgets/HexdumpWidget.cpp
+++ b/src/widgets/HexdumpWidget.cpp
@@ -90,6 +90,7 @@ HexdumpWidget::HexdumpWidget(MainWindow *main, QAction *action) :
     });
     connect(ui->hexTextView, &HexWidget::selectionChanged, this, &HexdumpWidget::selectionChanged);
     connect(ui->hexSideTab_2, &QTabWidget::currentChanged, this, &HexdumpWidget::refreshSelectionInfo);
+    ui->hexTextView->installEventFilter(this);
 
     initParsing();
     selectHexPreview();

--- a/src/widgets/HexdumpWidget.cpp
+++ b/src/widgets/HexdumpWidget.cpp
@@ -78,13 +78,6 @@ HexdumpWidget::HexdumpWidget(MainWindow *main, QAction *action) :
     this->ui->hexTextView->addAction(&syncAction);
 
     connect(Config(), SIGNAL(fontsUpdated()), this, SLOT(fontsUpdated()));
-
-    connect(this, &QDockWidget::visibilityChanged, this, [](bool visibility) {
-        if (visibility) {
-            Core()->setMemoryWidgetPriority(CutterCore::MemoryWidgetType::Hexdump);
-        }
-    });
-
     connect(Core(), &CutterCore::refreshAll, this, [this]() { refresh(); });
 
     connect(seekable, &CutterSeekable::seekableSeekChanged, this, &HexdumpWidget::onSeekChanged);

--- a/src/widgets/ImportsWidget.cpp
+++ b/src/widgets/ImportsWidget.cpp
@@ -194,5 +194,5 @@ void ImportsWidget::on_importsTreeView_doubleClicked(const QModelIndex &index)
     if (!index.isValid())
         return;
 
-    Core()->show(index.data(ImportsModel::AddressRole).toLongLong());
+    Core()->seekAndShow(index.data(ImportsModel::AddressRole).toLongLong());
 }

--- a/src/widgets/ImportsWidget.cpp
+++ b/src/widgets/ImportsWidget.cpp
@@ -194,5 +194,5 @@ void ImportsWidget::on_importsTreeView_doubleClicked(const QModelIndex &index)
     if (!index.isValid())
         return;
 
-    Core()->seek(index.data(ImportsModel::AddressRole).toLongLong());
+    Core()->show(index.data(ImportsModel::AddressRole).toLongLong());
 }

--- a/src/widgets/MemoryDockWidget.cpp
+++ b/src/widgets/MemoryDockWidget.cpp
@@ -1,35 +1,37 @@
 #include "MemoryDockWidget.h"
 #include "common/CutterSeekable.h"
-
+#include "MainWindow.h"
 #include <QAction>
 
 MemoryDockWidget::MemoryDockWidget(CutterCore::MemoryWidgetType type, MainWindow *parent, QAction *action)
     : CutterDockWidget(parent, action)
     , mType(type), seekable(new CutterSeekable(this))
 {
-    connect(Core(), &CutterCore::raisePrioritizedMemoryWidget, this, &MemoryDockWidget::handleRaiseMemoryWidget);
+    //connect(Core(), &CutterCore::raisePrioritizedMemoryWidget, this, &MemoryDockWidget::handleRaiseMemoryWidget); //TODO:[#1616] cleanup this
+    if (parent) {
+        parent->addMemoryDockWidget(this);
+    }
     connect(seekable, &CutterSeekable::syncChanged, this, &MemoryDockWidget::updateWindowTitle);
 }
 
-void MemoryDockWidget::handleRaiseMemoryWidget(CutterCore::MemoryWidgetType raiseType)
+bool MemoryDockWidget::tryRaiseMemoryWidget()
 {
     if (!seekable->isSynchronized()) {
-        return;
-    }
-    bool raisingEmptyGraph = (raiseType == CutterCore::MemoryWidgetType::Graph && Core()->isGraphEmpty());
-    if (raisingEmptyGraph) {
-        raiseType = CutterCore::MemoryWidgetType::Disassembly;
+        return false;
     }
 
-    if (raiseType == mType) {
-        if (getBoundAction()) {
-            getBoundAction()->setChecked(true);
-        }
-
-        show();
-        raise();
-        widgetToFocusOnRaise()->setFocus(Qt::FocusReason::TabFocusReason);
+    if (mType == CutterCore::MemoryWidgetType::Graph && Core()->isGraphEmpty()) {
+        return false;
     }
+
+    if (getBoundAction()) {
+        getBoundAction()->setChecked(true);
+    }
+
+    show();
+    raise();
+    widgetToFocusOnRaise()->setFocus(Qt::FocusReason::TabFocusReason);
+    return true;
 }
 
 void MemoryDockWidget::updateWindowTitle()

--- a/src/widgets/MemoryDockWidget.cpp
+++ b/src/widgets/MemoryDockWidget.cpp
@@ -2,6 +2,7 @@
 #include "common/CutterSeekable.h"
 #include "MainWindow.h"
 #include <QAction>
+#include <QEvent>
 
 MemoryDockWidget::MemoryDockWidget(MemoryWidgetType type, MainWindow *parent, QAction *action)
     : CutterDockWidget(parent, action)
@@ -37,6 +38,14 @@ void MemoryDockWidget::raiseMemoryWidget()
     show();
     raise();
     widgetToFocusOnRaise()->setFocus(Qt::FocusReason::TabFocusReason);
+}
+
+bool MemoryDockWidget::eventFilter(QObject *object, QEvent *event)
+{
+    if (event->type() == QEvent::FocusIn) {
+        mainWindow->setCurrentMemoryWidget(this);
+    }
+    return CutterDockWidget::eventFilter(object, event);
 }
 
 void MemoryDockWidget::updateWindowTitle()

--- a/src/widgets/MemoryDockWidget.cpp
+++ b/src/widgets/MemoryDockWidget.cpp
@@ -7,7 +7,6 @@ MemoryDockWidget::MemoryDockWidget(CutterCore::MemoryWidgetType type, MainWindow
     : CutterDockWidget(parent, action)
     , mType(type), seekable(new CutterSeekable(this))
 {
-    //connect(Core(), &CutterCore::raisePrioritizedMemoryWidget, this, &MemoryDockWidget::handleRaiseMemoryWidget); //TODO:[#1616] cleanup this
     if (parent) {
         parent->addMemoryDockWidget(this);
     }
@@ -23,6 +22,13 @@ bool MemoryDockWidget::tryRaiseMemoryWidget()
     if (mType == CutterCore::MemoryWidgetType::Graph && Core()->isGraphEmpty()) {
         return false;
     }
+    raiseMemoryWidget();
+
+    return true;
+}
+
+void MemoryDockWidget::raiseMemoryWidget()
+{
 
     if (getBoundAction()) {
         getBoundAction()->setChecked(true);
@@ -31,7 +37,6 @@ bool MemoryDockWidget::tryRaiseMemoryWidget()
     show();
     raise();
     widgetToFocusOnRaise()->setFocus(Qt::FocusReason::TabFocusReason);
-    return true;
 }
 
 void MemoryDockWidget::updateWindowTitle()

--- a/src/widgets/MemoryDockWidget.cpp
+++ b/src/widgets/MemoryDockWidget.cpp
@@ -50,11 +50,15 @@ bool MemoryDockWidget::eventFilter(QObject *object, QEvent *event)
 
 void MemoryDockWidget::updateWindowTitle()
 {
-    if (seekable->isSynchronized()) {
-        setWindowTitle(getWindowTitle());
-    } else {
-        setWindowTitle(getWindowTitle() + CutterSeekable::tr(" (unsynced)"));
+    QString name = getWindowTitle();
+    QString id = getDockNumber();
+    if (!id.isEmpty()) {
+        name += " " + id;
     }
+    if (!seekable->isSynchronized()) {
+        name += CutterSeekable::tr(" (unsynced)");
+    }
+    setWindowTitle(name);
 }
 
 CutterSeekable* MemoryDockWidget::getSeekable() const

--- a/src/widgets/MemoryDockWidget.cpp
+++ b/src/widgets/MemoryDockWidget.cpp
@@ -3,7 +3,7 @@
 #include "MainWindow.h"
 #include <QAction>
 
-MemoryDockWidget::MemoryDockWidget(CutterCore::MemoryWidgetType type, MainWindow *parent, QAction *action)
+MemoryDockWidget::MemoryDockWidget(MemoryWidgetType type, MainWindow *parent, QAction *action)
     : CutterDockWidget(parent, action)
     , mType(type), seekable(new CutterSeekable(this))
 {
@@ -19,7 +19,7 @@ bool MemoryDockWidget::tryRaiseMemoryWidget()
         return false;
     }
 
-    if (mType == CutterCore::MemoryWidgetType::Graph && Core()->isGraphEmpty()) {
+    if (mType == MemoryWidgetType::Graph && Core()->isGraphEmpty()) {
         return false;
     }
     raiseMemoryWidget();

--- a/src/widgets/MemoryDockWidget.h
+++ b/src/widgets/MemoryDockWidget.h
@@ -16,6 +16,11 @@ public:
     CutterSeekable* getSeekable() const;
 
     bool tryRaiseMemoryWidget();
+    void raiseMemoryWidget();
+    CutterCore::MemoryWidgetType getType() const
+    {
+        return mType;
+    }
 private:
 
     CutterCore::MemoryWidgetType mType;

--- a/src/widgets/MemoryDockWidget.h
+++ b/src/widgets/MemoryDockWidget.h
@@ -24,6 +24,7 @@ public:
     {
         return mType;
     }
+    bool eventFilter(QObject *object, QEvent *event);
 private:
 
     MemoryWidgetType mType;

--- a/src/widgets/MemoryDockWidget.h
+++ b/src/widgets/MemoryDockWidget.h
@@ -6,24 +6,27 @@
 
 class CutterSeekable;
 
+/* Disassembly/Graph/Hexdump/Pseudocode view priority */
+enum class MemoryWidgetType { Disassembly, Graph, Hexdump, Pseudocode };
+
 class MemoryDockWidget : public CutterDockWidget
 {
     Q_OBJECT
 public:
-    MemoryDockWidget(CutterCore::MemoryWidgetType type, MainWindow *parent, QAction *action = nullptr);
+    MemoryDockWidget(MemoryWidgetType type, MainWindow *parent, QAction *action = nullptr);
     ~MemoryDockWidget() {}
 
     CutterSeekable* getSeekable() const;
 
     bool tryRaiseMemoryWidget();
     void raiseMemoryWidget();
-    CutterCore::MemoryWidgetType getType() const
+    MemoryWidgetType getType() const
     {
         return mType;
     }
 private:
 
-    CutterCore::MemoryWidgetType mType;
+    MemoryWidgetType mType;
 
 public slots:
     void updateWindowTitle();

--- a/src/widgets/MemoryDockWidget.h
+++ b/src/widgets/MemoryDockWidget.h
@@ -15,8 +15,8 @@ public:
 
     CutterSeekable* getSeekable() const;
 
+    bool tryRaiseMemoryWidget();
 private:
-    void handleRaiseMemoryWidget(CutterCore::MemoryWidgetType raiseType);
 
     CutterCore::MemoryWidgetType mType;
 

--- a/src/widgets/MemoryMapWidget.cpp
+++ b/src/widgets/MemoryMapWidget.cpp
@@ -152,5 +152,5 @@ void MemoryMapWidget::on_memoryTreeView_doubleClicked(const QModelIndex &index)
 {
     MemoryMapDescription item = index.data(
                                     MemoryMapModel::MemoryDescriptionRole).value<MemoryMapDescription>();
-    Core()->seek(item.addrStart);
+    Core()->show(item.addrStart);
 }

--- a/src/widgets/MemoryMapWidget.cpp
+++ b/src/widgets/MemoryMapWidget.cpp
@@ -152,5 +152,5 @@ void MemoryMapWidget::on_memoryTreeView_doubleClicked(const QModelIndex &index)
 {
     MemoryMapDescription item = index.data(
                                     MemoryMapModel::MemoryDescriptionRole).value<MemoryMapDescription>();
-    Core()->show(item.addrStart);
+    Core()->seekAndShow(item.addrStart);
 }

--- a/src/widgets/Omnibar.cpp
+++ b/src/widgets/Omnibar.cpp
@@ -69,7 +69,7 @@ void Omnibar::on_gotoEntry_returnPressed()
 {
     QString str = this->text();
     if (!str.isEmpty()) {
-        Core()->show(str);
+        Core()->seekAndShow(str);
     }
 
     this->setText("");

--- a/src/widgets/Omnibar.cpp
+++ b/src/widgets/Omnibar.cpp
@@ -69,7 +69,7 @@ void Omnibar::on_gotoEntry_returnPressed()
 {
     QString str = this->text();
     if (!str.isEmpty()) {
-        Core()->seek(str);
+        Core()->show(str);
     }
 
     this->setText("");

--- a/src/widgets/PseudocodeWidget.cpp
+++ b/src/widgets/PseudocodeWidget.cpp
@@ -34,7 +34,7 @@ struct DecompiledCodeTextLine
 
 
 PseudocodeWidget::PseudocodeWidget(MainWindow *main, QAction *action) :
-    MemoryDockWidget(CutterCore::MemoryWidgetType::Pseudocode, main, action),
+    MemoryDockWidget(MemoryWidgetType::Pseudocode, main, action),
     ui(new Ui::PseudocodeWidget)
 {
     ui->setupUi(this);

--- a/src/widgets/PseudocodeWidget.cpp
+++ b/src/widgets/PseudocodeWidget.cpp
@@ -47,12 +47,6 @@ PseudocodeWidget::PseudocodeWidget(MainWindow *main, QAction *action) :
     connect(Config(), SIGNAL(fontsUpdated()), this, SLOT(fontsUpdated()));
     connect(Config(), SIGNAL(colorsUpdated()), this, SLOT(colorsUpdatedSlot()));
 
-    connect(this, &QDockWidget::visibilityChanged, this, [](bool visibility) {
-        if (visibility) {
-            Core()->setMemoryWidgetPriority(CutterCore::MemoryWidgetType::Pseudocode);
-        }
-    });
-
     // TODO Use RefreshDeferrer and remove the refresh button
     connect(ui->refreshButton, &QAbstractButton::clicked, this, [this]() {
         doRefresh(Core()->getOffset());

--- a/src/widgets/RegisterRefsWidget.cpp
+++ b/src/widgets/RegisterRefsWidget.cpp
@@ -179,7 +179,7 @@ void RegisterRefsWidget::on_registerRefTreeView_doubleClicked(const QModelIndex 
 {
     RegisterRefDescription item = index.data(
                                       RegisterRefModel::RegisterRefDescriptionRole).value<RegisterRefDescription>();
-    Core()->seek(item.value);
+    Core()->show(item.value);
 }
 
 void RegisterRefsWidget::showRegRefContextMenu(const QPoint &pt)

--- a/src/widgets/RegisterRefsWidget.cpp
+++ b/src/widgets/RegisterRefsWidget.cpp
@@ -179,7 +179,7 @@ void RegisterRefsWidget::on_registerRefTreeView_doubleClicked(const QModelIndex 
 {
     RegisterRefDescription item = index.data(
                                       RegisterRefModel::RegisterRefDescriptionRole).value<RegisterRefDescription>();
-    Core()->show(item.value);
+    Core()->seekAndShow(item.value);
 }
 
 void RegisterRefsWidget::showRegRefContextMenu(const QPoint &pt)

--- a/src/widgets/RelocsWidget.cpp
+++ b/src/widgets/RelocsWidget.cpp
@@ -147,7 +147,7 @@ void RelocsWidget::on_relocsTreeView_doubleClicked(const QModelIndex &index)
     if (!index.isValid())
         return;
 
-    Core()->seek(index.data(RelocsModel::AddressRole).toLongLong());
+    Core()->show(index.data(RelocsModel::AddressRole).toLongLong());
 }
 
 void RelocsWidget::refreshRelocs()

--- a/src/widgets/RelocsWidget.cpp
+++ b/src/widgets/RelocsWidget.cpp
@@ -147,7 +147,7 @@ void RelocsWidget::on_relocsTreeView_doubleClicked(const QModelIndex &index)
     if (!index.isValid())
         return;
 
-    Core()->show(index.data(RelocsModel::AddressRole).toLongLong());
+    Core()->seekAndShow(index.data(RelocsModel::AddressRole).toLongLong());
 }
 
 void RelocsWidget::refreshRelocs()

--- a/src/widgets/ResourcesWidget.cpp
+++ b/src/widgets/ResourcesWidget.cpp
@@ -107,5 +107,5 @@ void ResourcesWidget::onDoubleClicked(const QModelIndex &index)
         return;
 
     ResourcesDescription res = index.data(Qt::UserRole).value<ResourcesDescription>();
-    Core()->show(res.vaddr);
+    Core()->seekAndShow(res.vaddr);
 }

--- a/src/widgets/ResourcesWidget.cpp
+++ b/src/widgets/ResourcesWidget.cpp
@@ -107,5 +107,5 @@ void ResourcesWidget::onDoubleClicked(const QModelIndex &index)
         return;
 
     ResourcesDescription res = index.data(Qt::UserRole).value<ResourcesDescription>();
-    Core()->seek(res.vaddr);
+    Core()->show(res.vaddr);
 }

--- a/src/widgets/SearchWidget.cpp
+++ b/src/widgets/SearchWidget.cpp
@@ -206,7 +206,7 @@ void SearchWidget::on_searchTreeView_doubleClicked(const QModelIndex &index)
 
     SearchDescription search = index.data(
                                    SearchModel::SearchDescriptionRole).value<SearchDescription>();
-    Core()->show(search.offset);
+    Core()->seekAndShow(search.offset);
 }
 
 void SearchWidget::searchChanged()

--- a/src/widgets/SearchWidget.cpp
+++ b/src/widgets/SearchWidget.cpp
@@ -206,7 +206,7 @@ void SearchWidget::on_searchTreeView_doubleClicked(const QModelIndex &index)
 
     SearchDescription search = index.data(
                                    SearchModel::SearchDescriptionRole).value<SearchDescription>();
-    Core()->seek(search.offset);
+    Core()->show(search.offset);
 }
 
 void SearchWidget::searchChanged()

--- a/src/widgets/SectionsWidget.cpp
+++ b/src/widgets/SectionsWidget.cpp
@@ -303,7 +303,7 @@ void SectionsWidget::onSectionsDoubleClicked(const QModelIndex &index)
     }
 
     auto section = index.data(SectionsModel::SectionDescriptionRole).value<SectionDescription>();
-    Core()->seek(section.vaddr);
+    Core()->show(section.vaddr);
 }
 
 void SectionsWidget::resizeEvent(QResizeEvent *event) {
@@ -470,7 +470,7 @@ void AddrDockScene::mousePressEvent(QGraphicsSceneMouseEvent *event)
         if (event->buttons() & Qt::LeftButton) {
             RVA seekAddr = getAddrFromPos((int)event->scenePos().y(), true);
             disableCenterOn = true;
-            Core()->seek(seekAddr);
+            Core()->show(seekAddr);
             disableCenterOn = false;
             return;
         }

--- a/src/widgets/SectionsWidget.cpp
+++ b/src/widgets/SectionsWidget.cpp
@@ -303,7 +303,7 @@ void SectionsWidget::onSectionsDoubleClicked(const QModelIndex &index)
     }
 
     auto section = index.data(SectionsModel::SectionDescriptionRole).value<SectionDescription>();
-    Core()->show(section.vaddr);
+    Core()->seekAndShow(section.vaddr);
 }
 
 void SectionsWidget::resizeEvent(QResizeEvent *event) {
@@ -470,7 +470,7 @@ void AddrDockScene::mousePressEvent(QGraphicsSceneMouseEvent *event)
         if (event->buttons() & Qt::LeftButton) {
             RVA seekAddr = getAddrFromPos((int)event->scenePos().y(), true);
             disableCenterOn = true;
-            Core()->show(seekAddr);
+            Core()->seekAndShow(seekAddr);
             disableCenterOn = false;
             return;
         }

--- a/src/widgets/SegmentsWidget.cpp
+++ b/src/widgets/SegmentsWidget.cpp
@@ -188,5 +188,5 @@ void SegmentsWidget::onSegmentsDoubleClicked(const QModelIndex &index)
         return;
 
     auto segment = index.data(SegmentsModel::SegmentDescriptionRole).value<SegmentDescription>();
-    Core()->seek(segment.vaddr);
+    Core()->show(segment.vaddr);
 }

--- a/src/widgets/SegmentsWidget.cpp
+++ b/src/widgets/SegmentsWidget.cpp
@@ -188,5 +188,5 @@ void SegmentsWidget::onSegmentsDoubleClicked(const QModelIndex &index)
         return;
 
     auto segment = index.data(SegmentsModel::SegmentDescriptionRole).value<SegmentDescription>();
-    Core()->show(segment.vaddr);
+    Core()->seekAndShow(segment.vaddr);
 }

--- a/src/widgets/StackWidget.cpp
+++ b/src/widgets/StackWidget.cpp
@@ -108,7 +108,7 @@ void StackWidget::onDoubleClicked(const QModelIndex &index)
     // Check if we are clicking on the offset or value columns and seek if it is the case
     if (index.column() <= 1) {
         QString item = index.data().toString();
-        Core()->show(item);
+        Core()->seekAndShow(item);
     }
 }
 
@@ -123,7 +123,7 @@ void StackWidget::customMenuRequested(QPoint pos)
 void StackWidget::seekOffset()
 {
     QString offset = viewStack->selectionModel()->currentIndex().data().toString();
-    Core()->show(offset);
+    Core()->seekAndShow(offset);
 }
 
 void StackWidget::editStack()

--- a/src/widgets/StackWidget.cpp
+++ b/src/widgets/StackWidget.cpp
@@ -108,7 +108,7 @@ void StackWidget::onDoubleClicked(const QModelIndex &index)
     // Check if we are clicking on the offset or value columns and seek if it is the case
     if (index.column() <= 1) {
         QString item = index.data().toString();
-        Core()->seek(item);
+        Core()->show(item);
     }
 }
 
@@ -123,7 +123,7 @@ void StackWidget::customMenuRequested(QPoint pos)
 void StackWidget::seekOffset()
 {
     QString offset = viewStack->selectionModel()->currentIndex().data().toString();
-    Core()->seek(offset);
+    Core()->show(offset);
 }
 
 void StackWidget::editStack()

--- a/src/widgets/StringsWidget.cpp
+++ b/src/widgets/StringsWidget.cpp
@@ -204,7 +204,7 @@ void StringsWidget::on_stringsTreeView_doubleClicked(const QModelIndex &index)
     }
 
     StringDescription str = index.data(StringsModel::StringDescriptionRole).value<StringDescription>();
-    Core()->show(str.vaddr);
+    Core()->seekAndShow(str.vaddr);
 }
 
 void StringsWidget::refreshStrings()

--- a/src/widgets/StringsWidget.cpp
+++ b/src/widgets/StringsWidget.cpp
@@ -204,7 +204,7 @@ void StringsWidget::on_stringsTreeView_doubleClicked(const QModelIndex &index)
     }
 
     StringDescription str = index.data(StringsModel::StringDescriptionRole).value<StringDescription>();
-    Core()->seek(str.vaddr);
+    Core()->show(str.vaddr);
 }
 
 void StringsWidget::refreshStrings()

--- a/src/widgets/SymbolsWidget.cpp
+++ b/src/widgets/SymbolsWidget.cpp
@@ -150,7 +150,7 @@ void SymbolsWidget::on_symbolsTreeView_doubleClicked(const QModelIndex &index)
     }
 
     auto symbol = index.data(SymbolsModel::SymbolDescriptionRole).value<SymbolDescription>();
-    Core()->show(symbol.vaddr);
+    Core()->seekAndShow(symbol.vaddr);
 }
 
 void SymbolsWidget::refreshSymbols()

--- a/src/widgets/SymbolsWidget.cpp
+++ b/src/widgets/SymbolsWidget.cpp
@@ -150,7 +150,7 @@ void SymbolsWidget::on_symbolsTreeView_doubleClicked(const QModelIndex &index)
     }
 
     auto symbol = index.data(SymbolsModel::SymbolDescriptionRole).value<SymbolDescription>();
-    Core()->seek(symbol.vaddr);
+    Core()->show(symbol.vaddr);
 }
 
 void SymbolsWidget::refreshSymbols()

--- a/src/widgets/VTablesWidget.cpp
+++ b/src/widgets/VTablesWidget.cpp
@@ -188,10 +188,10 @@ void VTablesWidget::on_vTableTreeView_doubleClicked(const QModelIndex &index)
 
     QModelIndex parent = index.parent();
     if (parent.isValid()) {
-        Core()->show(index.data(
+        Core()->seekAndShow(index.data(
                          VTableModel::VTableDescriptionRole).value<BinClassMethodDescription>().addr);
     } else {
-        Core()->show(index.data(
+        Core()->seekAndShow(index.data(
                          VTableModel::VTableDescriptionRole).value<VTableDescription>().addr);
     }
 }

--- a/src/widgets/VTablesWidget.cpp
+++ b/src/widgets/VTablesWidget.cpp
@@ -188,10 +188,10 @@ void VTablesWidget::on_vTableTreeView_doubleClicked(const QModelIndex &index)
 
     QModelIndex parent = index.parent();
     if (parent.isValid()) {
-        Core()->seek(index.data(
+        Core()->show(index.data(
                          VTableModel::VTableDescriptionRole).value<BinClassMethodDescription>().addr);
     } else {
-        Core()->seek(index.data(
+        Core()->show(index.data(
                          VTableModel::VTableDescriptionRole).value<VTableDescription>().addr);
     }
 }

--- a/src/widgets/ZignaturesWidget.cpp
+++ b/src/widgets/ZignaturesWidget.cpp
@@ -151,5 +151,5 @@ void ZignaturesWidget::on_zignaturesTreeView_doubleClicked(const QModelIndex &in
 {
     ZignatureDescription item = index.data(
                                     ZignaturesModel::ZignatureDescriptionRole).value<ZignatureDescription>();
-    Core()->seek(item.offset);
+    Core()->show(item.offset);
 }

--- a/src/widgets/ZignaturesWidget.cpp
+++ b/src/widgets/ZignaturesWidget.cpp
@@ -151,5 +151,5 @@ void ZignaturesWidget::on_zignaturesTreeView_doubleClicked(const QModelIndex &in
 {
     ZignatureDescription item = index.data(
                                     ZignaturesModel::ZignatureDescriptionRole).value<ZignatureDescription>();
-    Core()->show(item.offset);
+    Core()->seekAndShow(item.offset);
 }


### PR DESCRIPTION
 <!-- Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request. -->


**Detailed description**

<!-- Explain the **details** for making this change. What existing problem does the pull request solve? Please provide enough information so that others can review your pull request -->

Changes in this PR
* Allow seeking without triggering raise memory widget. This was one of the major causes for unexpected changes in focus.
* Raise memory widget mostly moved to main window from core and each widget.
* Last active widget remembered using a pointer instead of memory widget type. Helps when there are multiple widgets with the same type.
* Initial version for "show in" context menu. Currently added only to disassembly and graph menus. Left adding it to other menus for separate PR as it would be good to also refactor some of the common actions for list widgets with addressable objects like functions, strings, imports, search results and others.

I couldn't quite decide if "show in/new disassembly" and others should create a new synchronized or unsynchronized memory widget. Currently Cutter is designed more for synchronized mode. In future the menu could also be reused for lines with jumps (show target). That should probably use unsynchronized. "Show in" and "show target" doesn't necessarily need to behave exactly the same.

**Parts that could be better**

Name for MainWindow and Core `show(address) ` is open for discussions. 

I am not too happy about using event filter for detecting memory widget activation.

**Test plan (required)**

- perform test case described in #1616 
- switching between disassembly and graph using space
  - works in normal case
  - works when either disassembly or graph widget is closed
  - works when disassembly is side by side with graph, test focus by moving up and down
- test rising last active
  - switch to memory widget (repeat with all)
  - switch to overview
  - double click on function
- test ignore empty graph
  - switch to graph
  - switch to symbol list, double click function observe that it switched to graph
  - switch to string list, double click string literal, observe that it switched to memory widget that isn't graph
- test with multiple widgets of the same kind
- disassembly side by side with hex widget, using master it is sometimes impossible to do keyboard navigation in hexwidget because seek moves focus to disassembly
- side by side use case

![showin3](https://user-images.githubusercontent.com/7101031/61330439-3dc52800-a828-11e9-88fc-214b3d0b78aa.png)

<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**

Closes #1616
