### PR TITLE
Use AddressableItemContextMenu in Registers widgtet.

### DIFF
--- a/src/widgets/RegistersWidget.cpp
+++ b/src/widgets/RegistersWidget.cpp
@@ -25,6 +25,12 @@ RegistersWidget::RegistersWidget(MainWindow *main, QAction *action) :
 
     connect(Core(), &CutterCore::refreshAll, this, &RegistersWidget::updateContents);
     connect(Core(), &CutterCore::registersChanged, this, &RegistersWidget::updateContents);
+
+    // Hide shortcuts because there is no way of selecting an item and triger them
+    for (auto &action : addressContextMenu.actions()) {
+        action->setShortcut(QKeySequence());
+        // setShortcutVisibleInContextMenu(false) doesn't work
+    }
 }
 
 RegistersWidget::~RegistersWidget() = default;
@@ -107,7 +113,7 @@ void RegistersWidget::setRegisterGrid()
         registerEditValue->setText(regValue);
         i++;
         // decide if we should change column
-        if (i >= registerLen / numCols + 1) {
+        if (i >= (registerLen + numCols - 1) / numCols) {
             i = 0;
             col += 2;
         }

--- a/src/widgets/RegistersWidget.cpp
+++ b/src/widgets/RegistersWidget.cpp
@@ -10,7 +10,8 @@
 
 RegistersWidget::RegistersWidget(MainWindow *main, QAction *action) :
     CutterDockWidget(main, action),
-    ui(new Ui::RegistersWidget)
+    ui(new Ui::RegistersWidget),
+    addressContextMenu(this, main)
 {
     ui->setupUi(this);
 
@@ -63,6 +64,14 @@ void RegistersWidget::setRegisterGrid()
             registerEditValue = new QLineEdit;
             registerEditValue->setFixedWidth(140);
             registerEditValue->setFont(Config()->getFont());
+            registerLabel->setContextMenuPolicy(Qt::CustomContextMenu);
+            connect(registerLabel, &QWidget::customContextMenuRequested, this, [this, registerEditValue, registerLabel](QPoint p){
+                openContextMenu(registerLabel->mapToGlobal(p), registerEditValue->text());
+            });
+            registerEditValue->setContextMenuPolicy(Qt::CustomContextMenu);
+            connect(registerEditValue, &QWidget::customContextMenuRequested, this, [this, registerEditValue](QPoint p){
+                openContextMenu(registerEditValue->mapToGlobal(p), registerEditValue->text());
+            });
             // add label and register value to grid
             registerLayout->addWidget(registerLabel, i, col);
             registerLayout->addWidget(registerEditValue, i, col + 1);
@@ -103,4 +112,10 @@ void RegistersWidget::setRegisterGrid()
             col += 2;
         }
     }
+}
+
+void RegistersWidget::openContextMenu(QPoint point, QString address)
+{
+    addressContextMenu.setTarget(address.toULongLong(nullptr, 16));
+    addressContextMenu.exec(point);
 }

--- a/src/widgets/RegistersWidget.h
+++ b/src/widgets/RegistersWidget.h
@@ -8,6 +8,7 @@
 
 #include "core/Cutter.h"
 #include "CutterDockWidget.h"
+#include "menus/AddressableItemContextMenu.h"
 
 class MainWindow;
 
@@ -26,10 +27,12 @@ public:
 private slots:
     void updateContents();
     void setRegisterGrid();
+    void openContextMenu(QPoint point, QString address);
 
 private:
     std::unique_ptr<Ui::RegistersWidget> ui;
     QGridLayout *registerLayout = new QGridLayout;
+    AddressableItemContextMenu addressContextMenu;
     int numCols = 2;
     int registerLen = 0;
     RefreshDeferrer *refreshDeferrer;


### PR DESCRIPTION
**Detailed description**

Use AddressableItemContextMenu in Registers widgtet. Works when clicking on either label or text input field.

**Test plan (required)**

* start emulation
* right click rsp label, check address using xrefs
* right click rsp input field, check address using xrefs
* repeat on rip which should have different address
* open menu using menu key on keyboard

![screenshot](https://user-images.githubusercontent.com/7101031/65768675-45635000-e13a-11e9-8b08-8feee41965ea.png)


**Closing issues**


<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
