### PR TITLE
Replacing all QRegExp with QRegularExpression

### DIFF
--- a/src/common/HexAsciiHighlighter.cpp
+++ b/src/common/HexAsciiHighlighter.cpp
@@ -8,42 +8,43 @@ AsciiHighlighter::AsciiHighlighter(QTextDocument *parent)
     HighlightingRule rule;
 
     asciiFormat.setForeground(QColor(65, 131, 215));
-    rule.pattern = QRegExp("\\b[A-Za-z0-9]+\\b");
+    rule.pattern = "\\b[A-Za-z0-9]+\\b";
     rule.format = asciiFormat;
     highlightingRules.append(rule);
 
-    commentStartExpression = QRegExp("/\\*");
-    commentEndExpression = QRegExp("\\*/");
+    commentStartRegularExpression = "/\\*";
+    commentEndRegularExpression = "\\*/";
 }
 
 void AsciiHighlighter::highlightBlock(const QString &text)
 {
     for (const HighlightingRule &rule : highlightingRules) {
-        QRegExp expression(rule.pattern);
-        int index = expression.indexIn(text);
+        QRegularExpression expression(rule.pattern);
+        int index = expression.match(text).capturedStart();
         while (index >= 0) {
-            int length = expression.matchedLength();
+            int length = expression.match(text).capturedLength();
             setFormat(index, length, rule.format);
-            index = expression.indexIn(text, index + length);
+            index = expression.match(text.mid(index + length)).capturedStart();
         }
     }
     setCurrentBlockState(0);
 
     int startIndex = 0;
     if (previousBlockState() != 1)
-        startIndex = commentStartExpression.indexIn(text);
+        startIndex = QRegularExpression(commentStartRegularExpression).match(text).capturedStart();
 
     while (startIndex >= 0) {
-        int endIndex = commentEndExpression.indexIn(text, startIndex);
+        QRegularExpressionMatch commentEndMatch = QRegularExpression(commentEndRegularExpression).match(text.mid(startIndex));
+        int endIndex = commentEndMatch.capturedStart();
         int commentLength;
         if (endIndex == -1) {
             setCurrentBlockState(1);
             commentLength = text.length() - startIndex;
         } else {
             commentLength = endIndex - startIndex
-                            + commentEndExpression.matchedLength();
+                            + commentEndMatch.capturedLength();
         }
         setFormat(startIndex, commentLength, multiLineCommentFormat);
-        startIndex = commentStartExpression.indexIn(text, startIndex + commentLength);
+        startIndex = QRegularExpression(commentStartRegularExpression).match(text.mid(startIndex + commentLength)).capturedStart();
     }
 }

--- a/src/common/HexAsciiHighlighter.cpp
+++ b/src/common/HexAsciiHighlighter.cpp
@@ -8,12 +8,12 @@ AsciiHighlighter::AsciiHighlighter(QTextDocument *parent)
     HighlightingRule rule;
 
     asciiFormat.setForeground(QColor(65, 131, 215));
-    rule.pattern = "\\b[A-Za-z0-9]+\\b";
+    rule.pattern.setPattern("\\b[A-Za-z0-9]+\\b");
     rule.format = asciiFormat;
     highlightingRules.append(rule);
 
-    commentStartRegularExpression = "/\\*";
-    commentEndRegularExpression = "\\*/";
+    commentStartRegularExpression.setPattern("/\\*");
+    commentEndRegularExpression.setPattern("\\*/");
 }
 
 void AsciiHighlighter::highlightBlock(const QString &text)

--- a/src/common/HexAsciiHighlighter.h
+++ b/src/common/HexAsciiHighlighter.h
@@ -5,6 +5,7 @@
 
 #include <QHash>
 #include <QTextCharFormat>
+#include <QRegularExpression>
 
 class QTextDocument;
 
@@ -20,13 +21,13 @@ protected:
 
 private:
     struct HighlightingRule {
-        QString pattern;
+        QRegularExpression pattern;
         QTextCharFormat format;
     };
     QVector<HighlightingRule> highlightingRules;
 
