### PR TITLE
Add addressable item context menu to stack widget

### DIFF
--- a/src/common/Helpers.cpp
+++ b/src/common/Helpers.cpp
@@ -12,6 +12,7 @@
 #include <QAbstractItemView>
 #include <QAbstractButton>
 #include <QDockWidget>
+#include <QMenu>
 
 static QAbstractItemView::ScrollMode scrollMode()
 {
@@ -238,6 +239,16 @@ void setThemeIcons(QList<QPair<void *, QString>> supportedIconsNames,
             iconPath += relativeThemeDir;
         }
         setter(p.first, QIcon(iconPath + p.second));
+    }
+}
+
+void prependQAction(QAction *action, QMenu *menu)
+{
+    auto actions = menu->actions();
+    if (actions.empty()) {
+        menu->addAction(action);
+    } else {
+        menu->insertAction(actions.first(), action);
     }
 }
 

--- a/src/common/Helpers.h
+++ b/src/common/Helpers.h
@@ -16,6 +16,8 @@ class QAbstractItemView;
 class QAbstractButton;
 class QWidget;
 class QTreeView;
+class QAction;
+class QMenu;
 
 namespace qhelpers {
 QString formatBytecount(const long bytecount);
@@ -50,6 +52,8 @@ QByteArray applyColorToSvg(const QByteArray &data, QColor color);
 QByteArray applyColorToSvg(const QString &filename, QColor color);
 
 void setThemeIcons(QList<QPair<void*, QString>> supportedIconsNames, std::function<void(void *, const QIcon &)> setter);
+
+void prependQAction(QAction *action, QMenu *menu);
 
 } // qhelpers
 

--- a/src/widgets/StackWidget.h
+++ b/src/widgets/StackWidget.h
@@ -7,6 +7,7 @@
 
 #include "core/Cutter.h"
 #include "CutterDockWidget.h"
+#include "menus/AddressableItemContextMenu.h"
 
 class MainWindow;
 
@@ -30,6 +31,8 @@ private slots:
     void customMenuRequested(QPoint pos);
     void seekOffset();
     void editStack();
+    void onCurrentChanged(const QModelIndex &current, const QModelIndex &previous);
+    void onItemChanged(QStandardItem *item);
 
 private:
     std::unique_ptr<Ui::StackWidget> ui;
@@ -38,4 +41,6 @@ private:
     QAction *seekAction;
     QAction *editAction;
     RefreshDeferrer *refreshDeferrer;
+    AddressableItemContextMenu addressableItemContextMenu;
+    bool updatingData = false;
 };

--- a/src/widgets/StackWidget.h
+++ b/src/widgets/StackWidget.h
@@ -40,6 +40,7 @@ private:
     QStandardItemModel *modelStack = new QStandardItemModel(1, 3, this);
     QAction *seekAction;
     QAction *editAction;
+    QAction menuText;
     RefreshDeferrer *refreshDeferrer;
     AddressableItemContextMenu addressableItemContextMenu;
     bool updatingData = false;

--- a/src/widgets/StackWidget.h
+++ b/src/widgets/StackWidget.h
@@ -29,7 +29,6 @@ private slots:
     void fontsUpdatedSlot();
     void onDoubleClicked(const QModelIndex &index);
     void customMenuRequested(QPoint pos);
-    void seekOffset();
     void editStack();
     void onCurrentChanged(const QModelIndex &current, const QModelIndex &previous);
     void onItemChanged(QStandardItem *item);
@@ -38,7 +37,6 @@ private:
     std::unique_ptr<Ui::StackWidget> ui;
     QTableView *viewStack = new QTableView;
     QStandardItemModel *modelStack = new QStandardItemModel(1, 3, this);
-    QAction *seekAction;
     QAction *editAction;
     QAction menuText;
     RefreshDeferrer *refreshDeferrer;


### PR DESCRIPTION
 <!-- Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request. -->


**Detailed description**

Use addressable item context menu in stack widget. Allow acting both on stack position and value pointed by pointer on stack.

Respect value editing directly in table. Previously it allowed editing the values but changes were ignored.

**Test plan (required)**

* Start emulator
* Edit a value using context menu
* Edit a value cell in table (use double click or f2 to enter edit mode), confirm with enter
* Try editing a value in table again, confirm that it is possible to enter edit mode
* Right click on offset cell, click xrefs and confirm that address is correct
* Right click on one of edited values, confirm that address is correct using xrefs
* Open context menu using menu key on keyboard, confirm target address
* Test that shortcuts work by clicking on cell and pressing 'x' for xrefs, try both offset and value column


**Closing issues**

<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
