### PR TITLE
Fix refresh after renaming imported function

### DIFF
--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -769,7 +769,7 @@ void DisassemblyContextMenu::on_actionRenameUsedHere_triggered()
         if (!newName.isEmpty()) {
             Core()->cmd("an " + newName + " @ " + QString::number(offset));
 
-            if (type == ThingUsedHere::Type::Address || type == ThingUsedHere::Type::Address) {
+            if (type == ThingUsedHere::Type::Address || type == ThingUsedHere::Type::Flag) {
                 Core()->triggerFlagsChanged();
             } else if (type == ThingUsedHere::Type::Var) {
                 Core()->triggerVarsChanged();


### PR DESCRIPTION
**Detailed description**

The first issue is that the disassembly function to rename a "used" function was not checking for Flag types.

There is a second issue which I am not sure if is a concern or not. The imported functions contain both a "flag" and a "function" type. Does this mean `functionRenamed()` and `flagRenamed()` should be emitted?


**Test plan (required)**

1. Rename an imported system function, observe that the view is refreshed immediately. 

![test-rename-imported-function](https://user-images.githubusercontent.com/6268446/66442410-2a41eb80-ea2a-11e9-858e-29bb32e64155.gif)


**Closing issues**

#1738
