### PR TITLE
Add information from aai to Dashboard, fixes #1571

### DIFF
--- a/src/widgets/Dashboard.cpp
+++ b/src/widgets/Dashboard.cpp
@@ -74,7 +74,7 @@ void Dashboard::updateContents()
     setBool(this->ui->strippedEdit, item2, "stripped");
     setBool(this->ui->relocsEdit, item2, "relocs");
 
-    // Add file hashes, anal info and libraries
+    // Add file hashes, analysis info and libraries
     QJsonObject hashes = Core()->cmdj("itj").object();
     setPlainText(ui->md5Edit, hashes["md5"].toString());
     setPlainText(ui->sha1Edit, hashes["sha1"].toString());

--- a/src/widgets/Dashboard.cpp
+++ b/src/widgets/Dashboard.cpp
@@ -86,8 +86,8 @@ void Dashboard::updateContents()
     setPlainText(ui->stringsLineEdit, QString::number(analinfo["strings"].toInt()));
     setPlainText(ui->symbolsLineEdit, QString::number(analinfo["symbols"].toInt()));
     setPlainText(ui->importsLineEdit, QString::number(analinfo["imports"].toInt()));
-    setPlainText(ui->coverageLineEdit, QString::number(analinfo["covrage"].toInt()));
-    setPlainText(ui->codeSizeLineEdit, QString::number(analinfo["codesz"].toInt()));
+    setPlainText(ui->coverageLineEdit, QString::number(analinfo["covrage"].toInt()) + " bytes");
+    setPlainText(ui->codeSizeLineEdit, QString::number(analinfo["codesz"].toInt()) + " bytes");
     setPlainText(ui->percentageLineEdit, QString::number(analinfo["percent"].toInt()) + "%");
 
     QStringList libs = Core()->cmdList("il");

--- a/src/widgets/Dashboard.cpp
+++ b/src/widgets/Dashboard.cpp
@@ -74,10 +74,21 @@ void Dashboard::updateContents()
     setBool(this->ui->strippedEdit, item2, "stripped");
     setBool(this->ui->relocsEdit, item2, "relocs");
 
-    // Add file hashes and libraries
+    // Add file hashes, anal info and libraries
     QJsonObject hashes = Core()->cmdj("itj").object();
     setPlainText(ui->md5Edit, hashes["md5"].toString());
     setPlainText(ui->sha1Edit, hashes["sha1"].toString());
