### PR TITLE
Remove old radare2 configuration variable

### DIFF
--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -124,7 +124,6 @@ static const QHash<QString, QVariant> asmOptions = {
     { "asm.tabs.off",       5 },
     { "asm.marks",          false },
     { "asm.refptr",         false },
-    { "asm.movlea",         false },
     { "esil.breakoninvalid",true },
     { "graph.offset",       false}
 };


### PR DESCRIPTION
Radare2 submodule was updated in this PR https://github.com/radareorg/cutter/pull/1652 but the now removed `asm.movlea` option (https://github.com/radare/radare2/pull/14482) was not removed from Cutter codebase.