### PR TITLE
Unify preferences layouts

### DIFF
--- a/src/dialogs/preferences/DebugOptionsWidget.ui
+++ b/src/dialogs/preferences/DebugOptionsWidget.ui
@@ -16,6 +16,9 @@
         <layout class="QVBoxLayout" name="verticalLayout">
             <item>
                 <layout class="QFormLayout" name="formLayout">
+                    <property name="fieldGrowthPolicy">
+                        <enum>QFormLayout::ExpandingFieldsGrow</enum>
+                    </property>
                     <property name="labelAlignment">
                         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
                     </property>
@@ -37,7 +40,14 @@
                         </widget>
                     </item>
                     <item row="1" column="1">
-                        <widget class="QLineEdit" name="debugArgs"/>
+                        <widget class="QLineEdit" name="debugArgs">
+                            <property name="sizePolicy">
+                                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                                    <horstretch>0</horstretch>
+                                    <verstretch>0</verstretch>
+                                </sizepolicy>
+                            </property>
+                        </widget>
                     </item>
                     <item row="2" column="0">
                         <widget class="QLabel" name="esilstackAddr">
@@ -47,7 +57,14 @@
                         </widget>
                     </item>
                     <item row="2" column="1">
-                        <widget class="QLineEdit" name="stackAddr"/>
+                        <widget class="QLineEdit" name="stackAddr">
+                            <property name="sizePolicy">
+                                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                                    <horstretch>0</horstretch>
+                                    <verstretch>0</verstretch>
+                                </sizepolicy>
+                            </property>
+                        </widget>
                     </item>
                     <item row="3" column="0">
                         <widget class="QLabel" name="esilStackSize">
@@ -57,7 +74,14 @@
                         </widget>
                     </item>
                     <item row="3" column="1">
-                        <widget class="QLineEdit" name="stackSize"/>
+                        <widget class="QLineEdit" name="stackSize">
+                            <property name="sizePolicy">
+                                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                                    <horstretch>0</horstretch>
+                                    <verstretch>0</verstretch>
+                                </sizepolicy>
+                            </property>
+                        </widget>
                     </item>
                 </layout>
             </item>

--- a/src/dialogs/preferences/DebugOptionsWidget.ui
+++ b/src/dialogs/preferences/DebugOptionsWidget.ui
@@ -6,111 +6,83 @@
             <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>442</width>
-                <height>225</height>
+                <width>489</width>
+                <height>201</height>
             </rect>
         </property>
         <property name="windowTitle">
             <string>Debug</string>
         </property>
         <layout class="QVBoxLayout" name="verticalLayout">
-            <property name="sizeConstraint">
-                <enum>QLayout::SetMinAndMaxSize</enum>
-            </property>
             <item>
                 <layout class="QFormLayout" name="formLayout">
+                    <property name="labelAlignment">
+                        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+                    </property>
                     <item row="0" column="0">
-                        <layout class="QHBoxLayout" name="pluginSelectionLayout">
-                            <item>
-                                <widget class="QLabel" name="pluginLabel">
-                                    <property name="text">
-                                        <string>Debug Plugin:</string>
-                                    </property>
-                                </widget>
-                            </item>
-                            <item row="0" column="1">
-                                <widget class="QComboBox" name="pluginComboBox">
-                                    <property name="sizePolicy">
-                                        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                                            <horstretch>0</horstretch>
-                                            <verstretch>0</verstretch>
-                                        </sizepolicy>
-                                    </property>
-                                </widget>
-                            </item>
-                        </layout>
-                    </item>
-                    <item row="1" column="0">
-                        <layout class="QHBoxLayout" name="argSelectionLayout">
-                            <item>
-                                <widget class="QLabel" name="argsLabel">
-                                    <property name="text">
-                                        <string>Program Arguments:</string>
-                                    </property>
-                                </widget>
-                            </item>
-                            <item>
-                                <widget class="QLineEdit" name="debugArgs">
-                                    <property name="sizePolicy">
-                                        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                                            <horstretch>0</horstretch>
-                                            <verstretch>0</verstretch>
-                                        </sizepolicy>
-                                    </property>
-                                </widget>
-                            </item>
-                        </layout>
-                    </item>
-                    <item row="2" column="0">
-                        <layout class="QHBoxLayout" name="esilVMOptions1">
-                            <item>
-                                <widget class="QLabel" name="esilstackAddr">
-                                    <property name="text">
-                                        <string>ESIL stack address:</string>
-                                    </property>
-                                </widget>
-                            </item>
-                            <item>
-                                <widget class="QLineEdit" name="stackAddr">
-                                    <property name="sizePolicy">
-                                        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                                            <horstretch>0</horstretch>
-                                            <verstretch>0</verstretch>
-                                        </sizepolicy>
-                                    </property>
-                                </widget>
-                            </item>
-                        </layout>
-                    </item>
-                    <item row="3" column="0">
-                        <layout class="QHBoxLayout" name="esilVMOptions2">
-                            <item>
-                                <widget class="QLabel" name="esilStackSize">
-                                    <property name="text">
-                                        <string>ESIL stack size:</string>
-                                    </property>
-                                </widget>
-                            </item>
-                            <item>
-                                <widget class="QLineEdit" name="stackSize">
-                                    <property name="sizePolicy">
-                                        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                                            <horstretch>0</horstretch>
-                                            <verstretch>0</verstretch>
-                                        </sizepolicy>
-                                    </property>
-                                </widget>
-                            </item>
-                        </layout>
-                    </item>
-                    <item row="4" column="0">
-                        <widget class="QCheckBox" name="esilBreakOnInvalid">
+                        <widget class="QLabel" name="pluginLabel">
                             <property name="text">
