### PR TITLE
Add context menu entries for target address

### DIFF
--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -915,7 +915,7 @@ QMenu *MainWindow::createShowInMenu(QWidget *parent, RVA address)
     auto createAddNewWidgetAction = [this, menu, address](QString label, MemoryWidgetType type) {
         QAction *action = new QAction(label, menu);
         connect(action, &QAction::triggered, this, [this, address, type](){
-            addNewMemoryWidget(type, address, true);
+            addNewMemoryWidget(type, address, false);
         });
         menu->addAction(action);
     };

--- a/src/menus/DisassemblyContextMenu.h
+++ b/src/menus/DisassemblyContextMenu.h
@@ -166,6 +166,7 @@ private:
     QAction actionSetToDataQword;
 
     QAction showInSubmenu;
+    QList<QAction*> showTargetMenuActions;
 
     // For creating anonymous entries (that are always visible)
     QAction *addAnonymousAction(QString name, const char *slot, QKeySequence shortcut);
@@ -197,5 +198,7 @@ private:
         Type type;
     };
     QVector<ThingUsedHere> getThingUsedHere(RVA offset);
+
+    void updateTargetMenuActions(const QVector<ThingUsedHere> &targets);
 };
 #endif // DISASSEMBLYCONTEXTMENU_H

--- a/src/menus/DisassemblyContextMenu.h
+++ b/src/menus/DisassemblyContextMenu.h
@@ -10,7 +10,7 @@ class DisassemblyContextMenu : public QMenu
     Q_OBJECT
 
 public:
-    DisassemblyContextMenu(QWidget *parent, MainWindow* mainWindow);
+    DisassemblyContextMenu(QWidget *parent, MainWindow *mainWindow);
     ~DisassemblyContextMenu();
 
 signals:
@@ -101,7 +101,7 @@ private:
     RVA offset;
     bool canCopy;
     QString curHighlightedWord; // The current highlighted word
-    MainWindow* mainWindow;
+    MainWindow *mainWindow;
 
     QList<QAction *> anonymousActions;
 
@@ -184,5 +184,18 @@ private:
     void addSetToDataMenu();
     void addEditMenu();
     void addDebugMenu();
+
+    struct ThingUsedHere {
+        QString name;
+        RVA offset;
+        enum class Type {
+            Var,
+            Function,
+            Flag,
+            Address
+        };
+        Type type;
+    };
+    QVector<ThingUsedHere> getThingUsedHere(RVA offset);
 };
 #endif // DISASSEMBLYCONTEXTMENU_H


### PR DESCRIPTION
 <!-- Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request. -->


**Detailed description**

When right clicking on instruction referring to some adress (move, jump or call) show additional context menu entries with "show in" actions and copy address.

Reuses logic from "rename x (used here)".

**Test plan (required)**

* right click on instruction reading from global variable
* right click on instruction calling function
* verify that show in works and uses correct address
* verify that copy address works

![cm11](https://user-images.githubusercontent.com/7101031/62967749-4ce0cb00-be12-11e9-983b-8aeac3ad087a.png)
![cm12](https://user-images.githubusercontent.com/7101031/62967750-4ce0cb00-be12-11e9-9d7d-ac4d615705a5.png)

**Known limitations**

* Expressions using registers point to address near 0 because registers are assumed to be 0, the same already happened before with "rename x (used here)"
* Register values during emulation mode are not taken into account

**~~Closing~~ issues**

Part of the functionality from #1682