### PR TITLE
Fix edit variable dialog when asm.ucase is on

### DIFF
--- a/src/dialogs/EditVariablesDialog.cpp
+++ b/src/dialogs/EditVariablesDialog.cpp
@@ -23,7 +23,7 @@ EditVariablesDialog::EditVariablesDialog(RVA offset, QString initialVar, QWidget
     int index = 0;
     for (const VariableDescription &var : variables) {
         ui->dropdownLocalVars->addItem(var.name, QVariant::fromValue(var));
-        if (var.name == initialVar) {
+        if (!QString::compare(var.name, initialVar, Qt::CaseInsensitive)) {
             currentItemIndex = index;
         }
         index++;


### PR DESCRIPTION
This PR aims at fixing https://github.com/radareorg/cutter/issues/1749.

Currently, the way `asm.ucase` works is that it will set everything uppercase (including stack variable names). I am not sure that this PR is the proper way of fixing it, but it works™.