### PR TITLE
Fix Native Plugin Loading for CMake

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -164,7 +164,9 @@ endif()
 
 
 add_executable(Cutter MACOSX_BUNDLE ${UI_FILES} ${QRC_FILES} ${SOURCE_FILES} ${HEADER_FILES} ${BINDINGS_SOURCE})
-set_target_properties(Cutter PROPERTIES MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/macos/Info.plist")
+set_target_properties(Cutter PROPERTIES
+        ENABLE_EXPORTS ON
+        MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/macos/Info.plist")
 
 if (TARGET Graphviz::GVC)
     target_link_libraries(Cutter Graphviz::GVC)


### PR DESCRIPTION
Regression introduced by #1805, cc @karliss:
```
[florian@florian-desktop cmake-build-debug]$ ./Cutter
Loading "/home/florian/.cutterrc"
Plugins are loaded from "/home/florian/.local/share/RadareOrg/Cutter/plugins"
Load Error for plugin "libr2ghidra_cutter.so" : "Cannot load library /home/florian/.local/share/RadareOrg/Cutter/plugins/native/libr2ghidra_cutter.so: (/home/florian/.local/share/RadareOrg/Cutter/plugins/native/libr2ghidra_cutter.so: undefined symbol: _ZNK10Decompiler10metaObjectEv)"
Loaded 0 plugin(s).
```

Because of https://cmake.org/cmake/help/v3.4/policy/CMP0065.html#policy:CMP0065, which was introduced in CMake 3.4, `ENABLE_EXPORTS` was disabled by default, which is required for native plugins to work.