### PR TITLE
Don't interpret data as code in xrefs from table.

### DIFF
--- a/src/dialogs/XrefsDialog.cpp
+++ b/src/dialogs/XrefsDialog.cpp
@@ -41,7 +41,9 @@ void XrefsDialog::fillRefs(QList<XrefDescription> refs, QList<XrefDescription> x
     for (const auto &xref : refs) {
         auto *tempItem = new QTreeWidgetItem();
         tempItem->setText(0, xref.to_str);
-        tempItem->setText(1, Core()->disassembleSingleInstruction(xref.to));
+        if (xref.type != "DATA") {
+            tempItem->setText(1, Core()->disassembleSingleInstruction(xref.to));
+        }
         tempItem->setText(2, xrefTypeString(xref.type));
         tempItem->setData(0, Qt::UserRole, QVariant::fromValue(xref));
         ui->fromTreeWidget->insertTopLevelItem(0, tempItem);
@@ -187,19 +189,14 @@ void XrefsDialog::fillRefsForAddress(RVA addr, QString name, bool whole_function
 
 QString XrefsDialog::xrefTypeString(const QString &type)
 {
-    switch (type.toStdString()[0]) {
-    case R_ANAL_REF_TYPE_CALL:
-        return QString("Call");
-    case R_ANAL_REF_TYPE_CODE:
+    if (type == "CODE") {
         return QString("Code");
-    case R_ANAL_REF_TYPE_DATA:
+    } else if (type == "CALL") {
+        return QString("Call");
+    } else if (type == "DATA") {
         return QString("Data");
-    case R_ANAL_REF_TYPE_NULL:
-        return QString();
-    case R_ANAL_REF_TYPE_STRING:
+    } else if (type == "STRING") {
         return QString("String");
-    default:
-        break;
     }
     return type;
 }


### PR DESCRIPTION

**Detailed description**

When instruction refers to data most ot the time there is no point trying interpret it as code so don't show anything instead.

**Test plan (required)**

Positive test
![xref3](https://user-images.githubusercontent.com/7101031/62834324-1c9efe00-bc53-11e9-86c1-a6ff799ced5e.png)
Negative test
![xref2](https://user-images.githubusercontent.com/7101031/62834299-d2b61800-bc52-11e9-9c8e-f2454515720e.png)


**Closing issues**
Fixes one of the problems identified in #1707 . Does not closes it.