### PR TITLE
Add context menu to PseudocodeWidget

### DIFF
--- a/src/widgets/PseudocodeWidget.h
+++ b/src/widgets/PseudocodeWidget.h
@@ -13,15 +13,20 @@ class PseudocodeWidget;
 class QTextEdit;
 class QSyntaxHighlighter;
 class QTextCursor;
+class DisassemblyContextMenu;
 struct DecompiledCodeTextLine;
 
 class PseudocodeWidget : public MemoryDockWidget
 {
     Q_OBJECT
+protected:
+    DisassemblyContextMenu *mCtxMenu;
 
 public:
     explicit PseudocodeWidget(MainWindow *main, QAction *action = nullptr);
     ~PseudocodeWidget();
+public slots:
+    void showDisasContextMenu(const QPoint &pt);
 
 private slots:
     void fontsUpdated();


### PR DESCRIPTION
 <!-- Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request. -->

![contextMenu_decompiler_r2dec](https://user-images.githubusercontent.com/20182642/62568378-b5b9c780-b895-11e9-9c78-b3fcabc2b277.gif)


**Detailed description**

This pull request will add support for DisassemblyContextMenu to PseudocodeWidget.
Currently, PseudocodeWidget will assign an address for each line in the pseudo code. When the context menu will be triggered, it will be triggered for the assigned address,

Current know limitations:
 - Multiple instructions that are aggregated by the decompiler to a single line will be assigned only with one address, So if you'll have this assembly:
```
lea rdi, str.HelloWorld
call sym.imp.puts
```
This will be aggregated by some decompilers (e.g r2dec) to: 
```
sym.imp.puts (str.HelloWorld);
```

Thus, when opening the context menu, it will be aware only to the instruction of "call sym.imp.puts`, thus, won't allow to edit the name of `str.HelloWorld`.

 - Some content of the context menu will affect only the disassembly and not the decompiled code. For example, adding an Analysis Hint that sets some immediate value to a String ("Set as... -> String")


**Test Plan**
0. make sure you have some decompiler installed and working in Cutter. For example, r2dec
1. open a binary in cutter
2. Open the Pseudocode widget
3. Choose a function you want to decompile and seek to it
4. Click on the "Refresh" button in the Pseudocode widget
5. Right click in a line of interest in the decompiled code
6. Interact with the context menu. For example, add comment
7. Use Keyboard shortcuts such as <kbd>;</kbd> to perform actions
2. 