### PR TITLE
Don't use scr.html in CommandTask

### DIFF
--- a/src/common/CommandTask.cpp
+++ b/src/common/CommandTask.cpp
@@ -10,7 +10,9 @@ CommandTask::CommandTask(const QString &cmd, ColorMode colorMode, bool outFormat
 void CommandTask::runTask() {
     TempConfig tempConfig;
     tempConfig.set("scr.color", colorMode);
-    tempConfig.set("scr.html", outFormatHtml);
     auto res = Core()->cmdTask(cmd);
+    if (outFormatHtml) {
+        res = CutterCore::ansiEscapeToHtml(res);
+    }
     emit finished(res);
 }


### PR DESCRIPTION
This is better because it doesn't force scr.html on every command, which would also apply in scripts that are run for example.