### PR TITLE
Fix graph zoom reset and use same font size as everything else.

### DIFF
--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -401,7 +401,7 @@ void DisassemblerGraphView::cleanupEdges()
 
 void DisassemblerGraphView::initFont()
 {
-    setFont(Config()->getBaseFont());
+    setFont(Config()->getFont());
     QFontMetricsF metrics(font());
     baseline = int(metrics.ascent());
     charWidth = metrics.width('X');
@@ -418,7 +418,7 @@ void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block,
 
     p.setPen(Qt::black);
     p.setBrush(Qt::gray);
-    p.setFont(Config()->getBaseFont());
+    p.setFont(Config()->getFont());
     p.drawRect(blockRect);
 
     breakpoints = Core()->getBreakpointsAddresses();
@@ -776,13 +776,19 @@ void DisassemblerGraphView::onSeekChanged(RVA addr)
 
 void DisassemblerGraphView::zoom(QPointF mouseRelativePos, double velocity)
 {
+    qreal newScale = getViewScale() * std::pow(1.25, velocity);
+    setZoom(mouseRelativePos, newScale);
+}
+
+void DisassemblerGraphView::setZoom(QPointF mouseRelativePos, double scale)
+{
     mouseRelativePos.rx() *= size().width();
     mouseRelativePos.ry() *= size().height();
     mouseRelativePos /= getViewScale();
 
     auto globalMouse = mouseRelativePos + getViewOffset();
     mouseRelativePos *= getViewScale();
-    qreal newScale = getViewScale() * std::pow(1.25, velocity);
+    qreal newScale = scale;
     newScale = std::max(newScale, 0.05);
     mouseRelativePos /= newScale;
     setViewScale(newScale);
@@ -806,9 +812,7 @@ void DisassemblerGraphView::zoomOut()
 
 void DisassemblerGraphView::zoomReset()
 {
-    setViewScale(1.0);
-    viewport()->update();
-    emit viewZoomed();
+    setZoom(QPointF(0.5, 0.5), 1);
 }
 
 void DisassemblerGraphView::takeTrue()

--- a/src/widgets/DisassemblerGraphView.h
+++ b/src/widgets/DisassemblerGraphView.h
@@ -131,6 +131,7 @@ public slots:
     void fontsUpdatedSlot();
     void onSeekChanged(RVA addr);
     void zoom(QPointF mouseRelativePos, double velocity);
+    void setZoom(QPointF mouseRelativePos, double scale);
     void zoomIn();
     void zoomOut();
     void zoomReset();


### PR DESCRIPTION
 <!-- Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request. -->


**Detailed description**

Fix graph zoom reset  (see test plan for instructions how to produce the bug).

Use same font size as disassembly widget when no additional zooming in graph has been done.

**Test plan (required)**

* Zoom in to a graph block
* Zoom out so that everything is small using keyboard without adjusting position
* Reset zoom using ctrl+= observe that block is still in the middle of screen, before fix view would move somewhere to the top left corner

**Closing issues**

<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