-    QString commentStartRegularExpression;
-    QString commentEndRegularExpression;
+    QRegularExpression commentStartRegularExpression;
+    QRegularExpression commentEndRegularExpression;
 
     QTextCharFormat keywordFormat;
     QTextCharFormat classFormat;

--- a/src/common/HexAsciiHighlighter.h
+++ b/src/common/HexAsciiHighlighter.h
@@ -20,13 +20,13 @@ protected:
 
 private:
     struct HighlightingRule {
-        QRegExp pattern;
+        QString pattern;
         QTextCharFormat format;
     };
     QVector<HighlightingRule> highlightingRules;
 
-    QRegExp commentStartExpression;
-    QRegExp commentEndExpression;
+    QString commentStartRegularExpression;
+    QString commentEndRegularExpression;
 
     QTextCharFormat keywordFormat;
     QTextCharFormat classFormat;

--- a/src/common/HexHighlighter.cpp
+++ b/src/common/HexHighlighter.cpp
@@ -27,20 +27,20 @@ HexHighlighter::HexHighlighter(QTextDocument *parent)
                     << "\\b75\\b" << "\\b76\\b" << "\\b77\\b" << "\\b78\\b" << "\\b79\\b" << "\\b7a\\b" << "\\b7b\\b"
                     << "\\b7c\\b" << "\\b7d\\b" << "\\b7e\\b" << "\\b7f\\b";
     for (const QString &pattern : keywordPatterns) {
-        rule.pattern = pattern;
-        rule.options = QRegularExpression::CaseInsensitiveOption;
+        rule.pattern.setPattern(pattern);
+        rule.pattern.setPatternOptions(QRegularExpression::CaseInsensitiveOption);
         rule.format = keywordFormat;
         highlightingRules.append(rule);
     }
 
     singleLineCommentFormat.setFontWeight(QFont::Bold);
     singleLineCommentFormat.setForeground(Qt::darkGreen);
-    rule.pattern = ";[^\n]*";
+    rule.pattern.setPattern(";[^\n]*");
     rule.format = singleLineCommentFormat;
     highlightingRules.append(rule);
 
-    commentStartRegularExpression = "/\\*";
-    commentEndRegularExpression = "\\*/";
+    commentStartRegularExpression.setPattern("/\\*");
+    commentEndRegularExpression.setPattern("\\*/");
 }
 
 void HexHighlighter::highlightBlock(const QString &text)

--- a/src/common/HexHighlighter.cpp
+++ b/src/common/HexHighlighter.cpp
@@ -27,51 +27,51 @@ HexHighlighter::HexHighlighter(QTextDocument *parent)
                     << "\\b75\\b" << "\\b76\\b" << "\\b77\\b" << "\\b78\\b" << "\\b79\\b" << "\\b7a\\b" << "\\b7b\\b"
                     << "\\b7c\\b" << "\\b7d\\b" << "\\b7e\\b" << "\\b7f\\b";
     for (const QString &pattern : keywordPatterns) {
-        rule.pattern = QRegExp(pattern);
-        rule.pattern.setCaseSensitivity(Qt::CaseInsensitive);
+        rule.pattern = pattern;
+        rule.options = QRegularExpression::CaseInsensitiveOption;
         rule.format = keywordFormat;
         highlightingRules.append(rule);
     }
 
     singleLineCommentFormat.setFontWeight(QFont::Bold);
     singleLineCommentFormat.setForeground(Qt::darkGreen);
-    rule.pattern = QRegExp(";[^\n]*");
+    rule.pattern = ";[^\n]*";
     rule.format = singleLineCommentFormat;
     highlightingRules.append(rule);
 
