### PR TITLE
Fix "ta" commands after radare2 command refactoring #1774

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -638,7 +638,7 @@ void CutterCore::applyStructureOffset(const QString &structureOffset, RVA offset
         offset = getOffset();
     }
 
-    this->cmdRaw("ta " + structureOffset + " @ " + QString::number(offset));
+    this->cmdRaw("aht " + structureOffset + " @ " + QString::number(offset));
     emit instructionChanged(offset);
 }
 

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -115,7 +115,7 @@ public:
 
     /**
      * @brief Changes immediate displacement to structure offset
-     * This function makes use of the "ta" command of r2 to apply structure
+     * This function makes use of the "aht" command of r2 to apply structure
      * offset to the immediate displacement used in the given instruction
      * \param structureOffset The name of struct which will be applied
      * \param offset The address of the instruction where the struct will be applied

--- a/src/dialogs/InitialOptionsDialog.cpp
+++ b/src/dialogs/InitialOptionsDialog.cpp
@@ -59,7 +59,7 @@ InitialOptionsDialog::InitialOptionsDialog(MainWindow *main):
         { { "avrr", tr("Recover class information from RTTI") }, new QCheckBox(), false },
         { { "aan", tr("Autoname functions based on context") }, new QCheckBox(), false },
         { { "aae", tr("Emulate code to find computed references") }, new QCheckBox(), false },
-        { { "aat", tr("Analyze all consecutive functions") }, new QCheckBox(), false },
+        { { "aafr", tr("Analyze all consecutive functions") }, new QCheckBox(), false },
         { { "aaft", tr("Type and Argument matching analysis") }, new QCheckBox(), false },
         { { "aaT", tr("Analyze code after trap-sleds") }, new QCheckBox(), false },
         { { "aap", tr("Analyze function preludes") }, new QCheckBox(), false },

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -362,7 +362,7 @@ void DisassemblyContextMenu::aboutToShowSlot()
 
         // Get the possible offsets using the "tas" command
         // TODO: add tasj command to radare2 and then use it here
-        QStringList ret = Core()->cmdList("tas " + memDisp.toString());
+        QStringList ret = Core()->cmdList("ahts " + memDisp.toString());
         for (const QString &val : ret) {
             if (val.isEmpty()) {
                 continue;

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -360,8 +360,8 @@ void DisassemblyContextMenu::aboutToShowSlot()
         structureOffsetMenu->menuAction()->setVisible(true);
         structureOffsetMenu->clear();
 
-        // Get the possible offsets using the "tas" command
-        // TODO: add tasj command to radare2 and then use it here
+        // Get the possible offsets using the "ahts" command
+        // TODO: add ahtj command to radare2 and then use it here
         QStringList ret = Core()->cmdList("ahts " + memDisp.toString());
         for (const QString &val : ret) {
             if (val.isEmpty()) {


### PR DESCRIPTION
This fixes broken functionality caused by https://github.com/radare/radare2/pull/14966 and closes https://github.com/radareorg/cutter/issues/1774.

Changes in radare2 are:
- "aho" --> "ahd"
- "aht" --> "aho"
- "ta" --> "aht"
- "tas" --> "ahts"
- "aat" --> "aafr"
- "taa" --> "aat"

I think they are all covered now in this PR. Anyway, since it's my first contribution to this repo, double-checking by any other core dev would be great.