### PR TITLE
Hide and resize hexdump sidebar with heuristics

### DIFF
--- a/src/widgets/HexdumpWidget.cpp
+++ b/src/widgets/HexdumpWidget.cpp
@@ -306,6 +306,11 @@ void HexdumpWidget::on_hexSideTab_2_currentChanged(int /*index*/)
 
 void HexdumpWidget::resizeEvent(QResizeEvent *event)
 {
+    // Heuristics to hide sidebar when it hides the content of the hexdump. 600px looks just "okay"
+    // Only applied when widget width is decreased to avoid unwanted behavior
+    if (event->oldSize().width() > event->size().width() && event->size().width() < 600) {
+        showSidePanel(false);
+    }
     QDockWidget::resizeEvent(event);
     refresh();
 }

--- a/src/widgets/HexdumpWidget.ui
+++ b/src/widgets/HexdumpWidget.ui
@@ -33,6 +33,12 @@
        <enum>Qt::Horizontal</enum>
       </property>
       <widget class="HexWidget" name="hexTextView">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+         <horstretch>1</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="frameShape">
         <enum>QFrame::NoFrame</enum>
        </property>
@@ -51,7 +57,7 @@
         <enum>QTabWidget::North</enum>
        </property>
        <property name="currentIndex">
-        <number>1</number>
+        <number>0</number>
        </property>
        <property name="usesScrollButtons">
         <bool>true</bool>


### PR DESCRIPTION

**Detailed description**

Often, the sidebar in the hexdump widget is too big and takes most of the view of the hexdump widget in a way that it even hides the hexdump text itself. 

This Pull Request does two things:
1. Change the size-policy to set the default proportion of the sidebar to be smaller
2. Applies some heuristics to hide the sidebar on resize events when it will likely to hide the hexdump.


**Test plan (required)**

1. Open hexdump and see that the sidebar is of a reasonable size and proportions
2. Make sure the sidebar is opened and start narrowing it by resizing until it hides the sidebar.