-    commentStartExpression = QRegExp("/\\*");
-    commentEndExpression = QRegExp("\\*/");
+    commentStartRegularExpression = "/\\*";
+    commentEndRegularExpression = "\\*/";
 }
 
 void HexHighlighter::highlightBlock(const QString &text)
 {
     for (const HighlightingRule &rule : highlightingRules) {
-        QRegExp expression(rule.pattern);
-        int index = expression.indexIn(text);
+        QRegularExpression expression(rule.pattern);
+        int index = expression.match(text).capturedStart();
         while (index >= 0) {
-            int length = expression.matchedLength();
+            int length = expression.match(text).capturedLength();
             setFormat(index, length, rule.format);
-            index = expression.indexIn(text, index + length);
+            index = expression.match(text.mid(index + length)).capturedStart();
         }
     }
     setCurrentBlockState(0);
 
     int startIndex = 0;
     if (previousBlockState() != 1)
-        startIndex = commentStartExpression.indexIn(text);
+        startIndex = QRegularExpression(commentStartRegularExpression).match(text).capturedStart();
 
     while (startIndex >= 0) {
-        int endIndex = commentEndExpression.indexIn(text, startIndex);
+        QRegularExpressionMatch commentEndMatch = QRegularExpression(commentEndRegularExpression).match(text.mid(startIndex));
+        int endIndex = commentEndMatch.capturedStart();
         int commentLength;
         if (endIndex == -1) {
             setCurrentBlockState(1);
             commentLength = text.length() - startIndex;
         } else {
             commentLength = endIndex - startIndex
-                            + commentEndExpression.matchedLength();
+                            + commentEndMatch.capturedLength();
         }
         setFormat(startIndex, commentLength, multiLineCommentFormat);
-        startIndex = commentStartExpression.indexIn(text, startIndex + commentLength);
+        startIndex = QRegularExpression(commentStartRegularExpression).match(text.mid(startIndex + commentLength)).capturedStart();
     }
 }
-

--- a/src/common/HexHighlighter.h
+++ b/src/common/HexHighlighter.h
@@ -21,14 +21,13 @@ protected:
 
 private:
     struct HighlightingRule {
-        QString pattern;
-        QRegularExpression::PatternOptions options;
+        QRegularExpression pattern;
         QTextCharFormat format;
     };
     QVector<HighlightingRule> highlightingRules;
 
-    QString commentStartRegularExpression;
-    QString commentEndRegularExpression;
+    QRegularExpression commentStartRegularExpression;
+    QRegularExpression commentEndRegularExpression;
 
     QTextCharFormat keywordFormat;
     QTextCharFormat classFormat;

--- a/src/common/HexHighlighter.h
+++ b/src/common/HexHighlighter.h
@@ -5,6 +5,7 @@
 
 #include <QHash>
 #include <QTextCharFormat>
+#include <QRegularExpression>
 
 class QTextDocument;
 
@@ -20,13 +21,14 @@ protected:
 
 private:
     struct HighlightingRule {
-        QRegExp pattern;
+        QString pattern;
+        QRegularExpression::PatternOptions options;
         QTextCharFormat format;
     };
     QVector<HighlightingRule> highlightingRules;
 
-    QRegExp commentStartExpression;
-    QRegExp commentEndExpression;
+    QString commentStartRegularExpression;
+    QString commentEndRegularExpression;
 
     QTextCharFormat keywordFormat;
     QTextCharFormat classFormat;

--- a/src/common/Highlighter.cpp
+++ b/src/common/Highlighter.cpp
@@ -13,8 +13,8 @@ Highlighter::Highlighter(QTextDocument *parent) :
     keywordFormat.setForeground(QColor(65, 131, 215));
 
     for (const QString &pattern : this->core->opcodes) {
-        rule.pattern = QRegExp("\\b" + pattern + "\\b");
-        rule.pattern.setCaseSensitivity(Qt::CaseInsensitive);
+        rule.pattern = "\\b" + pattern + "\\b";
+        rule.options = QRegularExpression::CaseInsensitiveOption;
         rule.format = keywordFormat;
         highlightingRules.append(rule);
     }
