### PR TITLE
Graph export without graphviz

### DIFF
--- a/src/Cutter.pro
+++ b/src/Cutter.pro
@@ -510,7 +510,7 @@ HEADERS  += \
     common/AddressableItemModel.h \
     widgets/ListDockWidget.h \
     widgets/AddressableItemList.h \
-    dialogs/MultitypeFileSaveDialog.cpp
+    dialogs/MultitypeFileSaveDialog.h
 
 GRAPHVIZ_HEADERS = widgets/GraphGridLayout.h
 

--- a/src/Cutter.pro
+++ b/src/Cutter.pro
@@ -374,7 +374,8 @@ SOURCES += \
     common/Decompiler.cpp \
     menus/AddressableItemContextMenu.cpp \
     common/AddressableItemModel.cpp \
-    widgets/ListDockWidget.cpp
+    widgets/ListDockWidget.cpp \
+    dialogs/MultitypeFileSaveDialog.cpp
 
 GRAPHVIZ_SOURCES = \
     widgets/GraphvizLayout.cpp
@@ -508,7 +509,8 @@ HEADERS  += \
     menus/AddressableItemContextMenu.h \
     common/AddressableItemModel.h \
     widgets/ListDockWidget.h \
-    widgets/AddressableItemList.h
+    widgets/AddressableItemList.h \
+    dialogs/MultitypeFileSaveDialog.cpp
 
 GRAPHVIZ_HEADERS = widgets/GraphGridLayout.h
 

--- a/src/dialogs/MultitypeFileSaveDialog.cpp
+++ b/src/dialogs/MultitypeFileSaveDialog.cpp
@@ -2,6 +2,7 @@
 
 #include "MultitypeFileSaveDialog.h"
 
+#include <QMessageBox>
 
 
 MultitypeFileSaveDialog::MultitypeFileSaveDialog(QWidget *parent,
@@ -52,6 +53,20 @@ MultitypeFileSaveDialog::TypeDescription MultitypeFileSaveDialog::selectedType()
     } else {
         return *filterIt;
     }
+}
+
+void MultitypeFileSaveDialog::done(int r)
+{
+    if (r == QDialog::Accepted) {
+        QFileInfo info(selectedFiles().first());
+        auto selectedType = this->selectedType();
+        if (selectedType.extension.isEmpty()) {
+            QMessageBox::warning(this, tr("File save error"),
+                                 tr("Unrecognized extension '%1'").arg(info.suffix()));
+            return;
+        }
+    }
+    QFileDialog::done(r);
 }
 
 void MultitypeFileSaveDialog::onFilterSelected(const QString &filter)

