### PR TITLE
Transfer zoom events from overview to main graph.

### DIFF
--- a/src/widgets/OverviewView.cpp
+++ b/src/widgets/OverviewView.cpp
@@ -27,6 +27,13 @@ void OverviewView::setData(int baseWidth, int baseHeight,
     viewport()->update();
 }
 
+void OverviewView::centreRect()
+{
+    qreal w = rangeRect.width();
+    qreal h = rangeRect.height();
+    initialDiff = QPointF(w / 2,  h / 2);
+}
+
 OverviewView::~OverviewView()
 {
 }

--- a/src/widgets/OverviewView.h
+++ b/src/widgets/OverviewView.h
@@ -32,6 +32,8 @@ public:
     void setData(int baseWidth, int baseHeight, std::unordered_map<ut64, GraphBlock> baseBlocks,
                  DisassemblerGraphView::EdgeConfigurationMapping baseEdgeConfigurations);
 
+    void centreRect();
+
 public slots:
     /**
      * @brief scale and center all nodes in, then run update

--- a/src/widgets/OverviewWidget.cpp
+++ b/src/widgets/OverviewWidget.cpp
@@ -18,6 +18,14 @@ OverviewWidget::OverviewWidget(MainWindow *main, QAction *action) :
     graphDataRefreshDeferrer = createRefreshDeferrer([this]() {
         updateGraphData();
     });
+
+    // Zoom shortcuts
+    QShortcut *shortcut_zoom_in = new QShortcut(QKeySequence(Qt::Key_Plus), this);
+    shortcut_zoom_in->setContext(Qt::WidgetWithChildrenShortcut);
+    connect(shortcut_zoom_in, &QShortcut::activated, this, [this](){ zoomTarget(1); });
+    QShortcut *shortcut_zoom_out = new QShortcut(QKeySequence(Qt::Key_Minus), this);
+    shortcut_zoom_out->setContext(Qt::WidgetWithChildrenShortcut);
+    connect(shortcut_zoom_out, &QShortcut::activated, this, [this](){ zoomTarget(-1); });
 }
 
 OverviewWidget::~OverviewWidget() {}
@@ -65,6 +73,14 @@ void OverviewWidget::setUserOpened(bool userOpened)
     emit userOpenedChanged(userOpened);
 }
 
+void OverviewWidget::zoomTarget(int d)
+{
+    if (!targetGraphWidget) {
+        return;
+    }
+    targetGraphWidget->getGraphView()->zoom(QPointF(0.5, 0.5), d);
+}
+
 void OverviewWidget::setTargetGraphWidget(GraphWidget *widget)
 {
     if (widget == targetGraphWidget) {
@@ -88,6 +104,12 @@ void OverviewWidget::setTargetGraphWidget(GraphWidget *widget)
     updateGraphData();
     updateRangeRect();
     setIsAvailable(targetGraphWidget != nullptr);
+}
+
+void OverviewWidget::wheelEvent(QWheelEvent *event)
+{
+    zoomTarget(event->angleDelta().y() / 90);
+    graphView->centreRect();
 }
 
 void OverviewWidget::targetClosed()

--- a/src/widgets/OverviewWidget.h
+++ b/src/widgets/OverviewWidget.h
@@ -31,6 +31,7 @@ private:
 
     void setIsAvailable(bool isAvailable);
     void setUserOpened(bool userOpened);
+    void zoomTarget(int d);
 
 private slots:
     void showEvent(QShowEvent *event) override;
@@ -87,6 +88,7 @@ public:
     bool getUserOpened() const          { return userOpened; }
 
     OverviewView *getGraphView() const  { return graphView; }
+    void wheelEvent(QWheelEvent *event) override;
 };
 
 #endif // OverviewWIDGET_H


### PR DESCRIPTION
**Detailed description**

No idea when would someone want to zoom with keyboard while focusing on overview. Mousewheel somewhat makes sense. Implemented this so that issue can be closed and stops attracting more people. 

**Test plan (required)**

* click on overview, press + -
* use scrollwheel

**Closing issues**

Closes #1592