### PR TITLE
Fix ClassesWidget sorting by vtable offset

### DIFF
--- a/src/widgets/ClassesWidget.cpp
+++ b/src/widgets/ClassesWidget.cpp
@@ -440,6 +440,8 @@ QVariant AnalClassesModel::data(const QModelIndex &index, int role) const
                     return QIcon(new SvgIconEngine(QString(":/img/icons/home.svg"), QPalette::WindowText));
                 }
                 return QVariant();
+            case VTableRole:
+                return -1;
             case NameRole:
                 return base.className;
             case TypeRole:

--- a/src/widgets/ClassesWidget.cpp
+++ b/src/widgets/ClassesWidget.cpp
@@ -470,6 +470,8 @@ QVariant AnalClassesModel::data(const QModelIndex &index, int role) const
                     return QIcon(new SvgIconEngine(QString(":/img/icons/fork.svg"), QPalette::WindowText));
                 }
                 return QVariant();
+            case VTableRole:
+                return QVariant::fromValue(meth.vtableOffset);
             case OffsetRole:
                 return QVariant::fromValue(meth.addr);
             case NameRole:
@@ -544,6 +546,14 @@ bool ClassesSortFilterProxyModel::lessThan(const QModelIndex &left, const QModel
         auto right_type = right.data(ClassesModel::TypeRole).value<ClassesModel::RowType>();
         if (left_type != right_type) {
             return left_type < right_type;
+        }
+    }
+    // fallthrough
+    case ClassesModel::VTABLE: {
+        auto left_vtable = left.data(ClassesModel::VTableRole).toLongLong();
+        auto right_vtable = right.data(ClassesModel::VTableRole).toLongLong();
+        if (left_vtable != right_vtable) {
+            return left_vtable < right_vtable;
         }
     }
     // fallthrough

--- a/src/widgets/ClassesWidget.h
+++ b/src/widgets/ClassesWidget.h
@@ -53,6 +53,14 @@ public:
      */
     static const int TypeRole = Qt::UserRole + 2;
 
+    /**
+     * @brief VTable role of data for QModelIndex
+     *
+     * will contain values of type long long for sorting
+     * by vtable offset
+     */
+    static const int VTableRole = Qt::UserRole + 3;
+
     explicit ClassesModel(QObject *parent = nullptr) : QAbstractItemModel(parent) {}
 
     QVariant headerData(int section, Qt::Orientation orientation,


### PR DESCRIPTION
Sorting by vtable offset in ClassesWidget was comparing strings instead of values

Before:
![2019-07-23_22-50_1](https://user-images.githubusercontent.com/1407751/61746617-67d49800-ad9c-11e9-946c-dfb2925b7dda.png)

After:
![2019-07-23_22-50](https://user-images.githubusercontent.com/1407751/61746634-6f943c80-ad9c-11e9-9faa-743c3dcae479.png)
