### PR TITLE
Fix Disassembly widget focus detection.

### DIFF
--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -668,7 +668,7 @@ bool DisassemblyWidget::eventFilter(QObject *obj, QEvent *event)
 
         return true;
     }
-    return CutterDockWidget::eventFilter(obj, event);
+    return MemoryDockWidget::eventFilter(obj, event);
 }
 
 QString DisassemblyWidget::getWindowTitle() const


### PR DESCRIPTION
 <!-- Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request. -->


**Detailed description**

Fix disassembly widget focus detection for detecting last active memory widget


**Test plan (required)**

* open hexdump widget side by side with disassmbly
* move strings tab on top of hexdump
* activate hexdump
* switch to strings 
* click on disassembly widget
* double click a string in string widget
* observe that seek changed and focus changed to disassembly widget, before fix it would raise hexdump widget

**Closing issues**

<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
