### PR TITLE
Rebase debug to current main

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1188,7 +1188,7 @@ void CutterCore::stopDebug()
             cmd(QString("dp- %1; o %2; .ar-").arg(QString::number(currentlyAttachedToPID), currentlyOpenFile));
             currentlyAttachedToPID = -1;
         } else {
-            cmd(QString("dk 9; e cfg.debug=false; o %1; .ar-").arg(currentlyOpenFile));
+            cmd("dk 9; oo; .ar-");
             // close ptrace file descriptors left open
             QJsonArray openFilesArray = cmdj("oj").array();;
             for (QJsonValue value : openFilesArray) {
@@ -2857,7 +2857,7 @@ QString CutterCore::getVersionInformation()
         { "r_hash", &r_hash_version },
         { "r_fs", &r_fs_version },
         { "r_io", &r_io_version },
-#if !USE_LIB_MAGIC        
+#if !USE_LIB_MAGIC
         { "r_magic", &r_magic_version },
 #endif
         { "r_parse", &r_parse_version },

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1122,6 +1122,7 @@ void CutterCore::startDebug()
     if (!currentlyDebugging) {
         offsetPriorDebugging = getOffset();
     }
+    currentlyOpenFile = getConfig("file.path");
     cmd("ood");
     emit registersChanged();
     if (!currentlyDebugging) {
@@ -1140,8 +1141,7 @@ void CutterCore::startEmulation()
         offsetPriorDebugging = getOffset();
     }
     // clear registers, init esil state, stack, progcounter at current seek
-    cmd("ar0; aei; aeim; aeip");
-    emit registersChanged();
+    cmd("aei; aeim; aeip");
     if (!currentlyDebugging || !currentlyEmulating) {
         // prevent register flags from appearing during debug/emul
         setConfig("asm.flags", false);
@@ -1152,6 +1152,7 @@ void CutterCore::startEmulation()
         emit changeDebugView();
         emit flagsChanged();
     }
+    emit registersChanged();
     emit stackChanged();
     emit refreshCodeViews();
 }
@@ -1164,7 +1165,7 @@ void CutterCore::attachDebug(int pid)
     // attach to process with dbg plugin
     cmd("o-*; e cfg.debug = true; o+ dbg://" + QString::number(pid));
     QString programCounterValue = cmd("dr?`drn PC`").trimmed();
-    seekAndShow(programCounterValue);
+    seek(programCounterValue);
     emit registersChanged();
     if (!currentlyDebugging || !currentlyEmulating) {
         // prevent register flags from appearing during debug/emul
@@ -1187,7 +1188,16 @@ void CutterCore::stopDebug()
             cmd(QString("dp- %1; o %2; .ar-").arg(QString::number(currentlyAttachedToPID), currentlyOpenFile));
             currentlyAttachedToPID = -1;
         } else {
-            cmd("dk 9; oo; .ar-");
+            cmd(QString("dk 9; e cfg.debug=false; o %1; .ar-").arg(currentlyOpenFile));
+            // close ptrace file descriptors left open
+            QJsonArray openFilesArray = cmdj("oj").array();;
+            for (QJsonValue value : openFilesArray) {
+                QJsonObject openFile = value.toObject();
+                QString URI = openFile["uri"].toString();
+                if (URI.contains("ptrace")) {
+                    cmd("o-" + QString::number(openFile["fd"].toInt()));
+                }
+            }
         }
         seekAndShow(offsetPriorDebugging);
         setConfig("asm.flags", true);
@@ -1196,6 +1206,13 @@ void CutterCore::stopDebug()
         emit flagsChanged();
         emit changeDefinedView();
     }
+}
+
+void CutterCore::syncAndSeekProgramCounter()
+{
+    QString programCounterValue = cmd("dr?`drn PC`").trimmed();
+    seek(programCounterValue);
+    emit registersChanged();
 }
 
 void CutterCore::continueDebug()
@@ -1220,6 +1237,7 @@ void CutterCore::continueUntilDebug(QString offset)
             cmd("dcu " + offset);
         }
         emit registersChanged();
