### PR TITLE
Add support to remember IO mode for recent files

### DIFF
--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -191,6 +191,34 @@ void Configuration::setRecentFolder(const QString &dir)
 }
 
 /**
+ * @brief Get the previously selected io mode for the given file
+ * @param filePath - path to the file whose previously selected IO mode is to be found
+ * @return string representing the IO mode for the file, if it exists in the settings,
+ * empty string otherwise
+ */
+QString Configuration::getIOMode(const QString &filePath)
+{
+    return s.value("ioModes").toHash()[filePath].toString();
+}
+
+/**
+ * @brief Save the IO mode for the given file
+ * If the ioMode is empty, then it is removed from the settings
+ * @param filePath - path to the file whose IO mode is to be saved
+ * @param ioMode - IO mode of the file
+ */
+void Configuration::setIOMode(const QString &filePath, const QString &ioMode)
+{
+    QHash<QString, QVariant> ioModes = s.value("ioModes").toHash();
+    if (ioMode.isEmpty()) {
+        ioModes.remove(filePath);
+    } else {
+        ioModes[filePath] = ioMode;
+    }
+    s.setValue("ioModes", ioModes);
+}
+
+/**
  * @brief Configuration::setFilesTabLastClicked
  * Set the new file dialog last clicked tab
  * @param lastClicked

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -154,6 +154,9 @@ public:
     QString getSelectedDecompiler();
     void setSelectedDecompiler(const QString &id);
 
+    QString getIOMode(const QString &filePath);
+    void setIOMode(const QString &filePath, const QString &ioMode);
+
 signals:
     void fontsUpdated();
     void colorsUpdated();

--- a/src/dialogs/NewFileDialog.h
+++ b/src/dialogs/NewFileDialog.h
@@ -41,6 +41,8 @@ private slots:
 
     void on_tabWidget_currentChanged(int index);
 
+    void on_newFileEdit_textChanged(const QString &filePath);
+
 protected:
     void dragEnterEvent(QDragEnterEvent *event);
     void dropEvent(QDropEvent *event);


### PR DESCRIPTION
Closes #1681 
Opening a file from the NewFileDialog will remember its IO mode. Whenever a file is selected from the recent files list, the IO mode will change to the one which was used to open the file earlier.
