### PR TITLE
Redirect stdout/stderr to Console Widget

### DIFF
--- a/src/widgets/ConsoleWidget.cpp
+++ b/src/widgets/ConsoleWidget.cpp
@@ -366,7 +366,7 @@ void ConsoleWidget::redirectOutput()
     QString pipeName = QString::fromLatin1(PIPE_NAME).arg(QUuid::createUuid().toString());
 
     SECURITY_ATTRIBUTES attributes = {sizeof(SECURITY_ATTRIBUTES), 0, false};
-    hWrite = CreateNamedPipe((wchar_t*)pipeName.utf16(), PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED,
+    hWrite = CreateNamedPipeW((wchar_t*)pipeName.utf16(), PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED,
                              PIPE_TYPE_BYTE | PIPE_WAIT, 1, PIPE_SIZE, PIPE_SIZE, 0, &attributes);
  
     int writeFd = _open_osfhandle((intptr_t)hWrite, _O_WRONLY | _O_TEXT);

--- a/src/widgets/ConsoleWidget.cpp
+++ b/src/widgets/ConsoleWidget.cpp
@@ -351,7 +351,7 @@ void ConsoleWidget::processQueuedOutput()
 
         // Get the last segment that wasn't overwritten by carriage return
         output = output.trimmed();
-        addOutput(output.remove(0, output.lastIndexOf('\r')));
+        addOutput(output.remove(0, output.lastIndexOf('\r')).trimmed());
     }
 }
 

--- a/src/widgets/ConsoleWidget.cpp
+++ b/src/widgets/ConsoleWidget.cpp
@@ -404,14 +404,14 @@ void ConsoleWidget::redirectOutput()
 
     SECURITY_ATTRIBUTES attributes = {sizeof(SECURITY_ATTRIBUTES), 0, false};
     hWrite = ::CreateNamedPipe((wchar_t*)pipeName.utf16(), PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED,
-                                  PIPE_TYPE_BYTE | PIPE_WAIT, 1, PIPE_SIZE, PIPE_SIZE, 0, &attributes);
+                               PIPE_TYPE_BYTE | PIPE_WAIT, 1, PIPE_SIZE, PIPE_SIZE, 0, &attributes);
     
     localSocket = new QLocalSocket(this);
     localSocket->connectToServer(pipeName, QIODevice::ReadOnly);
 
     connect(localSocket, SIGNAL(readyRead()), this, SLOT(processQueuedOutput()));
 
-    int writeFd = _open_osfhandle((intptr_t)hWrite, _O_WRONLY|_O_TEXT);
+    int writeFd = _open_osfhandle((intptr_t)hWrite, _O_WRONLY | _O_TEXT);
 
     dup2(writeFd, fileno(stdout));
     dup2(writeFd, fileno(stderr));

--- a/src/widgets/ConsoleWidget.cpp
+++ b/src/widgets/ConsoleWidget.cpp
@@ -358,7 +358,7 @@ void ConsoleWidget::processQueuedOutput()
 void ConsoleWidget::redirectOutput()
 {
     // Make sure that we are running in a valid console with initialized output handles
-    if(0 > fileno(stderr) && 0 > fileno(stdout)) {
+    if (0 > fileno(stderr) && 0 > fileno(stdout)) {
         addOutput("Run cutter in a console to enable r2 output redirection into this widget.");
         return;
     }
@@ -372,7 +372,7 @@ void ConsoleWidget::redirectOutput()
 
     SECURITY_ATTRIBUTES attributes = {sizeof(SECURITY_ATTRIBUTES), 0, false};
     hWrite = CreateNamedPipeW((wchar_t*)pipeName.utf16(), PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED,
-                             PIPE_TYPE_BYTE | PIPE_WAIT, 1, PIPE_SIZE, PIPE_SIZE, 0, &attributes);
+                              PIPE_TYPE_BYTE | PIPE_WAIT, 1, PIPE_SIZE, PIPE_SIZE, 0, &attributes);
  
     int writeFd = _open_osfhandle((intptr_t)hWrite, _O_WRONLY | _O_TEXT);
     dup2(writeFd, fileno(stdout));

--- a/src/widgets/ConsoleWidget.h
+++ b/src/widgets/ConsoleWidget.h
@@ -7,6 +7,7 @@
 
 #include <QStringListModel>
 #include <QSocketNotifier>
+#include <QLocalSocket>
 
 #include <memory>
 
@@ -96,11 +97,17 @@ private:
     QCompleter *completer;
     QShortcut *historyUpShortcut;
     QShortcut *historyDownShortcut;
-    int redirectPipeFds[2];
     FILE *origStderr;
     FILE *origStdout;
+#ifdef Q_OS_WIN
+    QLocalSocket *localSocket;
+    HANDLE hRead;
+    HANDLE hWrite;
+#else
+    int redirectPipeFds[2];
     QVector<char> *redirectionBuffer;
     QSocketNotifier *outputNotifier;
+#endif
 };
 
 #endif // CONSOLEWIDGET_H

--- a/src/widgets/ConsoleWidget.h
+++ b/src/widgets/ConsoleWidget.h
@@ -6,6 +6,7 @@
 #include "common/CommandTask.h"
 
 #include <QStringListModel>
+#include <QSocketNotifier>
 
 #include <memory>
 
@@ -62,6 +63,11 @@ private slots:
 
     void clear();
 
+    /**
+     * @brief Passes redirected output from the pipe to the terminal and console
+     */
+    void processQueuedOutput();
+
 private:
     void scrollOutputToEnd();
     void historyAdd(const QString &input);
@@ -69,6 +75,12 @@ private:
     void removeLastLine();
     void executeCommand(const QString &command);
     void setWrap(bool wrap);
+
+    /**
+     * @brief Redirects stderr and stdout to the output pipe which is handled by
+     *        processQueuedOutput
+     */
+    void redirectOutput();
 
     QSharedPointer<CommandTask> commandTask;
 
@@ -84,6 +96,11 @@ private:
     QCompleter *completer;
     QShortcut *historyUpShortcut;
     QShortcut *historyDownShortcut;
+    int redirectPipeFds[2];
+    FILE *origStderr;
+    FILE *origStdout;
+    QVector<char> *redirectionBuffer;
+    QSocketNotifier *outputNotifier;
 };
 
 #endif // CONSOLEWIDGET_H

--- a/src/widgets/ConsoleWidget.h
+++ b/src/widgets/ConsoleWidget.h
@@ -99,8 +99,8 @@ private:
     QShortcut *historyDownShortcut;
     FILE *origStderr;
     FILE *origStdout;
+    QLocalSocket *pipeSocket;
 #ifdef Q_OS_WIN
-    QLocalSocket *localSocket;
     HANDLE hRead;
     HANDLE hWrite;
 #else


### PR DESCRIPTION
**Detailed description**

Currently, python plugin output printed by print() and radare/cutter output printed into stderr/stdout is only shown in console.
This branch adds stdout/stderr redirection to the console widget in addition to the regular console.

**Test plan (required)**

Create a plugin that prints a prepared text with the text formatting available in r2 at a very high rate, compare the console widget output to the text file to make sure there weren't any loses and visually go over the output to confirm that the text was formatted correctly.

**Closing issues**
closes #1434 
closes #966 