### PR TITLE
Add shortcuts to breakpoints widget

### DIFF
--- a/src/widgets/BreakpointWidget.cpp
+++ b/src/widgets/BreakpointWidget.cpp
@@ -127,14 +127,16 @@ BreakpointWidget::BreakpointWidget(MainWindow *main, QAction *action) :
     });
 
     setScrollMode();
-
+ 
     actionDelBreakpoint = new QAction(tr("Delete breakpoint"), this);
     actionDelBreakpoint->setShortcut(Qt::Key_Delete);
+    actionDelBreakpoint->setShortcutContext(Qt::WidgetShortcut);
     connect(actionDelBreakpoint, &QAction::triggered, this, &BreakpointWidget::delBreakpoint);
     ui->breakpointTreeView->addAction(actionDelBreakpoint);
 
     actionToggleBreakpoint = new QAction(tr("Toggle breakpoint"), this);
     actionToggleBreakpoint->setShortcut(Qt::Key_Space);
+    actionToggleBreakpoint->setShortcutContext(Qt::WidgetShortcut);
     connect(actionToggleBreakpoint, &QAction::triggered, this, &BreakpointWidget::toggleBreakpoint);
     ui->breakpointTreeView->addAction(actionToggleBreakpoint);
 

--- a/src/widgets/BreakpointWidget.cpp
+++ b/src/widgets/BreakpointWidget.cpp
@@ -127,10 +127,17 @@ BreakpointWidget::BreakpointWidget(MainWindow *main, QAction *action) :
     });
 
     setScrollMode();
+
     actionDelBreakpoint = new QAction(tr("Delete breakpoint"), this);
-    actionToggleBreakpoint = new QAction(tr("Toggle breakpoint"), this);
+    actionDelBreakpoint->setShortcut(Qt::Key_Delete);
     connect(actionDelBreakpoint, &QAction::triggered, this, &BreakpointWidget::delBreakpoint);
+    ui->breakpointTreeView->addAction(actionDelBreakpoint);
+
+    actionToggleBreakpoint = new QAction(tr("Toggle breakpoint"), this);
+    actionToggleBreakpoint->setShortcut(Qt::Key_Space);
     connect(actionToggleBreakpoint, &QAction::triggered, this, &BreakpointWidget::toggleBreakpoint);
+    ui->breakpointTreeView->addAction(actionToggleBreakpoint);
+
     connect(Core(), &CutterCore::refreshAll, this, &BreakpointWidget::refreshBreakpoint);
     connect(Core(), &CutterCore::breakpointsChanged, this, &BreakpointWidget::refreshBreakpoint);
     connect(Core(), &CutterCore::refreshCodeViews, this, &BreakpointWidget::refreshBreakpoint);


### PR DESCRIPTION
 <!-- Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request. -->


**Detailed description**
This PR adds the <kbd>Space</kbd> shortcut to toggle breakpoint and <kbd>Del</kbd> shortcut to delete it. 

**Test plan (required)**
1. Enter emulation mode
2. Define breakpoint(s)
3. Open the breakpoint widget
4. Toggle breakpoint using <kbd>space</kbd>
5. Toggle breakpoint using context menu
6. Delete breakpoint using <kbd>Del</kbd>