--- a/src/dialogs/MultitypeFileSaveDialog.cpp
+++ b/src/dialogs/MultitypeFileSaveDialog.cpp
@@ -1,0 +1,88 @@
+#include "CutterConfig.h"
+
+#include "MultitypeFileSaveDialog.h"
+
+
+
+MultitypeFileSaveDialog::MultitypeFileSaveDialog(QWidget *parent,
+                                                 const QString &caption,
+                                                 const QString &directory)
+    : QFileDialog(parent, caption, directory)
+{
+    this->setAcceptMode(AcceptMode::AcceptSave);
+    this->setFileMode(QFileDialog::AnyFile);
+
+    connect(this, &QFileDialog::filterSelected, this, &MultitypeFileSaveDialog::onFilterSelected);
+}
+
+void MultitypeFileSaveDialog::setTypes(const QVector<MultitypeFileSaveDialog::TypeDescription>
+                                       types, bool useDetection)
+{
+    this->hasTypeDetection = useDetection;
+    this->types.clear();
+    this->types.reserve(types.size() + (useDetection ? 1 : 0));
+    if (useDetection) {
+        this->types.push_back(TypeDescription{tr("Detect type (*)"), "", QVariant()});
+    }
+    this->types.append(types);
+    QStringList filters;
+    for (auto &type : this->types) {
+        filters.append(type.description);
+    }
+    setNameFilters(filters);
+    onFilterSelected(this->types.first().description);
+}
+
+MultitypeFileSaveDialog::TypeDescription MultitypeFileSaveDialog::selectedType() const
+{
+    auto filterIt = findType(this->selectedNameFilter());
+    if (filterIt == this->types.end()) {
+        return {};
+    }
+    if (hasTypeDetection && filterIt == this->types.begin()) {
+        QFileInfo info(this->selectedFiles().first());
+        QString currentSuffix = info.suffix();
+        filterIt = std::find_if(types.begin(), types.end(), [&currentSuffix](const TypeDescription & v) {
+            return currentSuffix == v.extension;
+        });
+        if (filterIt != types.end()) {
+            return *filterIt;
+        }
+        return {};
+    } else {
+        return *filterIt;
+    }
+}
+
+void MultitypeFileSaveDialog::onFilterSelected(const QString &filter)
+{
+    auto it = findType(filter);
+    if (it == types.end()) {
+        return;
+    }
+    bool detectionSelected = hasTypeDetection && it == types.begin();
+    if (detectionSelected) {
+        setDefaultSuffix(types[1].extension);
+    } else {
+        setDefaultSuffix(it->extension);
+    }
+    if (!this->selectedFiles().empty()) {
+        QString currentSelection = this->selectedFiles().first();
+        QFileInfo info(currentSelection);
+        if (!detectionSelected) {
+            QString currentSuffix = info.suffix();
+            if (currentSuffix != it->extension) {
+                selectFile(info.dir().filePath(info.completeBaseName() + "." + it->extension));
+            }
+        }
+    }
+}
+
+QVector<MultitypeFileSaveDialog::TypeDescription>::const_iterator
+MultitypeFileSaveDialog::findType(const QString &description) const
+{
+    return std::find_if(types.begin(), types.end(),
+    [&description](const TypeDescription & v) {
+        return v.description == description;
+    });
+}

--- a/src/dialogs/MultitypeFileSaveDialog.h
+++ b/src/dialogs/MultitypeFileSaveDialog.h
@@ -1,0 +1,33 @@
+#ifndef MULTITYPEFILESAVEDIALOG_H
+#define MULTITYPEFILESAVEDIALOG_H
+
+#include <QDialog>
+#include <QFileDialog>
+#include <QVariant>
+
+class MultitypeFileSaveDialog : public QFileDialog
+{
+    Q_OBJECT
+
+public:
+    struct TypeDescription {
+        QString description;
+        QString extension;
+        QVariant data;
+    };
+
+    explicit MultitypeFileSaveDialog(QWidget *parent = nullptr,
+                                     const QString &caption = QString(),
+                                     const QString &directory = QString());
+
+    void setTypes(const QVector<TypeDescription> types, bool useDetection = true);
+    TypeDescription selectedType() const;
+private:
+    void onFilterSelected(const QString &filter);
+    QVector<TypeDescription>::const_iterator findType(const QString &description) const;
+
+    QVector<TypeDescription> types;
+    bool hasTypeDetection;
+};
+
+#endif // MULTITYPEFILESAVEDIALOG_H

--- a/src/dialogs/MultitypeFileSaveDialog.h
+++ b/src/dialogs/MultitypeFileSaveDialog.h
@@ -22,6 +22,8 @@ public:
 
     void setTypes(const QVector<TypeDescription> types, bool useDetection = true);
     TypeDescription selectedType() const;
+protected:
+    void done(int r) override;
 private:
     void onFilterSelected(const QString &filter);
     QVector<TypeDescription>::const_iterator findType(const QString &description) const;

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -1080,26 +1080,29 @@ void DisassemblerGraphView::on_actionExportGraph_triggered()
     case GraphExportType::Svg:
         this->saveAsSvg(filePath);
         break;
-    }
 