+
+    QJsonObject analinfo = Core()->cmdj("aaij").object();
+    setPlainText(ui->functionsLineEdit, QString::number(analinfo["fcns"].toInt()));
+    setPlainText(ui->xRefsLineEdit, QString::number(analinfo["xrefs"].toInt()));
+    setPlainText(ui->callsLineEdit, QString::number(analinfo["calls"].toInt()));
+    setPlainText(ui->stringsLineEdit, QString::number(analinfo["strings"].toInt()));
+    setPlainText(ui->symbolsLineEdit, QString::number(analinfo["symbols"].toInt()));
+    setPlainText(ui->importsLineEdit, QString::number(analinfo["imports"].toInt()));
+    setPlainText(ui->coverageLineEdit, QString::number(analinfo["covrage"].toInt()));
+    setPlainText(ui->codeSizeLineEdit, QString::number(analinfo["codesz"].toInt()));
+    setPlainText(ui->percentageLineEdit, QString::number(analinfo["percent"].toInt()) + "%");
 
     QStringList libs = Core()->cmdList("il");
     if (!libs.isEmpty()) {

--- a/src/widgets/Dashboard.ui
+++ b/src/widgets/Dashboard.ui
@@ -1240,7 +1240,7 @@
                     </font>
                    </property>
                    <property name="text">
-                    <string>Coverage:</string>
+                    <string>Analysis coverage:</string>
                    </property>
                   </widget>
                  </item>
@@ -1286,7 +1286,7 @@
                     </font>
                    </property>
                    <property name="text">
-                    <string>Percentage:</string>
+                    <string>Coverage percent:</string>
                    </property>
                   </widget>
                  </item>

--- a/src/widgets/Dashboard.ui
+++ b/src/widgets/Dashboard.ui
@@ -56,7 +56,7 @@
          <x>0</x>
          <y>0</y>
          <width>1055</width>
-         <height>982</height>
+         <height>980</height>
         </rect>
        </property>
        <layout class="QHBoxLayout" name="horizontalLayout_5">
@@ -973,99 +973,334 @@
               <number>0</number>
              </property>
              <item>
-              <layout class="QFormLayout" name="formLayout_2">
-               <property name="fieldGrowthPolicy">
-                <enum>QFormLayout::ExpandingFieldsGrow</enum>
-               </property>
-               <property name="labelAlignment">
-                <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-               </property>
-               <property name="verticalSpacing">
-                <number>3</number>
-               </property>
-               <item row="0" column="0">
-                <widget class="QLabel" name="label_32">
+              <layout class="QVBoxLayout" name="verticalLayout_4">
+               <item>
+                <layout class="QFormLayout" name="formLayout_2">
+                 <property name="fieldGrowthPolicy">
+                  <enum>QFormLayout::ExpandingFieldsGrow</enum>
+                 </property>
+                 <property name="labelAlignment">
+                  <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+                 </property>
+                 <property name="verticalSpacing">
+                  <number>3</number>
+                 </property>
+                 <item row="0" column="0">
+                  <widget class="QLabel" name="label_32">
+                   <property name="font">
+                    <font>
+                     <weight>75</weight>
+                     <bold>true</bold>
+                    </font>
+                   </property>
+                   <property name="text">
+                    <string>MD5:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="0" column="1">
+                  <widget class="QLineEdit" name="md5Edit">
+                   <property name="text">
+                    <string/>
+                   </property>
+                   <property name="frame">
+                    <bool>false</bool>
+                   </property>
+                   <property name="readOnly">
+                    <bool>true</bool>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="0">
+                  <widget class="QLabel" name="label_33">
+                   <property name="font">
+                    <font>
+                     <weight>75</weight>
+                     <bold>true</bold>
+                    </font>
+                   </property>
+                   <property name="text">
+                    <string>SHA1:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="1">
+                  <widget class="QLineEdit" name="sha1Edit">
+                   <property name="text">
+                    <string/>
+                   </property>
+                   <property name="frame">
+                    <bool>false</bool>
+                   </property>
+                   <property name="readOnly">
+                    <bool>true</bool>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="2" column="0">
+                  <widget class="QLabel" name="label_8">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="font">
+                    <font>
+                     <weight>75</weight>
+                     <bold>true</bold>
+                    </font>
+                   </property>
+                   <property name="text">
+                    <string>Entropy:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="2" column="1">
+                  <widget class="QLabel" name="lblEntropy">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="text">
+                    <string notr="true"/>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </item>
+               <item>
+                <widget class="QLabel" name="label_9">
                  <property name="font">
                   <font>
+                   <pointsize>17</pointsize>
                    <weight>75</weight>
                    <bold>true</bold>
                   </font>
                  </property>
                  <property name="text">
-                  <string>MD5:</string>
+                  <string>Analysis info</string>
                  </property>
                 </widget>
                </item>
-               <item row="0" column="1">
-                <widget class="QLineEdit" name="md5Edit">
-                 <property name="text">
-                  <string/>
+               <item>
+                <layout class="QFormLayout" name="formLayout_5">
+                 <property name="fieldGrowthPolicy">
+                  <enum>QFormLayout::ExpandingFieldsGrow</enum>
                  </property>
-                 <property name="frame">
-                  <bool>false</bool>
+                 <property name="verticalSpacing">
+                  <number>3</number>
                  </property>
-                 <property name="readOnly">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="0">
-                <widget class="QLabel" name="label_33">
-                 <property name="font">
-                  <font>
-                   <weight>75</weight>
-                   <bold>true</bold>
-                  </font>
-                 </property>
-                 <property name="text">
-                  <string>SHA1:</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="1">
-                <widget class="QLineEdit" name="sha1Edit">
-                 <property name="text">
-                  <string/>
-                 </property>
-                 <property name="frame">
-                  <bool>false</bool>
-                 </property>
-                 <property name="readOnly">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="0">
-                <widget class="QLabel" name="label_8">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="font">
-                  <font>
-                   <weight>75</weight>
-                   <bold>true</bold>
-                  </font>
-                 </property>
-                 <property name="text">
-                  <string>Entropy:</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="1">
-                <widget class="QLabel" name="lblEntropy">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="text">
-                  <string notr="true"/>
-                 </property>
-                </widget>
+                 <item row="0" column="0">
+                  <widget class="QLabel" name="functionsLabel">
+                   <property name="font">
+                    <font>
+                     <weight>75</weight>
+                     <bold>true</bold>
+                    </font>
+                   </property>
+                   <property name="text">
+                    <string>Functions:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="0" column="1">
+                  <widget class="QLineEdit" name="functionsLineEdit">
+                   <property name="frame">
+                    <bool>false</bool>
+                   </property>
+                   <property name="readOnly">
+                    <bool>true</bool>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="0">
+                  <widget class="QLabel" name="xRefsLabel">
+                   <property name="font">
+                    <font>
+                     <weight>75</weight>
+                     <bold>true</bold>
+                    </font>
+                   </property>
+                   <property name="text">
+                    <string>X-Refs:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="1">
+                  <widget class="QLineEdit" name="xRefsLineEdit">
+                   <property name="frame">
+                    <bool>false</bool>
+                   </property>
+                   <property name="readOnly">
+                    <bool>true</bool>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="2" column="0">
+                  <widget class="QLabel" name="callsLabel">
+                   <property name="font">
+                    <font>
+                     <weight>75</weight>
+                     <bold>true</bold>
+                    </font>
+                   </property>
+                   <property name="text">
+                    <string>Calls:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="2" column="1">
+                  <widget class="QLineEdit" name="callsLineEdit">
+                   <property name="frame">
+                    <bool>false</bool>
+                   </property>
+                   <property name="readOnly">
+                    <bool>true</bool>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="3" column="0">
+                  <widget class="QLabel" name="stringsLabel">
+                   <property name="font">
+                    <font>
+                     <weight>75</weight>
+                     <bold>true</bold>
+                    </font>
+                   </property>
+                   <property name="text">
+                    <string>Strings:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="3" column="1">
+                  <widget class="QLineEdit" name="stringsLineEdit">
+                   <property name="frame">
+                    <bool>false</bool>
+                   </property>
+                   <property name="readOnly">
+                    <bool>true</bool>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="4" column="0">
+                  <widget class="QLabel" name="symbolsLabel">
+                   <property name="font">
+                    <font>
+                     <weight>75</weight>
+                     <bold>true</bold>
+                    </font>
+                   </property>
+                   <property name="text">
+                    <string>Symbols:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="4" column="1">
+                  <widget class="QLineEdit" name="symbolsLineEdit">
+                   <property name="frame">
+                    <bool>false</bool>
+                   </property>
+                   <property name="readOnly">
+                    <bool>true</bool>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="5" column="0">
+                  <widget class="QLabel" name="importsLabel">
+                   <property name="font">
+                    <font>
+                     <weight>75</weight>
+                     <bold>true</bold>
+                    </font>
+                   </property>
+                   <property name="text">
+                    <string>Imports:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="5" column="1">
+                  <widget class="QLineEdit" name="importsLineEdit">
+                   <property name="frame">
+                    <bool>false</bool>
+                   </property>
+                   <property name="readOnly">
+                    <bool>true</bool>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="6" column="0">
+                  <widget class="QLabel" name="coverageLabel">
+                   <property name="font">
+                    <font>
+                     <weight>75</weight>
+                     <bold>true</bold>
+                    </font>
+                   </property>
+                   <property name="text">
+                    <string>Coverage:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="6" column="1">
+                  <widget class="QLineEdit" name="coverageLineEdit">
+                   <property name="frame">
+                    <bool>false</bool>
+                   </property>
+                   <property name="readOnly">
+                    <bool>true</bool>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="7" column="0">
+                  <widget class="QLabel" name="codeSizeLabel">
+                   <property name="font">
+                    <font>
+                     <weight>75</weight>
+                     <bold>true</bold>
+                    </font>
+                   </property>
+                   <property name="text">
+                    <string>Code size:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="7" column="1">
+                  <widget class="QLineEdit" name="codeSizeLineEdit">
+                   <property name="frame">
+                    <bool>false</bool>
+                   </property>
+                   <property name="readOnly">
+                    <bool>true</bool>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="8" column="0">
+                  <widget class="QLabel" name="percentageLabel">
+                   <property name="font">
+                    <font>
+                     <weight>75</weight>
+                     <bold>true</bold>
+                    </font>
+                   </property>
+                   <property name="text">
+                    <string>Percentage:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="8" column="1">
+                  <widget class="QLineEdit" name="percentageLineEdit">
+                   <property name="frame">
+                    <bool>false</bool>
+                   </property>
+                   <property name="readOnly">
+                    <bool>true</bool>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
                </item>
               </layout>
              </item>


### PR DESCRIPTION

**Detailed description**

Adds analysis info (aai) to Dashboard widget.

**Test plan (required)**

Ran analysis of the binary and checked that analysis info is showing in Dashboard (and is the same as aai output in r2).
![image](https://user-images.githubusercontent.com/32012316/65679095-23e06680-e05d-11e9-8488-74cc0854821b.png)

**Closing issues**

Closes #1571 .
