### PR TITLE
Allow seeking in unsynchronized widgets using 'g'.

### DIFF
--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -844,8 +844,8 @@ void MainWindow::updateDockActionsChecked()
 
 MemoryWidgetType MainWindow::getMemoryWidgetTypeToRestore()
 {
-    if (lastMemoryWidget) {
-        return lastMemoryWidget->getType();
+    if (lastSyncMemoryWidget) {
+        return lastSyncMemoryWidget->getType();
     }
     return MemoryWidgetType::Disassembly;
 }
@@ -876,8 +876,8 @@ QString MainWindow::getUniqueObjectName(const QString &widgetType) const
 
 void MainWindow::showMemoryWidget()
 {
-    if (lastMemoryWidget) {
-        if (lastMemoryWidget->tryRaiseMemoryWidget()) {
+    if (lastSyncMemoryWidget) {
+        if (lastSyncMemoryWidget->tryRaiseMemoryWidget()) {
             return;
         }
     }
@@ -929,8 +929,14 @@ QMenu *MainWindow::createShowInMenu(QWidget *parent, RVA address)
 void MainWindow::setCurrentMemoryWidget(MemoryDockWidget *memoryWidget)
 {
     if (memoryWidget->getSeekable()->isSynchronized()) {
-        lastMemoryWidget = memoryWidget;
+        lastSyncMemoryWidget = memoryWidget;
     }
+    lastMemoryWidget = memoryWidget;
+}
+
+MemoryDockWidget *MainWindow::getLastMemoryWidget()
+{
+    return lastMemoryWidget;
 }
 
 MemoryDockWidget *MainWindow::addNewMemoryWidget(MemoryWidgetType type, RVA address,
@@ -999,6 +1005,9 @@ void MainWindow::addMemoryDockWidget(MemoryDockWidget *widget)
 void MainWindow::removeWidget(QDockWidget *widget)
 {
     dockWidgets.removeAll(widget);
+    if (lastSyncMemoryWidget == widget) {
+        lastSyncMemoryWidget = nullptr;
+    }
     if (lastMemoryWidget == widget) {
         lastMemoryWidget = nullptr;
     }

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -120,6 +120,7 @@ public:
 
     QMenu *createShowInMenu(QWidget *parent, RVA address);
     void setCurrentMemoryWidget(MemoryDockWidget* memoryWidget);
+    MemoryDockWidget* getLastMemoryWidget();
 
 public slots:
     void finalizeOpen();
@@ -286,6 +287,7 @@ private:
      */
     QMap<QString, std::function<CutterDockWidget*(MainWindow*, QAction*)>> widgetTypeToConstructorMap;
 
+    MemoryDockWidget* lastSyncMemoryWidget = nullptr;
     MemoryDockWidget* lastMemoryWidget = nullptr;
 };
 

--- a/src/widgets/Omnibar.cpp
+++ b/src/widgets/Omnibar.cpp
@@ -1,5 +1,6 @@
 #include "Omnibar.h"
 #include "core/MainWindow.h"
+#include "CutterSeekable.h"
 
 #include <QStringListModel>
 #include <QCompleter>
@@ -69,7 +70,13 @@ void Omnibar::on_gotoEntry_returnPressed()
 {
     QString str = this->text();
     if (!str.isEmpty()) {
-        Core()->seekAndShow(str);
+        if (auto memoryWidget = main->getLastMemoryWidget()) {
+            RVA offset = Core()->math(str);
+            memoryWidget->getSeekable()->seek(offset);
+            memoryWidget->raiseMemoryWidget();
+        } else {
+            Core()->seekAndShow(str);
+        }
     }
 
     this->setText("");


### PR DESCRIPTION
 <!-- Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request. -->


**Detailed description**

Before the changes omnibar changed the global seek.

After the change omnibar changes seek of last active memory widget regardless of it's synchronization state. Any changes in global seek happen indirectly if performing seek in synchronized widget.


**Test plan (required)**

* Open two synchronized memory widgets side by  and perform seek in omnibar, observe that both memory widgets changed the position
* unsync one of the widgets
* click on the synchronized widget
* press g and seek somewhere, observe that unsynchronized widget didn't change
* click on unsynchronized widget
* pres g and seek, observe that only unsynchronized widget changed
* put all memory widgets in one tab group
* switch to search widget
* perform seek and observe that a memory widget gets shown
* close recently viewed memory widgets
* seek and observe that one of remaining memory widgets get shown
* close all memory widgets
* perform seek and observe that a disassembly widget gets created (poor placement of newly created memory widgets is a separate problem)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**

<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