-    //TODO: handle graphviz export
-    /*int startIdx = dialog.selectedNameFilter().lastIndexOf("*.") + 2;
-    int count = dialog.selectedNameFilter().length() - startIdx - 1;
-    QString format = dialog.selectedNameFilter().mid(startIdx, count);
-    QString fileName = dialog.selectedFiles()[0];
-    if (format != "dot") {
+    case GraphExportType::GVDot: {
+        QFile file(filePath);
+        if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+            qWarning() << "Can't open file";
+            return;
+        }
+        QTextStream fileOut(&file);
+        fileOut << Core()->cmd("agfd $FB");
+    }
+    break;
+
+    case GraphExportType::GVJson:
+    case GraphExportType::GVGif:
+    case GraphExportType::GVPng:
+    case GraphExportType::GVJpeg:
+    case GraphExportType::GVPostScript:
+    case GraphExportType::GVSvg:
         TempConfig tempConfig;
-        tempConfig.set("graph.gv.format", format);
-        qWarning() << Core()->cmd(QString("agfw \"%1\" @ $FB").arg(fileName));
-        return;
+        tempConfig.set("graph.gv.format", selectedType.extension);
+        qWarning() << Core()->cmd(QString("agfw \"%1\" @ $FB").arg(filePath));
+        break;
     }
-    QFile file(fileName);
-    if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
-        qWarning() << "Can't open file";
-        return;
-    }
-    QTextStream fileOut(&file);
-    fileOut << Core()->cmd("agfd $FB");*/
 }
 
 void DisassemblerGraphView::mousePressEvent(QMouseEvent *event)

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -1013,7 +1013,7 @@ void DisassemblerGraphView::blockTransitionedTo(GraphView::GraphBlock *to)
 
 
 enum class GraphExportType {
-    Gif, Png, Jpeg, Svg, GVDot, GVJson,
+    Png, Jpeg, Svg, GVDot, GVJson,
     GVGif, GVPng, GVJpeg, GVPostScript, GVSvg
 };
 Q_DECLARE_METATYPE(GraphExportType);
@@ -1022,7 +1022,6 @@ void DisassemblerGraphView::on_actionExportGraph_triggered()
 {
     QVector<MultitypeFileSaveDialog::TypeDescription> types = {
         {tr("PNG (*.png)"), "png", QVariant::fromValue(GraphExportType::Png)},
-        {tr("GIF (*.gif)"), "gif", QVariant::fromValue(GraphExportType::Gif)},
         {tr("JPEG (*.jpg)"), "jpg", QVariant::fromValue(GraphExportType::Jpeg)},
         {tr("SVG (*.svg)"), "svg", QVariant::fromValue(GraphExportType::Svg)}
     };
@@ -1054,7 +1053,6 @@ void DisassemblerGraphView::on_actionExportGraph_triggered()
     QString filePath = dialog.selectedFiles().first();
     switch (selectedType.data.value<GraphExportType>()) {
     case GraphExportType::Png:
-    case GraphExportType::Gif:
     case GraphExportType::Jpeg:
         this->saveAsBitmap(filePath);
         break;

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -1067,7 +1067,7 @@ void DisassemblerGraphView::on_actionExportGraph_triggered()
             return;
         }
         QTextStream fileOut(&file);
-        fileOut << Core()->cmd("agfd $FB");
+        fileOut << Core()->cmd(QString("agfd 0x%1").arg(currentFcnAddr, 0, 16));
     }
     break;
 
@@ -1079,7 +1079,7 @@ void DisassemblerGraphView::on_actionExportGraph_triggered()
     case GraphExportType::GVSvg:
         TempConfig tempConfig;
         tempConfig.set("graph.gv.format", selectedType.extension);
-        qWarning() << Core()->cmd(QString("agfw \"%1\" @ $FB").arg(filePath));
+        qWarning() << Core()->cmd(QString("agfw \"%1\" @ 0x%2").arg(filePath).arg(currentFcnAddr, 0, 16));
         break;
     }
 }

