### PR TITLE
Use more specific stylesheet selecters.

### DIFF
--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -71,8 +71,8 @@ DisassemblyWidget::DisassemblyWidget(MainWindow *main, QAction *action)
     mDisasScrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarPolicy::ScrollBarAlwaysOff);
     // Use stylesheet instead of QWidget::setFrameShape(QFrame::NoShape) to avoid
     // issues with dark and light interface themes
-    mDisasScrollArea->setStyleSheet("border: 0px transparent black;");
-    mDisasTextEdit->setStyleSheet("border: 0px transparent black;");
+    mDisasScrollArea->setStyleSheet("QAbstractScrollArea { border: 0px transparent black; }");
+    mDisasTextEdit->setStyleSheet("QPlainTextEdit { border: 0px transparent black; }");
     mDisasTextEdit->setFocusProxy(this);
     mDisasTextEdit->setFocusPolicy(Qt::ClickFocus);
     mDisasScrollArea->setFocusProxy(this);


### PR DESCRIPTION
**Detailed description**

Prevents unintended application of style to internal subwidgets.

In future use of stylesheets without selector should be avoided even when applied to single widget. Builtin widgets can be internally built from other widgets.

**Test plan (required)**

Screenshot before changes can be seen in #1655

![scrollbar](https://user-images.githubusercontent.com/7101031/61415236-cdd2a280-a8f8-11e9-82cc-66153cc78acb.png)

**Closing issues**

Closes #1655