### PR TITLE
Added QtVersion inside AboutDialog

### DIFF
--- a/src/dialogs/AboutDialog.cpp
+++ b/src/dialogs/AboutDialog.cpp
@@ -28,7 +28,8 @@ AboutDialog::AboutDialog(QWidget *parent) :
 
     QString aboutString("<h1>Cutter</h1>"
                         + tr("Version") + " " CUTTER_VERSION_FULL "<br/>"
-                        + tr("Using r2-") + R2_GITTAP
+                        + tr("Using r2-") + R2_GITTAP + "<br/>"
+                        + buildQtVersionString()
                         + "<p><b>" + tr("Optional Features:") + "</b><br/>"
                         + QString("Python: %1<br/>").arg(
 #ifdef CUTTER_ENABLE_PYTHON
@@ -91,7 +92,7 @@ void AboutDialog::on_checkForUpdatesButton_clicked()
 
     connect(&updateWorker, &UpdateWorker::checkComplete, &waitDialog, &QProgressDialog::cancel);
     connect(&updateWorker, &UpdateWorker::checkComplete,
-    [&updateWorker](const QVersionNumber &version, const QString & error) {
+    [&updateWorker](const QVersionNumber & version, const QString & error) {
         if (!error.isEmpty()) {
             QMessageBox::critical(nullptr, tr("Error!"), error);
         } else {
@@ -110,4 +111,33 @@ void AboutDialog::on_checkForUpdatesButton_clicked()
 void AboutDialog::on_updatesCheckBox_stateChanged(int)
 {
     Config()->setAutoUpdateEnabled(!Config()->getAutoUpdateEnabled());
+}
+
+static QString compilerString()
+{
+#if defined(Q_CC_CLANG) // must be before GNU, because clang claims to be GNU too
+    QString isAppleString;
+#if defined(__apple_build_version__) // Apple clang has other version numbers
+    isAppleString = QLatin1String(" (Apple)");
+#endif
+    return QLatin1String("Clang " ) + QString::number(__clang_major__) + QLatin1Char('.')
+           + QString::number(__clang_minor__) + isAppleString;
+#elif defined(Q_CC_GNU)
+    return QLatin1String("GCC " ) + QLatin1String(__VERSION__);
+#elif defined(Q_CC_MSVC)
+    if (_MSC_VER > 1999)
+        return QLatin1String("MSVC <unknown>");
+    if (_MSC_VER >= 1910)
+        return QLatin1String("MSVC 2017");
+    if (_MSC_VER >= 1900)
+        return QLatin1String("MSVC 2015");
+#endif
+    return QLatin1String("<unknown compiler>");
+}
+
+QString AboutDialog::buildQtVersionString(void)
+{
+    return tr("Based on Qt %1 (%2, %3 bit)").arg(QLatin1String(qVersion()),
+                                                 compilerString(),
+                                                 QString::number(QSysInfo::WordSize));
 }

--- a/src/dialogs/AboutDialog.h
+++ b/src/dialogs/AboutDialog.h
@@ -38,6 +38,8 @@ private slots:
 
 private:
     std::unique_ptr<Ui::AboutDialog> ui;
+
+    QString buildQtVersionString(void);
 };
 
 #endif // ABOUTDIALOG_H


### PR DESCRIPTION
**Detailed description**
Added QtVersion to AboutDialog.

![image](https://user-images.githubusercontent.com/10772605/61480455-50f60600-a996-11e9-9fb4-fb926696e1ed.png)


**Closing issues**
Closes https://github.com/radareorg/cutter/issues/1488
