### PR TITLE
Fix link to screenshot in appdata

### DIFF
--- a/src/org.radare.Cutter.appdata.xml
+++ b/src/org.radare.Cutter.appdata.xml
@@ -16,7 +16,7 @@
 
   <screenshots>
     <screenshot>
-      <image>https://raw.githubusercontent.com/radareorg/cutter/master/docs/images/screenshot.png</image>
+      <image>https://raw.githubusercontent.com/radareorg/cutter/master/docs/source/images/screenshot.png</image>
       <caption>Main UI</caption>
     </screenshot>
   </screenshots>


### PR DESCRIPTION
**Detailed description**
Fixes the invalid link to UI screenshot in appdata.

**Test plan (required)**
Tried to open the link and ensured that I get the screenshot.
