### PR TITLE
Fix arrow offset when scrolling with arrows or zooming in.

### DIFF
--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -379,18 +379,21 @@ void DisassemblyWidget::zoomIn()
 {
     mDisasTextEdit->zoomIn();
     updateMaxLines();
+    leftPanel->update();
 }
 
 void DisassemblyWidget::zoomOut()
 {
     mDisasTextEdit->zoomOut();
     updateMaxLines();
+    leftPanel->update();
 }
 
 void DisassemblyWidget::zoomReset()
 {
     setupFonts();
     updateMaxLines();
+    leftPanel->update();
 }
 
 void DisassemblyWidget::highlightCurrentLine()
@@ -746,6 +749,12 @@ void DisassemblyScrollArea::resetScrollBars()
     verticalScrollBar()->blockSignals(false);
 }
 
+qreal DisassemblyTextEdit::textOffset() const
+{
+    return (blockBoundingGeometry(document()->begin()).topLeft() +
+            contentOffset()).y();
+}
+
 bool DisassemblyTextEdit::viewportEvent(QEvent *event)
 {
     switch (event->type()) {
@@ -826,7 +835,7 @@ void DisassemblyLeftPanel::paintEvent(QPaintEvent *event)
     constexpr int arrowWidth = 5;
     int rightOffset = size().rwidth();
     auto tEdit = qobject_cast<DisassemblyTextEdit*>(disas->getTextWidget());
-    int topOffset = int(tEdit->document()->documentMargin() + tEdit->contentsMargins().top());
+    int topOffset = int(tEdit->contentsMargins().top() + tEdit->textOffset());
     int lineHeight = disas->getFontMetrics().height();
     QColor arrowColorDown = ConfigColor("flow");
     QColor arrowColorUp = ConfigColor("cflow");

--- a/src/widgets/DisassemblyWidget.h
+++ b/src/widgets/DisassemblyWidget.h
@@ -125,6 +125,7 @@ public:
         this->lockScroll = lock;
     }
 
+    qreal textOffset() const;
 protected:
     bool viewportEvent(QEvent *event) override;
     void scrollContentsBy(int dx, int dy) override;


### PR DESCRIPTION

**Detailed description**



**Test plan (required)**

* scroll down using arrow keys at least 5-10 times, make sure arrows have correct offset
* test zoom bug - happens most reliably at very large zoom

* tested with 2 different font sizes
* few different qt theme engines on Linux

**Closing issues**

Closes #1657