### PR TITLE
Fix crash when using graph shortcut

### DIFF
--- a/src/widgets/GraphWidget.cpp
+++ b/src/widgets/GraphWidget.cpp
@@ -32,7 +32,6 @@ GraphWidget::GraphWidget(MainWindow *main, QAction *action) :
     QShortcut *toggle_shortcut = new QShortcut(widgetShortcuts["GraphWidget"], main);
     connect(toggle_shortcut, &QShortcut::activated, this, [ = ]() {
             toggleDockWidget(true); 
-            main->updateDockActionChecked(action);
     });
 
     connect(graphView, &DisassemblerGraphView::nameChanged, this, &MemoryDockWidget::updateWindowTitle);


### PR DESCRIPTION
 <!-- Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request. -->


**Detailed description**

Graph action in the menu currently isn't togglable so the code trying to do it can be safely removed.

The shortcut has other problems that were there before, but at least it won't cause crash now.

**Test plan (required)**

* open cutter
* press shift-g observe no crash
* switch to disassembly
* press shift-g observe that shortcut works

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**
closes #1800
<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
