### PR TITLE
Implement parsing selected bytes as Yara

### DIFF
--- a/src/widgets/HexdumpWidget.cpp
+++ b/src/widgets/HexdumpWidget.cpp
@@ -254,6 +254,9 @@ void HexdumpWidget::updateParseWindow(RVA start_address, int size)
         case 9: // JavaScript
             ui->hexDisasTextEdit->setPlainText(Core()->cmd("pcJ " + argument));
             break;
+        case 10: // Yara
+            ui->hexDisasTextEdit->setPlainText(Core()->cmd("pcy " + argument));
+            break;
         default:
             ui->hexDisasTextEdit->setPlainText("");
         }

--- a/src/widgets/HexdumpWidget.ui
+++ b/src/widgets/HexdumpWidget.ui
@@ -153,6 +153,11 @@
                  <string>JavaScript</string>
                 </property>
                </item>
+               <item>
+                <property name="text">
+                 <string>Yara</string>
+                </property>
+               </item>
               </widget>
              </item>
              <item>


### PR DESCRIPTION

**Detailed description**

As for the request in https://github.com/radareorg/radare2/issues/15216 , radare2 now support the `pcy` command to print bytes as Yara (https://github.com/radareorg/radare2/commit/1c4392dbf565791a8fbb65a11a8d463af9edd1ca).

This Pull Request updates radare2 version and implements this feature in the hexdump widget of Cutter. Updating radare2 will also help to apply the fix to https://github.com/radareorg/cutter/issues/1749 .

![image](https://user-images.githubusercontent.com/20182642/66310373-ba8e0c80-e914-11e9-8c70-74209840be40.png)

**Test plan (required)**
1. Go the hexdump widget
2. Select bytes
3. Open the "Parsing" tab of the side panel
4. Select Yara and see output

