### PR TITLE
Fix Main Task Synchronization

### DIFF
--- a/src/common/R2Task.cpp
+++ b/src/common/R2Task.cpp
@@ -3,7 +3,7 @@
 
 R2Task::R2Task(const QString &cmd, bool transient)
 {
-    task = r_core_task_new(Core()->core(),
+    task = r_core_task_new(Core()->core_,
         true,
         cmd.toLocal8Bit().constData(),
         static_cast<RCoreTaskCallback>(&R2Task::taskFinishedCallback),
@@ -29,17 +29,17 @@ void R2Task::taskFinished()
 
 void R2Task::startTask()
 {
-    r_core_task_enqueue(Core()->core(), task);
+    r_core_task_enqueue(Core()->core_, task);
 }
 
 void R2Task::breakTask()
 {
-    r_core_task_break(Core()->core(), task->id);
+    r_core_task_break(Core()->core_, task->id);
 }
 
 void R2Task::joinTask()
 {
-    r_core_task_join(Core()->core(), nullptr, task->id);
+    r_core_task_join(Core()->core_, nullptr, task->id);
 }
 
 QString R2Task::getResult()


### PR DESCRIPTION
This fixes some delicate race conditions.

From now on, when accessing the RCore in CutterCore, we must always use `CORE_LOCK();` and access it like `core->...` and everything will be fine.