--- a/src/widgets/DisassemblerGraphView.h
+++ b/src/widgets/DisassemblerGraphView.h
@@ -87,10 +87,11 @@ class DisassemblerGraphView : public GraphView
     };
 
 public:
-    DisassemblerGraphView(QWidget *parent, CutterSeekable* seekable, MainWindow* mainWindow);
+    DisassemblerGraphView(QWidget *parent, CutterSeekable *seekable, MainWindow *mainWindow);
     ~DisassemblerGraphView() override;
     std::unordered_map<ut64, DisassemblyBlock> disassembly_blocks;
-    virtual void drawBlock(QPainter &p, GraphView::GraphBlock &block) override;
+    virtual void drawBlock(QPainter &p, GraphView::GraphBlock &block, const QPoint &offset,
+                           qreal scale) override;
     virtual void blockClicked(GraphView::GraphBlock &block, QMouseEvent *event, QPoint pos) override;
     virtual void blockDoubleClicked(GraphView::GraphBlock &block, QMouseEvent *event,
                                     QPoint pos) override;
@@ -109,6 +110,12 @@ public:
     using EdgeConfigurationMapping = std::map<std::pair<ut64, ut64>, EdgeConfiguration>;
     EdgeConfigurationMapping getEdgeConfigurations();
 
+    /**
+     * @brief keep the current addr of the fcn of Graph
+     * Everytime overview updates its contents, it compares this value with the one in Graph
+     * if they aren't same, then Overview needs to update the pixmap cache.
+     */
+    ut64 currentFcnAddr = RVA_INVALID; // TODO: make this less public
 public slots:
     void refreshView();
     void colorsUpdatedSlot();
@@ -210,7 +217,7 @@ signals:
     void viewZoomed();
     void graphMoved();
     void resized();
-    void nameChanged(const QString& name);
+    void nameChanged(const QString &name);
 
 public:
     bool isGraphEmpty()     { return emptyGraph; }

--- a/src/widgets/DisassemblerGraphView.h
+++ b/src/widgets/DisassemblerGraphView.h
@@ -90,15 +90,15 @@ public:
     DisassemblerGraphView(QWidget *parent, CutterSeekable *seekable, MainWindow *mainWindow);
     ~DisassemblerGraphView() override;
     std::unordered_map<ut64, DisassemblyBlock> disassembly_blocks;
-    virtual void drawBlock(QPainter &p, GraphView::GraphBlock &block, const QPoint &offset,
-                           qreal scale) override;
+    virtual void drawBlock(QPainter &p, GraphView::GraphBlock &block, bool interactive) override;
     virtual void blockClicked(GraphView::GraphBlock &block, QMouseEvent *event, QPoint pos) override;
     virtual void blockDoubleClicked(GraphView::GraphBlock &block, QMouseEvent *event,
                                     QPoint pos) override;
     virtual bool helpEvent(QHelpEvent *event) override;
     virtual void blockHelpEvent(GraphView::GraphBlock &block, QHelpEvent *event, QPoint pos) override;
     virtual GraphView::EdgeConfiguration edgeConfiguration(GraphView::GraphBlock &from,
-                                                           GraphView::GraphBlock *to) override;
+                                                           GraphView::GraphBlock *to,
+                                                           bool interactive) override;
     virtual void blockTransitionedTo(GraphView::GraphBlock *to) override;
 
     void loadCurrentGraph();

--- a/src/widgets/DisassemblerGraphView.h
+++ b/src/widgets/DisassemblerGraphView.h
@@ -110,6 +110,13 @@ public:
     using EdgeConfigurationMapping = std::map<std::pair<ut64, ut64>, EdgeConfiguration>;
     EdgeConfigurationMapping getEdgeConfigurations();
 
