### PR TITLE
Add search color option feature + sort color options by name

### DIFF
--- a/src/dialogs/preferences/ColorThemeEditDialog.ui
+++ b/src/dialogs/preferences/ColorThemeEditDialog.ui
@@ -48,20 +48,31 @@
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout">
          <item>
-          <widget class="ColorThemeListView" name="colorThemeListView" native="true">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>400</width>
-             <height>400</height>
-            </size>
-           </property>
-          </widget>
+          <layout class="QVBoxLayout" name="verticalLayout_5">
+           <item>
+            <widget class="QLineEdit" name="filterLineEdit">
+             <property name="placeholderText">
+              <string>Search</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="ColorThemeListView" name="colorThemeListView" native="true">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>400</width>
+               <height>400</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </item>
          <item>
           <layout class="QVBoxLayout" name="colorPickerAndPreviewLayout">

--- a/src/widgets/ColorThemeListView.cpp
+++ b/src/widgets/ColorThemeListView.cpp
@@ -39,7 +39,7 @@ void ColorOptionDelegate::paint(QPainter *painter,
                                 const QStyleOptionViewItem &option,
                                 const QModelIndex &index) const
 {
-    int margin = this->margin * 1;
+    int margin = this->margin * painter->device()->devicePixelRatioF();
     painter->save();
     painter->setFont(option.font);
     painter->setRenderHint(QPainter::Antialiasing);

--- a/src/widgets/ColorThemeListView.cpp
+++ b/src/widgets/ColorThemeListView.cpp
@@ -267,7 +267,7 @@ void ColorThemeListView::mouseReleaseEvent(QMouseEvent* e)
         QJsonArray rgb = ThemeWorker().getTheme(
                              Config()->getColorTheme()).object()[co.optionName].toArray();
         co.color = QColor(rgb[0].toInt(), rgb[1].toInt(), rgb[2].toInt());
-        colorSettingsModel()->setData(currentIndex(), QVariant::fromValue(co));
+        model()->setData(currentIndex(), QVariant::fromValue(co));
         QCursor c;
         c.setShape(Qt::CursorShape::ArrowCursor);
         setCursor(c);

--- a/src/widgets/ColorThemeListView.h
+++ b/src/widgets/ColorThemeListView.h
@@ -14,6 +14,7 @@ struct ColorOption {
 };
 Q_DECLARE_METATYPE(ColorOption);
 
+class ColorSettingsModel;
 
 class ColorThemeListView : public QListView
 {
@@ -21,6 +22,8 @@ class ColorThemeListView : public QListView
 public:
     ColorThemeListView(QWidget *parent = nullptr);
     virtual ~ColorThemeListView() override {}
+
+    ColorSettingsModel* colorSettingsModel() const;
 
 protected slots:
     void currentChanged(const QModelIndex &current,
@@ -32,6 +35,7 @@ protected slots:
     void mouseReleaseEvent(QMouseEvent *e) override;
 
     void mouseMoveEvent(QMouseEvent *e) override;
+
 
 private slots:
     void blinkTimeout();


### PR DESCRIPTION
 <!-- Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request. -->


**Detailed description**
Now we have color options in theme editor sorted by their r2 name, not displayed one. This makes it harder to find option you want.

This PR  implements sorting by displayed name and adds search line edit to make it easier to find stuff.

<!-- Explain the **details** for making this change. What existing problem does the pull request solve? Please provide enough information so that others can review your pull request -->


**Test plan (required)**
Open theme editor, enter some string in search line edit, try to change theme, save it.

![image](https://user-images.githubusercontent.com/42874998/65822583-8f8a2580-e24f-11e9-9e12-b4279024e1da.png)

![image](https://user-images.githubusercontent.com/42874998/65822588-9a44ba80-e24f-11e9-867e-df79be803f07.png)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**
none
<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
