### PR TITLE
Read global offset when opening a new hexdump widget.

### DIFF
--- a/src/widgets/HexdumpWidget.cpp
+++ b/src/widgets/HexdumpWidget.cpp
@@ -94,6 +94,9 @@ HexdumpWidget::HexdumpWidget(MainWindow *main, QAction *action) :
 
     initParsing();
     selectHexPreview();
+
+    // apply initial offset
+    refresh(seekable->getOffset());
 }
 
 void HexdumpWidget::onSeekChanged(RVA addr)


### PR DESCRIPTION
 <!-- Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request. -->


**Detailed description**

Ensures that newly created hexdump widgets show current offset instead of 0x00000000.

**Test plan (required)**

* Open disassembly widget at non zero offset
* Add new hexdump using "Window/Add Hexdump"
* observe that newly created hexdump widget shows the same offset as disassembly widget (before fix it showed 0x0)

**Closing issues**

<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