+        emit stackChanged();
         emit refreshCodeViews();
     }
 }
@@ -1232,9 +1250,7 @@ void CutterCore::continueUntilCall()
         } else {
             cmd("dcc");
         }
-        QString programCounterValue = cmd("dr?`drn PC`").trimmed();
-        seekAndShow(programCounterValue);
-        emit registersChanged();
+        syncAndSeekProgramCounter();
     }
 }
 
@@ -1246,29 +1262,31 @@ void CutterCore::continueUntilSyscall()
         } else {
             cmd("dcs");
         }
-        QString programCounterValue = cmd("dr?`drn PC`").trimmed();
-        seekAndShow(programCounterValue);
-        emit registersChanged();
+        syncAndSeekProgramCounter();
     }
 }
 
 void CutterCore::stepDebug()
 {
     if (currentlyDebugging) {
-        cmdEsil("ds");
-        QString programCounterValue = cmd("dr?`drn PC`").trimmed();
-        seekAndShow(programCounterValue);
-        emit registersChanged();
+        if (currentlyEmulating) {
+            cmdEsil("aes");
+        } else {
+            cmd("ds");
+        }
+        syncAndSeekProgramCounter();
     }
 }
 
 void CutterCore::stepOverDebug()
 {
     if (currentlyDebugging) {
-        cmdEsil("dso");
-        QString programCounterValue = cmd("dr?`drn PC`").trimmed();
-        seekAndShow(programCounterValue);
-        emit registersChanged();
+        if (currentlyEmulating) {
+            cmdEsil("aeso");
+        } else {
+            cmd("dso");
+        }
+        syncAndSeekProgramCounter();
     }
 }
 
@@ -1276,9 +1294,7 @@ void CutterCore::stepOutDebug()
 {
     if (currentlyDebugging) {
         cmd("dsf");
-        QString programCounterValue = cmd("dr?`drn PC`").trimmed();
-        seekAndShow(programCounterValue);
-        emit registersChanged();
+        syncAndSeekProgramCounter();
     }
 }
 

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -225,6 +225,7 @@ public:
     void startEmulation();
     void attachDebug(int pid);
     void stopDebug();
+    void syncAndSeekProgramCounter();
     void continueDebug();
     void continueUntilCall();
     void continueUntilSyscall();

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -212,7 +212,9 @@ void MainWindow::initToolBar()
 
     DebugActions *debugActions = new DebugActions(ui->mainToolBar, this);
     // Debug menu
+    ui->menuDebug->addAction(debugActions->actionStart);
     ui->menuDebug->addAction(debugActions->actionStartEmul);
+    ui->menuDebug->addAction(debugActions->actionAttach);
     ui->menuDebug->addSeparator();
     ui->menuDebug->addAction(debugActions->actionStep);
     ui->menuDebug->addAction(debugActions->actionStepOver);

