### PR TITLE
Fixed file name display in new file dialog

### DIFF
--- a/src/core/CutterCommon.h
+++ b/src/core/CutterCommon.h
@@ -9,10 +9,10 @@
 #include <QString>
 
 // Workaround for compile errors on Windows
-#ifdef _WIN32
+#ifdef Q_OS_WIN
 #undef min
 #undef max
-#endif //_WIN32
+#endif // Q_OS_WIN
 
 // radare2 list iteration macros
 #define CutterRListForeach(list, it, type, x) \


### PR DESCRIPTION
Before:
Cf the linked issue below

Now:
![image](https://user-images.githubusercontent.com/10772605/61554442-3f2b6600-aa5d-11e9-8994-c63e47b7acb7.png)

This is not the intended solution, but I think it's fine as well.

Fixes https://github.com/radareorg/cutter/issues/1642