### PR TITLE
fix #1802 (newly created graph docks have no title)

### DIFF
--- a/src/widgets/GraphWidget.cpp
+++ b/src/widgets/GraphWidget.cpp
@@ -26,6 +26,9 @@ GraphWidget::GraphWidget(MainWindow *main, QAction *action) :
     graphView = new DisassemblerGraphView(layoutWidget, seekable, main);
     layout->addWidget(graphView);
 
+    // Title needs to get set after graphView is defined
+    updateWindowTitle();
+
     // getting the name of the class is implementation defined, and cannot be
     // used reliably across different compilers.
     //QShortcut *toggle_shortcut = new QShortcut(widgetShortcuts[typeid(this).name()], main);


### PR DESCRIPTION
 <!-- Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request. -->


**Detailed description**

Graph docks didn't have a title when initially created.  I called the updateWindowTitle() function of MemoryDockWidget to create the title after graphView is defined.  
<!-- Explain the **details** for making this change. What existing problem does the pull request solve? Please provide enough information so that others can review your pull request -->


**Test plan (required)**

* Open any file in cutter
* Click Windows/Add Graph
* Observe that the dock has a title

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
![DeepinScreenshot_select-area_20191004141338](https://user-images.githubusercontent.com/1759360/66233603-66cfb900-e6b1-11e9-8e69-fb9f0bf0ea5c.png)
<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**

closes #1802 

<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