+    enum class GraphExportType {
+        Png, Jpeg, Svg, GVDot, GVJson,
+        GVGif, GVPng, GVJpeg, GVPostScript, GVSvg
+    };
+    void exportGraph(QString filePath, GraphExportType type);
+    void exportR2GraphvizGraph(QString filePath, QString type);
+
     /**
      * @brief keep the current addr of the fcn of Graph
      * Everytime overview updates its contents, it compares this value with the one in Graph

--- a/src/widgets/GraphView.h
+++ b/src/widgets/GraphView.h
@@ -35,13 +35,13 @@ public:
 
     enum class Layout {
         GridNarrow
-        ,GridMedium
-        ,GridWide
+        , GridMedium
+        , GridWide
 #ifdef CUTTER_ENABLE_GRAPHVIZ
-        ,GraphvizOrtho
-        ,GraphvizOrthoLR
-        ,GraphvizPolyline
-        ,GraphvizPolylineLR
+        , GraphvizOrtho
+        , GraphvizOrthoLR
+        , GraphvizPolyline
+        , GraphvizPolylineLR
 #endif
     };
 
@@ -65,16 +65,13 @@ public:
      */
     void showRectangle(const QRect &rect, bool anywhere = false);
 
-    /**
-     * @brief keep the current addr of the fcn of Graph
-     * Everytime overview updates its contents, it compares this value with the one in Graph
-     * if they aren't same, then Overview needs to update the pixmap cache.
-     */
-    ut64 currentFcnAddr = RVA_INVALID; // TODO: move application specific code out of graph view
-
     void setGraphLayout(Layout layout);
     Layout getGraphLayout() const { return graphLayout; }
 
+    void paint(QPainter &p, QPoint offset, QRect area, qreal scale = 1.0); //TODO:
+
+    void saveAsBitmap(QString path, const char *format = nullptr);
+    void saveAsSvg(QString path);
 protected:
     std::unordered_map<ut64, GraphBlock> blocks;
     QColor backgroundColor = QColor(Qt::white);
@@ -89,7 +86,8 @@ protected:
     void computeGraph(ut64 entry);
 
     // Callbacks that should be overridden
-    virtual void drawBlock(QPainter &p, GraphView::GraphBlock &block);
+    virtual void drawBlock(QPainter &p, GraphView::GraphBlock &block, const QPoint &offset,
+                           qreal scale);  //TODO: it should be possible to avoid manual scaling using qt drawing transformation API
     virtual void blockClicked(GraphView::GraphBlock &block, QMouseEvent *event, QPoint pos);
     virtual void blockDoubleClicked(GraphView::GraphBlock &block, QMouseEvent *event, QPoint pos);
     virtual void blockHelpEvent(GraphView::GraphBlock &block, QHelpEvent *event, QPoint pos);
@@ -166,9 +164,9 @@ private:
     QSize getRequiredCacheSize();
     qreal getRequiredCacheDevicePixelRatioF();
 
-    QPolygonF recalculatePolygon(QPolygonF polygon);
+    QPolygonF recalculatePolygon(QPolygonF polygon,
+                                 QPointF offset); //TODO: use qt view transform functionality
     void beginMouseDrag(QMouseEvent *event);
-
 public:
     QPoint getViewOffset() const    { return offset; }
     void setViewOffset(QPoint offset);

--- a/src/widgets/GraphView.h
+++ b/src/widgets/GraphView.h
@@ -68,7 +68,7 @@ public:
     void setGraphLayout(Layout layout);
     Layout getGraphLayout() const { return graphLayout; }
 
-    void paint(QPainter &p, QPoint offset, QRect area, qreal scale = 1.0); //TODO:
+    void paint(QPainter &p, QPoint offset, QRect area, qreal scale = 1.0, bool interactive = true);
 
     void saveAsBitmap(QString path, const char *format = nullptr);
     void saveAsSvg(QString path);
@@ -86,15 +86,21 @@ protected:
     void computeGraph(ut64 entry);
 
     // Callbacks that should be overridden