@@ -22,8 +22,8 @@ Highlighter::Highlighter(QTextDocument *parent) :
     regFormat.setForeground(QColor(236, 100, 75));
 
     for (const QString &pattern : this->core->regs) {
-        rule.pattern = QRegExp("\\b" + pattern + "\\b");
-        rule.pattern.setCaseSensitivity(Qt::CaseInsensitive);
+        rule.pattern = "\\b" + pattern + "\\b";
+        rule.options = QRegularExpression::CaseInsensitiveOption;
         rule.format = regFormat;
         highlightingRules.append(rule);
     }
@@ -31,42 +31,43 @@ Highlighter::Highlighter(QTextDocument *parent) :
 
     singleLineCommentFormat.setFontWeight(QFont::Bold);
     singleLineCommentFormat.setForeground(QColor(63, 195, 128));
-    rule.pattern = QRegExp(";[^\n]*");
+    rule.pattern = ";[^\n]*";
     rule.format = singleLineCommentFormat;
     highlightingRules.append(rule);
 
-    commentStartExpression = QRegExp("/\\*");
-    commentEndExpression = QRegExp("\\*/");
+    commentStartRegularExpression = "/\\*";
+    commentEndRegularExpression = "\\*/";
 }
 
 void Highlighter::highlightBlock(const QString &text)
 {
     for (const HighlightingRule &rule : highlightingRules) {
-        QRegExp expression(rule.pattern);
-        int index = expression.indexIn(text);
+        QRegularExpression expression(rule.pattern, rule.options);
+        int index = expression.match(text).capturedStart();
         while (index >= 0) {
-            int length = expression.matchedLength();
+            int length = expression.match(text).capturedLength();
             setFormat(index, length, rule.format);
-            index = expression.indexIn(text, index + length);
+            index = expression.match(text.mid(index + length)).capturedStart();
         }
     }
     setCurrentBlockState(0);
 
     int startIndex = 0;
     if (previousBlockState() != 1)
-        startIndex = commentStartExpression.indexIn(text);
+        startIndex = QRegularExpression(commentStartRegularExpression).match(text).capturedStart();
 
     while (startIndex >= 0) {
-        int endIndex = commentEndExpression.indexIn(text, startIndex);
+        QRegularExpressionMatch commentEndMatch = QRegularExpression(commentEndRegularExpression).match(text.mid(startIndex));
+        int endIndex = commentEndMatch.capturedStart();
         int commentLength;
         if (endIndex == -1) {
             setCurrentBlockState(1);
             commentLength = text.length() - startIndex;
         } else {
             commentLength = endIndex - startIndex
-                            + commentEndExpression.matchedLength();
+                            + commentEndMatch.capturedLength();
         }
         setFormat(startIndex, commentLength, multiLineCommentFormat);
-        startIndex = commentStartExpression.indexIn(text, startIndex + commentLength);
+        startIndex = QRegularExpression(commentStartRegularExpression).match(text.mid(startIndex + commentLength)).capturedStart();
     }
 }

--- a/src/common/Highlighter.cpp
+++ b/src/common/Highlighter.cpp
@@ -13,8 +13,8 @@ Highlighter::Highlighter(QTextDocument *parent) :
     keywordFormat.setForeground(QColor(65, 131, 215));
 
     for (const QString &pattern : this->core->opcodes) {
-        rule.pattern = "\\b" + pattern + "\\b";
-        rule.options = QRegularExpression::CaseInsensitiveOption;
+        rule.pattern.setPattern("\\b" + pattern + "\\b");
+        rule.pattern.setPatternOptions(QRegularExpression::CaseInsensitiveOption);
         rule.format = keywordFormat;
         highlightingRules.append(rule);
     }
@@ -22,8 +22,8 @@ Highlighter::Highlighter(QTextDocument *parent) :
     regFormat.setForeground(QColor(236, 100, 75));
 
     for (const QString &pattern : this->core->regs) {
-        rule.pattern = "\\b" + pattern + "\\b";
-        rule.options = QRegularExpression::CaseInsensitiveOption;
+        rule.pattern.setPattern("\\b" + pattern + "\\b");
+        rule.pattern.setPatternOptions(QRegularExpression::CaseInsensitiveOption);
         rule.format = regFormat;
         highlightingRules.append(rule);
     }
