### PR TITLE
Restore hexwidget cursor after making empty selection.

### DIFF
--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -442,8 +442,10 @@ void HexWidget::mousePressEvent(QMouseEvent *event)
 void HexWidget::mouseReleaseEvent(QMouseEvent *event)
 {
     if (event->button() == Qt::LeftButton) {
-        if (selection.isEmpty())
+        if (selection.isEmpty()) {
             selection.init(cursor.address);
+            cursorEnabled = true;
+        }
         updatingSelection = false;
     }
 }


### PR DESCRIPTION
 <!-- Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request. -->


**Detailed description**

Restore blinking cursor after making empty selection using mouse. This can easily happen by accident when slightly dragging the mouse when clicking to change cursor position.

**Test plan (required)**

In hexwidget

first case
* press left mouse key
* slightly move cursor, but less than would be required for for selecting a byte
* release left mouse key
* observe if cursor is blinking in the correct position (before the patch cursor should disappear)

second case
* start selecting bytes with mouse
* move the mouse to initial position so that selection is empty  
* observe if cursor is blinking in the correct position

**Closing issues**

<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