-                                <string>Break esil execution when instruction is invalid (esil.breakoninvalid)</string>
+                                <string>Debug Plugin:</string>
                             </property>
                         </widget>
                     </item>
+                    <item row="0" column="1">
+                        <widget class="QComboBox" name="pluginComboBox"/>
+                    </item>
+                    <item row="1" column="0">
+                        <widget class="QLabel" name="argsLabel">
+                            <property name="text">
+                                <string>Program Arguments:</string>
+                            </property>
+                        </widget>
+                    </item>
+                    <item row="1" column="1">
+                        <widget class="QLineEdit" name="debugArgs"/>
+                    </item>
+                    <item row="2" column="0">
+                        <widget class="QLabel" name="esilstackAddr">
+                            <property name="text">
+                                <string>ESIL stack address:</string>
+                            </property>
+                        </widget>
+                    </item>
+                    <item row="2" column="1">
+                        <widget class="QLineEdit" name="stackAddr"/>
+                    </item>
+                    <item row="3" column="0">
+                        <widget class="QLabel" name="esilStackSize">
+                            <property name="text">
+                                <string>ESIL stack size:</string>
+                            </property>
+                        </widget>
+                    </item>
+                    <item row="3" column="1">
+                        <widget class="QLineEdit" name="stackSize"/>
+                    </item>
                 </layout>
+            </item>
+            <item>
+                <widget class="QWidget" name="widget_2" native="true">
+                    <property name="sizePolicy">
+                        <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                        </sizepolicy>
+                    </property>
+                    <widget class="QCheckBox" name="esilBreakOnInvalid">
+                        <property name="geometry">
+                            <rect>
+                                <x>0</x>
+                                <y>0</y>
+                                <width>469</width>
+                                <height>24</height>
+                            </rect>
+                        </property>
+                        <property name="text">
+                            <string>Break esil execution when instruction is invalid (esil.breakoninvalid)</string>
+                        </property>
+                    </widget>
+                </widget>
             </item>
         </layout>
     </widget>

--- a/src/dialogs/preferences/GraphOptionsWidget.ui
+++ b/src/dialogs/preferences/GraphOptionsWidget.ui
@@ -7,51 +7,51 @@
     <x>0</x>
     <y>0</y>
     <width>567</width>
-    <height>300</height>
+    <height>79</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Graph</string>
   </property>
-  <widget class="QWidget" name="">
-   <property name="geometry">
-    <rect>
-     <x>30</x>
-     <y>10</y>
-     <width>253</width>
-     <height>62</height>
-    </rect>
-   </property>
-   <layout class="QGridLayout" name="gridLayout_2">
-    <item row="0" column="0">
-     <widget class="QLabel" name="maxColsLabel">
-      <property name="text">
-       <string>Maximum Line Length:</string>
-      </property>
-     </widget>
-    </item>
-    <item row="0" column="1">
-     <widget class="QSpinBox" name="maxColsSpinBox">
-      <property name="minimum">
-       <number>10</number>
-      </property>
-      <property name="maximum">
-       <number>999999999</number>
-      </property>
-      <property name="singleStep">
-       <number>5</number>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="0" colspan="2">
+  <layout class="QVBoxLayout" name="verticalLayout_3">
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="maxColsLabel">
+       <property name="text">
+        <string>Maximum Line Length:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QSpinBox" name="maxColsSpinBox"/>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QWidget" name="widget" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <widget class="QCheckBox" name="graphOffsetCheckBox">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>208</width>
+        <height>24</height>
+       </rect>
+      </property>
       <property name="text">
-       <string>Show offsets (graph.offset) </string>
+       <string>Show offsets (graph.offset)</string>
       </property>
      </widget>
-    </item>
-   </layout>
-  </widget>
+    </widget>
+   </item>
+  </layout>
  </widget>
  <resources/>
  <connections/>


### PR DESCRIPTION
Change debug preferences layout from this:
![2019-07-17_14-23](https://user-images.githubusercontent.com/1407751/61474790-ad065d80-a989-11e9-8ae6-1d99097c16da.png)

to this:
![2019-07-18_17-11](https://user-images.githubusercontent.com/1407751/61474794-b099e480-a989-11e9-8d06-0b0f38194c92.png)

There are also changes to "Graph" but it looks the same.