--- a/src/widgets/DebugActions.cpp
+++ b/src/widgets/DebugActions.cpp
@@ -158,7 +158,7 @@ DebugActions::DebugActions(QToolBar *toolBar, MainWindow *main) :
 
 void DebugActions::setButtonVisibleIfMainExists()
 {
-    int mainExists = Core()->cmd("f?main; ??").toInt();
+    int mainExists = Core()->cmd("f?sym.main; ??").toInt();
     // if main is not a flag we hide the continue until main button
     if (!mainExists) {
         actionContinueUntilMain->setVisible(false);
@@ -168,7 +168,8 @@ void DebugActions::setButtonVisibleIfMainExists()
 
 void DebugActions::continueUntilMain()
 {
-    Core()->continueUntilDebug("main");
+    QString mainAddr = Core()->cmd("?v sym.main");
+    Core()->continueUntilDebug(mainAddr);
 }
 
 void DebugActions::attachProcessDialog()

--- a/src/widgets/DebugActions.cpp
+++ b/src/widgets/DebugActions.cpp
@@ -71,11 +71,11 @@ DebugActions::DebugActions(QToolBar *toolBar, MainWindow *main) :
     QMenu *startMenu = new QMenu(startButton);
 
     // only emulation is currently allowed
-    // startMenu->addAction(actionStart);
-    // startMenu->addAction(actionAttach);
-    // startButton->setDefaultAction(actionStart);
+    startMenu->addAction(actionStart);
     startMenu->addAction(actionStartEmul);
-    startButton->setDefaultAction(actionStartEmul);
+    startMenu->addAction(actionAttach);
+    startButton->setDefaultAction(actionStart);
+    // startButton->setDefaultAction(actionStartEmul);
     startButton->setMenu(startMenu);
 
     QToolButton *continueUntilButton = new QToolButton;

--- a/src/widgets/DebugActions.cpp
+++ b/src/widgets/DebugActions.cpp
@@ -78,7 +78,7 @@ DebugActions::DebugActions(QToolBar *toolBar, MainWindow *main) :
     // startButton->setDefaultAction(actionStartEmul);
     startButton->setMenu(startMenu);
 
-    QToolButton *continueUntilButton = new QToolButton;
+    continueUntilButton = new QToolButton;
     continueUntilButton->setPopupMode(QToolButton::MenuButtonPopup);
     connect(continueUntilButton, &QToolButton::triggered, continueUntilButton,
             &QToolButton::setDefaultAction);
@@ -112,6 +112,7 @@ DebugActions::DebugActions(QToolBar *toolBar, MainWindow *main) :
         actionStart->setIcon(startDebugIcon);
         actionStartEmul->setText(startEmulLabel);
         actionStartEmul->setIcon(startEmulIcon);
+        continueUntilButton->setDefaultAction(actionContinueUntilMain);
         setAllActionsVisible(false);
     });
     connect(actionStep, &QAction::triggered, Core(), &CutterCore::stepDebug);
@@ -130,6 +131,7 @@ DebugActions::DebugActions(QToolBar *toolBar, MainWindow *main) :
         actionStartEmul->setVisible(false);
         actionStart->setText(restartDebugLabel);
         actionStart->setIcon(restartIcon);
+        setButtonVisibleIfMainExists();
         Core()->startDebug();
     });
 
@@ -152,6 +154,16 @@ DebugActions::DebugActions(QToolBar *toolBar, MainWindow *main) :
     connect(actionContinueUntilMain, &QAction::triggered, this, &DebugActions::continueUntilMain);
     connect(actionContinueUntilCall, &QAction::triggered, Core(), &CutterCore::continueUntilCall);
     connect(actionContinueUntilSyscall, &QAction::triggered, Core(), &CutterCore::continueUntilSyscall);
+}
+
+void DebugActions::setButtonVisibleIfMainExists()
+{
+    int mainExists = Core()->cmd("f?main; ??").toInt();
+    // if main is not a flag we hide the continue until main button
+    if (!mainExists) {
+        actionContinueUntilMain->setVisible(false);
+        continueUntilButton->setDefaultAction(actionContinueUntilCall);
+    }
 }
 
 void DebugActions::continueUntilMain()

--- a/src/widgets/DebugActions.h
+++ b/src/widgets/DebugActions.h
@@ -4,6 +4,7 @@
 
 class MainWindow;
 class QToolBar;
+class QToolButton;
 
 class DebugActions : public QObject
 {
@@ -30,10 +31,12 @@ public:
 private:
     MainWindow *main;
     QList<QAction *> allActions;
+    QToolButton *continueUntilButton;
 
 private slots:
     void continueUntilMain();
     void attachProcessDialog();
     void attachProcess(int pid);
     void setAllActionsVisible(bool visible);
+    void setButtonVisibleIfMainExists();
 };


### PR DESCRIPTION
**Detailed description**
 
To submit PRs for this branch it would be best if it is rebased to upstream first, otherwise any future pull will come with lots of file changes from a previous merge/rebase and make it really hard for the maintainers to understand the changes.

Diff'd with master while going over the changes at https://github.com/radareorg/cutter/compare/debug, seems alright. Might need to re-add MemoryMapWidget.ui later(was removed in upstream, wasn't changed in debug).

Potentially solved #1162 by updating everything - couldn't replicate the issues on Windows 10.