### PR TITLE
Adjust arrow offset calculation.

### DIFF
--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -823,8 +823,7 @@ void DisassemblyLeftPanel::paintEvent(QPaintEvent *event)
     constexpr int arrowWidth = 5;
     int rightOffset = size().rwidth();
     auto tEdit = qobject_cast<DisassemblyTextEdit*>(disas->getTextWidget());
-    int topOffset = int(tEdit->document()->documentMargin() + tEdit->contentsMargins().top() +
-                        disas->contentsMargins().top());
+    int topOffset = int(tEdit->document()->documentMargin() + tEdit->contentsMargins().top());
     int lineHeight = disas->getFontMetrics().height();
     QColor arrowColorDown = ConfigColor("flow");
     QColor arrowColorUp = ConfigColor("cflow");


### PR DESCRIPTION

**Detailed description**

At least on my computer disassembly arrows where pointing near bottom of lines.  `disas->contentsMargins().top()` looked like most likely candidate for incorrect offset. It contains  both the arrow part and text part so I assume it's offset applies to both equally.

**Test plan (required)**

![arrow_top](https://user-images.githubusercontent.com/7101031/61184146-ffc2db00-a652-11e9-8e51-44110da69bba.png)

It would be good for someone else to confirm that this patch fixes offset instead of breaking it on their computers.