@@ -31,18 +31,18 @@ Highlighter::Highlighter(QTextDocument *parent) :
 
     singleLineCommentFormat.setFontWeight(QFont::Bold);
     singleLineCommentFormat.setForeground(QColor(63, 195, 128));
-    rule.pattern = ";[^\n]*";
+    rule.pattern.setPattern(";[^\n]*");
     rule.format = singleLineCommentFormat;
     highlightingRules.append(rule);
 
-    commentStartRegularExpression = "/\\*";
-    commentEndRegularExpression = "\\*/";
+    commentStartRegularExpression.setPattern("/\\*");
+    commentEndRegularExpression.setPattern("\\*/");
 }
 
 void Highlighter::highlightBlock(const QString &text)
 {
     for (const HighlightingRule &rule : highlightingRules) {
-        QRegularExpression expression(rule.pattern, rule.options);
+        QRegularExpression expression(rule.pattern);
         int index = expression.match(text).capturedStart();
         while (index >= 0) {
             int length = expression.match(text).capturedLength();

--- a/src/common/Highlighter.h
+++ b/src/common/Highlighter.h
@@ -25,14 +25,13 @@ private:
     CutterCore *core;
 
     struct HighlightingRule {
-        QString pattern;
-        QRegularExpression::PatternOptions options;
+        QRegularExpression pattern;
         QTextCharFormat format;
     };
     QVector<HighlightingRule> highlightingRules;
 
-    QString commentStartRegularExpression;
-    QString commentEndRegularExpression;
+    QRegularExpression commentStartRegularExpression;
+    QRegularExpression commentEndRegularExpression;
 
     QTextCharFormat keywordFormat;
     QTextCharFormat regFormat;

--- a/src/common/Highlighter.h
+++ b/src/common/Highlighter.h
@@ -6,6 +6,7 @@
 #include <QSyntaxHighlighter>
 #include <QHash>
 #include <QTextCharFormat>
+#include <QRegularExpression>
 
 class QTextDocument;
 class MainWindow;
@@ -24,13 +25,14 @@ private:
     CutterCore *core;
 
     struct HighlightingRule {
-        QRegExp pattern;
+        QString pattern;
+        QRegularExpression::PatternOptions options;
         QTextCharFormat format;
     };
     QVector<HighlightingRule> highlightingRules;
 
-    QRegExp commentStartExpression;
-    QRegExp commentEndExpression;
+    QString commentStartRegularExpression;
+    QString commentEndRegularExpression;
 
     QTextCharFormat keywordFormat;
     QTextCharFormat regFormat;

--- a/src/common/MdHighlighter.cpp
+++ b/src/common/MdHighlighter.cpp
@@ -16,14 +16,14 @@ MdHighlighter::MdHighlighter(QTextDocument *parent)
                     << "\\_\\_([^\\\\]+)\\_\\_";
 
     for (const QString &pattern : keywordPatterns) {
-        rule.pattern = QRegExp(pattern);
+        rule.pattern = pattern;
         rule.format = keywordFormat;
         highlightingRules.append(rule);
     }
 
     singleLineCommentFormat.setFontWeight(QFont::Bold);
     singleLineCommentFormat.setForeground(Qt::darkGreen);
-    rule.pattern = QRegExp(";[^\n]*");
+    rule.pattern = ";[^\n]*";
     rule.format = singleLineCommentFormat;
     highlightingRules.append(rule);
 }
@@ -31,12 +31,12 @@ MdHighlighter::MdHighlighter(QTextDocument *parent)
 void MdHighlighter::highlightBlock(const QString &text)
 {
     for (const HighlightingRule &rule : highlightingRules) {
-        QRegExp expression(rule.pattern);
-        int index = expression.indexIn(text);
+        QRegularExpression expression(rule.pattern);
+        int index = expression.match(text).capturedStart();
         while (index >= 0) {
-            int length = expression.matchedLength();
+            int length = expression.match(text).capturedLength();
             setFormat(index, length, rule.format);
-            index = expression.indexIn(text, index + length);
+            index = expression.match(text.mid(index + length)).capturedStart();
         }
     }
     setCurrentBlockState(0);

--- a/src/common/MdHighlighter.cpp
+++ b/src/common/MdHighlighter.cpp
@@ -16,14 +16,14 @@ MdHighlighter::MdHighlighter(QTextDocument *parent)
                     << "\\_\\_([^\\\\]+)\\_\\_";
 
     for (const QString &pattern : keywordPatterns) {
-        rule.pattern = pattern;
+        rule.pattern.setPattern(pattern);
         rule.format = keywordFormat;
         highlightingRules.append(rule);
     }
 
     singleLineCommentFormat.setFontWeight(QFont::Bold);
     singleLineCommentFormat.setForeground(Qt::darkGreen);
-    rule.pattern = ";[^\n]*";
+    rule.pattern.setPattern(";[^\n]*");
     rule.format = singleLineCommentFormat;
     highlightingRules.append(rule);
 }

--- a/src/common/MdHighlighter.h
+++ b/src/common/MdHighlighter.h
@@ -5,6 +5,7 @@
 
 #include <QHash>
 #include <QTextCharFormat>
+#include <QRegularExpression>
 
 class QTextDocument;
 
@@ -20,7 +21,7 @@ protected:
 
 private:
     struct HighlightingRule {
-        QString pattern;
+        QRegularExpression pattern;
         QTextCharFormat format;
     };
     QVector<HighlightingRule> highlightingRules;

--- a/src/common/MdHighlighter.h
+++ b/src/common/MdHighlighter.h
@@ -20,13 +20,10 @@ protected:
 
 private:
     struct HighlightingRule {
-        QRegExp pattern;
+        QString pattern;
         QTextCharFormat format;
     };
     QVector<HighlightingRule> highlightingRules;
-
-    QRegExp commentStartExpression;
-    QRegExp commentEndExpression;
 
     QTextCharFormat keywordFormat;
     QTextCharFormat classFormat;

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -293,7 +293,7 @@ bool CutterCore::sdbSet(QString path, QString key, QString val)
 
 QString CutterCore::sanitizeStringForCommand(QString s)
 {
-    static const QRegExp regexp(";|@");
+    static const QRegularExpression regexp(";|@");
     return s.replace(regexp, QStringLiteral("_"));
 }
 
@@ -955,7 +955,7 @@ QString CutterCore::createFunctionAt(RVA addr)
 
 QString CutterCore::createFunctionAt(RVA addr, QString name)
 {
-    static const QRegExp regExp("[^a-zA-Z0-9_]");
+    static const QRegularExpression regExp("[^a-zA-Z0-9_]");
     name.remove(regExp);
     QString command = "af " + name + " " + RAddressString(addr);
     QString ret = cmd(command);
@@ -2727,9 +2727,12 @@ void CutterCore::deleteProject(const QString &name)
 
 bool CutterCore::isProjectNameValid(const QString &name)
 {
-    // see is_valid_project_name() in libr/core/project.c
-    static const QRegExp regexp(R"(^[a-zA-Z0-9\\\._:-]{1,}$)");
-    return regexp.exactMatch(name) && !name.endsWith(".zip") ;
+    // see is_valid_project_name() in libr/core/project.
+
+    QString pattern(R"(^[a-zA-Z0-9\\\._:-]{1,}$)");
+    // The below construct mimics the behaviour of QRegexP::exactMatch(), which was here before
+    static const QRegularExpression regexp("\\A(?:" + pattern + ")\\z");
+    return regexp.match(name).hasMatch() && !name.endsWith(".zip") ;
 }
 
 QList<DisassemblyLine> CutterCore::disassembleLines(RVA offset, int lines)

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -1122,7 +1122,7 @@ void MainWindow::resetDockWidgetList()
     for (auto it : dockWidgets) {
         if (isLeft.contains(it->metaObject()->className())) {
             toClose.append(it);
-        } else if (QRegExp("\\w+ \\d+").exactMatch(it->objectName())) {
+        } else if (QRegularExpression("\\A(?:\\w+ \\d+)\\z").match(it->objectName()).hasMatch()) {
             isLeft.append(it->metaObject()->className());
         }
     }

--- a/src/dialogs/HexdumpRangeDialog.cpp
+++ b/src/dialogs/HexdumpRangeDialog.cpp
@@ -1,7 +1,7 @@
 #include "HexdumpRangeDialog.h"
 #include "ui_HexdumpRangeDialog.h"
 
-#include <QRegExpValidator>
+#include <QRegularExpressionValidator>
 #include <QPushButton>
 #include <cstdint>
 #include "core/Cutter.h"
@@ -12,7 +12,7 @@ HexdumpRangeDialog::HexdumpRangeDialog(QWidget *parent, bool allowEmpty) :
     allowEmpty(allowEmpty)
 {
     ui->setupUi(this);
-    QRegExpValidator *v = new QRegExpValidator(QRegExp("(?:0[xX])?[0-9a-fA-F]+"), this);
+    QRegularExpressionValidator *v = new QRegularExpressionValidator(QRegularExpression("(?:0[xX])?[0-9a-fA-F]+"), this);
     ui->lengthLineEdit->setValidator(v);
     ui->startAddressLineEdit->setValidator(v);
     ui->endAddressLineEdit->setValidator(v);

--- a/src/dialogs/preferences/AppearanceOptionsWidget.cpp
+++ b/src/dialogs/preferences/AppearanceOptionsWidget.cpp
@@ -258,7 +258,7 @@ QIcon AppearanceOptionsWidget::getIconFromSvg(const QString& fileName, const QCo
         return QIcon();
     }
     QString data = file.readAll();
-    data.replace(QRegExp(QString("#%1").arg(before.isValid() ? before.name().remove(0, 1) : "[0-9a-fA-F]{6}")),
+    data.replace(QRegularExpression(QString("#%1").arg(before.isValid() ? before.name().remove(0, 1) : "[0-9a-fA-F]{6}")),
                  QString("%1").arg(after.name()));
 
     QSvgRenderer svgRenderer(data.toUtf8());

--- a/src/widgets/ColorPicker.cpp
+++ b/src/widgets/ColorPicker.cpp
@@ -225,7 +225,8 @@ void ColorPicker::setColor(const QColor& color)
 void ColorPicker::colorChannelChanged()
 {
     QString txt = ui->hexLineEdit->text();
-    if (!QRegExp("#[0-9a-fA-F]{6}").exactMatch(txt)) {
+    // Regex pattern below mimics the behaviour of former RegExp::exactMatch()
+    if (!QRegularExpression("\\A(?:#[0-9a-fA-F]{6})\\z").match(txt).hasMatch()) {
         return;
     }
     QColor hexColor = txt;

--- a/src/widgets/ColorThemeListView.cpp
+++ b/src/widgets/ColorThemeListView.cpp
@@ -192,7 +192,7 @@ QPixmap ColorOptionDelegate::getPixmapFromSvg(const QString& fileName, const QCo
         return QPixmap();
     }
     QString data = file.readAll();
-    data.replace(QRegExp("#[0-9a-fA-F]{6}"), QString("%1").arg(after.name()));
+    data.replace(QRegularExpression("#[0-9a-fA-F]{6}"), QString("%1").arg(after.name()));
 
     QSvgRenderer svgRenderer(data.toUtf8());
     QPixmap pix(QSize(qApp->fontMetrics().height(), qApp->fontMetrics().height()));


### PR DESCRIPTION
**Detailed description**

According to #961, all `QRegExp` should get replaced by `QRegularExpression`. I did all that changes in the code and refacrored it so that it *should* work like before. However, as I am no user of `Cutter` and do not know, how to use the software, I am unable to know out of the box, what actions I have to perform, to verify the code changes. 

If you give me a hint, what I have to do in the interfaces to see the behaviour, I will of course examine the behaviour myself

closes #961