### PR TITLE
Add more shortcuts to DisassemblyContextMenu

### DIFF
--- a/docs/source/shortcuts.rst
+++ b/docs/source/shortcuts.rst
@@ -33,6 +33,7 @@ Widget shortcuts
 
 Disassembly view shortcuts
 --------------------------
+*Most of these shortcuts are also applied to Disassembly Graph view*
 
 +------------+----------------------------------+
 | Shortcut   | Function                         |
@@ -45,9 +46,23 @@ Disassembly view shortcuts
 +------------+----------------------------------+
 | ;          | Add comment                      |
 +------------+----------------------------------+
+| P          | Define a new function            |
++------------+----------------------------------+
+| Shift+P    | Edit function                    |
++------------+----------------------------------+
+| U          | Undefine a function              |
++------------+----------------------------------+
 | N          | Rename current function/flag     |
 +------------+----------------------------------+
 | Shift+N    | Rename flag/function used here   |
++------------+----------------------------------+
+| Y          | Edit\rename local variables      |
++------------+----------------------------------+
+| L          | Link a type\struct to address    |
++------------+----------------------------------+
+| A          | Set current address to String    |
++------------+----------------------------------+
+| C          | Set current address to Code      |
 +------------+----------------------------------+
 | X          | Show Xrefs                       |
 +------------+----------------------------------+

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -943,6 +943,13 @@ void CutterCore::cmdEsil(const char *command)
     }
 }
 
+QString CutterCore::createFunctionAt(RVA addr)
+{
+    QString ret = cmd("af " + RAddressString(addr));
+    emit functionsChanged();
+    return ret;
+}
+
 QString CutterCore::createFunctionAt(RVA addr, QString name)
 {
     static const QRegExp regExp("[^a-zA-Z0-9_]");

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -76,6 +76,7 @@ public:
     RVA getLastFunctionInstruction(RVA addr);
     QString cmdFunctionAt(QString addr);
     QString cmdFunctionAt(RVA addr);
+    QString createFunctionAt(RVA addr);
     QString createFunctionAt(RVA addr, QString name);
     QStringList getDisassemblyPreview(RVA address, int num_of_lines);
 

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -49,7 +49,7 @@ DisassemblyContextMenu::DisassemblyContextMenu(QWidget *parent, MainWindow *main
     addAction(&actionRename);
 
     initAction(&actionEditFunction, tr("Edit function"),
-               SLOT(on_actionEditFunction_triggered()));
+               SLOT(on_actionEditFunction_triggered()), getEditFunctionSequence());
     addAction(&actionEditFunction);
 
     initAction(&actionRenameUsedHere, tr("Rename Flag/Fcn/Var Used Here"),
@@ -67,11 +67,11 @@ DisassemblyContextMenu::DisassemblyContextMenu(QWidget *parent, MainWindow *main
     addAction(&actionDeleteFlag);
 
     initAction(&actionDeleteFunction, tr("Undefine function"),
-               SLOT(on_actionDeleteFunction_triggered()));
+               SLOT(on_actionDeleteFunction_triggered()), getUndefineFunctionSequence());
     addAction(&actionDeleteFunction);
 
     initAction(&actionAnalyzeFunction, tr("Define function here"),
-               SLOT(on_actionAnalyzeFunction_triggered()));
+               SLOT(on_actionAnalyzeFunction_triggered()), getDefineNewFunctionSequence());
     addAction(&actionAnalyzeFunction);
 
     addSeparator();
@@ -529,6 +529,22 @@ QList<QKeySequence> DisassemblyContextMenu::getAddBPSequence() const
 {
     return {Qt::Key_F2, Qt::CTRL + Qt::Key_B};
 }
+
+QKeySequence DisassemblyContextMenu::getDefineNewFunctionSequence() const
+{
+    return {Qt::Key_P};
+}
+
+QKeySequence DisassemblyContextMenu::getEditFunctionSequence() const
+{
+    return {Qt::SHIFT + Qt::Key_P};
+}
+
+QKeySequence DisassemblyContextMenu::getUndefineFunctionSequence() const
+{
+    return {Qt::Key_U};
+}
+
 
 void DisassemblyContextMenu::on_actionEditInstruction_triggered()
 {

--- a/src/menus/DisassemblyContextMenu.h
+++ b/src/menus/DisassemblyContextMenu.h
@@ -90,6 +90,9 @@ private:
     QKeySequence getRetypeSequence() const;
     QKeySequence getXRefSequence() const;
     QKeySequence getDisplayOptionsSequence() const;
+    QKeySequence getDefineNewFunctionSequence() const;
+    QKeySequence getUndefineFunctionSequence() const;
+    QKeySequence getEditFunctionSequence() const;
     QList<QKeySequence> getAddBPSequence() const;
 
     /**


### PR DESCRIPTION


**Detailed description**
This pull request adds three shortcuts for DisassemblyContextMenu

1. <kbd>P</kbd> to define a function
2. <kbd>Shift</kbd>+<kbd>P</kbd> to edit a function
3. <kbd>U</kbd>  to undefine a function

in addition, this PR will also add an overload method for `createFunctionAt` to create a function without specifying a name. This will be used in another PR.

On a side note, I really don't like this whole `get*Sequence()` things. We better have a proper shortcuts structs, globally.

**Test plan (required)**

1. Open a binary in Cutter. Got to a function and press <kbd>U</kbd> to undefine it
2. Press <kbd>P</kbd> to redefine it
3. Press <kbd>Shift+</kbd><kbd>P</kbd> to edit the newly defined function