-    virtual void drawBlock(QPainter &p, GraphView::GraphBlock &block, const QPoint &offset,
-                           qreal scale);  //TODO: it should be possible to avoid manual scaling using qt drawing transformation API
+    /**
+     * @brief drawBlock
+     * @param p painter object, not necesarily current widget
+     * @param block
+     * @param interactive - can be used for disabling elemnts during export
+     */
+    virtual void drawBlock(QPainter &p, GraphView::GraphBlock &block, bool interactive = true);
     virtual void blockClicked(GraphView::GraphBlock &block, QMouseEvent *event, QPoint pos);
     virtual void blockDoubleClicked(GraphView::GraphBlock &block, QMouseEvent *event, QPoint pos);
     virtual void blockHelpEvent(GraphView::GraphBlock &block, QHelpEvent *event, QPoint pos);
     virtual bool helpEvent(QHelpEvent *event);
     virtual void blockTransitionedTo(GraphView::GraphBlock *to);
     virtual void wheelEvent(QWheelEvent *event) override;
-    virtual EdgeConfiguration edgeConfiguration(GraphView::GraphBlock &from, GraphView::GraphBlock *to);
+    virtual EdgeConfiguration edgeConfiguration(GraphView::GraphBlock &from, GraphView::GraphBlock *to,
+                                                bool interactive = true);
 
     bool event(QEvent *event) override;
 
@@ -164,8 +170,6 @@ private:
     QSize getRequiredCacheSize();
     qreal getRequiredCacheDevicePixelRatioF();
 
-    QPolygonF recalculatePolygon(QPolygonF polygon,
-                                 QPointF offset); //TODO: use qt view transform functionality
     void beginMouseDrag(QMouseEvent *event);
 public:
     QPoint getViewOffset() const    { return offset; }

--- a/src/widgets/OverviewView.cpp
+++ b/src/widgets/OverviewView.cpp
@@ -52,10 +52,11 @@ void OverviewView::refreshView()
     viewport()->update();
 }
 
-void OverviewView::drawBlock(QPainter &p, GraphView::GraphBlock &block)
+void OverviewView::drawBlock(QPainter &p, GraphView::GraphBlock &block, const QPoint &offset,
+                             qreal scale)
 {
-    int blockX = block.x - getViewOffset().x();
-    int blockY = block.y - getViewOffset().y();
+    int blockX = block.x - offset.x();
+    int blockY = block.y - offset.y();
 
     p.setPen(Qt::black);
     p.setBrush(Qt::gray);

--- a/src/widgets/OverviewView.cpp
+++ b/src/widgets/OverviewView.cpp
@@ -52,18 +52,16 @@ void OverviewView::refreshView()
     viewport()->update();
 }
 
-void OverviewView::drawBlock(QPainter &p, GraphView::GraphBlock &block, const QPoint &offset,
-                             qreal scale)
+void OverviewView::drawBlock(QPainter &p, GraphView::GraphBlock &block, bool interactive)
 {
-    int blockX = block.x - offset.x();
-    int blockY = block.y - offset.y();
+    Q_UNUSED(interactive)
+    QRectF blockRect(block.x, block.y, block.width, block.height);
 
     p.setPen(Qt::black);
     p.setBrush(Qt::gray);
-    p.drawRect(blockX, blockY, block.width, block.height);
+    p.drawRect(blockRect);
     p.setBrush(QColor(0, 0, 0, 100));
-    p.drawRect(blockX + 2, blockY + 2,
-               block.width, block.height);
+    p.drawRect(blockRect.translated(2, 2));
 
     // Draw basic block highlighting/tracing
     auto bb = Core()->getBBHighlighter()->getBasicBlock(block.entry);
@@ -75,8 +73,7 @@ void OverviewView::drawBlock(QPainter &p, GraphView::GraphBlock &block, const QP
         p.setBrush(disassemblyBackgroundColor);
     }
     p.setPen(QPen(graphNodeColor, 1));
-    p.drawRect(blockX, blockY,
-               block.width, block.height);
+    p.drawRect(blockRect);
 }
 
 void OverviewView::paintEvent(QPaintEvent *event)
