### PR TITLE
Allow returning to top level in sdb widget.

### DIFF
--- a/src/widgets/SdbWidget.cpp
+++ b/src/widgets/SdbWidget.cpp
@@ -17,14 +17,12 @@ SdbWidget::SdbWidget(MainWindow *main, QAction *action) :
     path.clear();
 
     connect(Core(), SIGNAL(refreshAll()), this, SLOT(reload()));
-    reload(nullptr);
+    reload();
 }
 
 void SdbWidget::reload(QString _path)
 {
-    if (!_path.isNull()) {
-        path = _path;
-    }
+    path = _path;
 
     ui->lineEdit->setText(path);
     /* insert root sdb keyvalue pairs */
@@ -44,7 +42,9 @@ void SdbWidget::reload(QString _path)
     qhelpers::adjustColumns(ui->treeWidget, 0);
     /* namespaces */
     keys = Core()->sdbList(path);
-    keys.append("..");
+    if (!path.isEmpty()) {
+        keys.append("..");
+    }
     for (const QString &key : keys) {
         QTreeWidgetItem *tempItem = new QTreeWidgetItem();
         tempItem->setText(0, key + "/");

--- a/src/widgets/SdbWidget.h
+++ b/src/widgets/SdbWidget.h
@@ -25,7 +25,7 @@ private slots:
     void on_lockButton_clicked();
     void on_treeWidget_itemChanged(QTreeWidgetItem *item, int column);
 
-    void reload(QString _path = nullptr);
+    void reload(QString _path = QString());
 
 private:
     std::unique_ptr<Ui::SdbWidget> ui;


### PR DESCRIPTION
**Detailed description**

Fix bug that prevented returning to top level in sdb widget.
Don't show "../" item when located at top level.

**Test plan (required)**

* Open sdb widget
* Enter bin/
* double click on "../"
* observe that widget has returned to top level
* Enter bin/cur
* Return to top level by clicking ../ twice
* Make sure "../" isn't shown when located at top level.

**Closing issues**