@@ -132,8 +129,10 @@ void OverviewView::wheelEvent(QWheelEvent *event)
 }
 
 GraphView::EdgeConfiguration OverviewView::edgeConfiguration(GraphView::GraphBlock &from,
-                                                             GraphView::GraphBlock *to)
+                                                             GraphView::GraphBlock *to,
+                                                             bool interactive)
 {
+    Q_UNUSED(interactive)
     EdgeConfiguration ec;
     auto baseEcIt = edgeConfigurations.find({from.entry, to->entry});
     if (baseEcIt != edgeConfigurations.end())

--- a/src/widgets/OverviewView.h
+++ b/src/widgets/OverviewView.h
@@ -34,6 +34,12 @@ public:
 
     void centreRect();
 
+    /**
+     * @brief keep the current addr of the fcn of Graph
+     * Everytime overview updates its contents, it compares this value with the one in Graph
+     * if they aren't same, then Overview needs to update the pixmap cache.
+     */
+    ut64 currentFcnAddr = RVA_INVALID; // TODO: make this less public
 public slots:
     /**
      * @brief scale and center all nodes in, then run update
@@ -97,7 +103,8 @@ private:
     /**
      * @brief draw the computed blocks passed by Graph
      */
-    virtual void drawBlock(QPainter &p, GraphView::GraphBlock &block) override;
+    virtual void drawBlock(QPainter &p, GraphView::GraphBlock &block, const QPoint &offset,
+                           qreal scale) override;
 
     /**
      * @brief override the edgeConfiguration so as to

--- a/src/widgets/OverviewView.h
+++ b/src/widgets/OverviewView.h
@@ -103,8 +103,7 @@ private:
     /**
      * @brief draw the computed blocks passed by Graph
      */
-    virtual void drawBlock(QPainter &p, GraphView::GraphBlock &block, const QPoint &offset,
-                           qreal scale) override;
+    virtual void drawBlock(QPainter &p, GraphView::GraphBlock &block, bool interactive) override;
 
     /**
      * @brief override the edgeConfiguration so as to
@@ -112,7 +111,8 @@ private:
      * @return EdgeConfiguration
      */
     virtual GraphView::EdgeConfiguration edgeConfiguration(GraphView::GraphBlock &from,
-                                                           GraphView::GraphBlock *to) override;
+                                                           GraphView::GraphBlock *to,
+                                                           bool interactive) override;
 
     /**
      * @brief base background color changing depending on the theme


### PR DESCRIPTION
 <!-- Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request. -->


**Detailed description**

Some refactoring in graph widget so that drawing functions don't depend on current widget state and can be reused for drawing to image file.

Graph image export now has entries for exporting as png, jpg or svg using Cutter's drawing code.  R2+Graphviz based export is still there but new export is preferred for the supported formats unless Graphviz based export is explicitly selected.

 New file save dialog with multiple type support.  Unfortunately can't be done with native file save dialogs at least through Qt. I am a bit surprised that doesn't have proper builtin file save dialog that supports multiple types.  In QFileDialog type selection functions only as filter even in save mode. The new save dialog should prevent some of the confusion that could happen when exported file type differed from selected one.

<!-- Explain the **details** for making this change. What existing problem does the pull request solve? Please provide enough information so that others can review your pull request -->


**Test plan (required)**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

* Test that all formats create image with correct format (don't trust extension)
* Test type detection from extension
* Try type detection with invalid extension

<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

![exportg](https://user-images.githubusercontent.com/7101031/64816563-99a1f800-d5b0-11e9-8e18-bc12ff76f782.png)

**Closing issues**
Closes #1722