### PR TITLE
Deduplicate seek forward and backward action.

### DIFF
--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -1283,16 +1283,6 @@ void MainWindow::on_actionForward_triggered()
     core->seekNext();
 }
 
-void MainWindow::on_actionUndoSeek_triggered()
-{
-    core->seekPrev();
-}
-
-void MainWindow::on_actionRedoSeek_triggered()
-{
-    core->seekNext();
-}
-
 void MainWindow::on_actionDisasAdd_comment_triggered()
 {
     CommentsDialog c(this);

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -168,8 +168,6 @@ private slots:
 
     void on_actionBackward_triggered();
     void on_actionForward_triggered();
-    void on_actionUndoSeek_triggered();
-    void on_actionRedoSeek_triggered();
 
     void on_actionOpen_triggered();
 

--- a/src/core/MainWindow.ui
+++ b/src/core/MainWindow.ui
@@ -113,8 +113,8 @@
      <string>Edit</string>
     </property>
     <addaction name="actionSearch"/>
-    <addaction name="actionUndoSeek"/>
-    <addaction name="actionRedoSeek"/>
+    <addaction name="actionBackward"/>
+    <addaction name="actionForward"/>
     <addaction name="separator"/>
     <addaction name="actionPreferences"/>
    </widget>
@@ -293,16 +293,6 @@
     <string>Ctrl+S</string>
    </property>
   </action>
-  <action name="actionUndoSeek">
-   <property name="text">
-    <string>Undo Seek</string>
-   </property>
-  </action>
-  <action name="actionRedoSeek">
-   <property name="text">
-    <string>Redo Seek</string>
-   </property>
-  </action>
   <action name="actionCut">
    <property name="text">
     <string>Cut</string>
@@ -358,7 +348,7 @@
      <normaloff>:/img/icons/arrow_left.svg</normaloff>:/img/icons/arrow_left.svg</iconset>
    </property>
    <property name="text">
-    <string>Back</string>
+    <string>Undo Seek</string>
    </property>
    <property name="toolTip">
     <string>Go back</string>
@@ -370,7 +360,7 @@
      <normaloff>:/img/icons/arrow_right.svg</normaloff>:/img/icons/arrow_right.svg</iconset>
    </property>
    <property name="text">
-    <string>Forward</string>
+    <string>Redo Seek</string>
    </property>
   </action>
   <action name="actionLock">
@@ -884,11 +874,6 @@
   <action name="actionSaveAs">
    <property name="text">
     <string>Save As...</string>
-   </property>
-  </action>
-  <action name="actionTmp">
-   <property name="text">
-    <string>Tmp</string>
    </property>
   </action>
   <action name="actionGraph">


### PR DESCRIPTION

 <!-- Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request. -->


**Detailed description**

Use the same QAction for seek in menu bar and toolbar. Allows action shortcut to be displayed in any of applicable places. Will also help with state synchronization in future if we decide to implement disabling of buttons when further seeking is not possible.

Don't want to steal too many "good first issue" from those who need them, but I didn't want to explain Qt recommended approach one more time.

<!-- Explain the **details** for making this change. What existing problem does the pull request solve? Please provide enough information so that others can review your pull request -->


**Test plan (required)**

* Test that buttons in toolbar work
* Test buttons in the menu
* Make sure menu displays shortcuts

![seek_but](https://user-images.githubusercontent.com/7101031/66864327-929a4b00-ef9d-11e9-95c3-93a4eb0bd1b2.png)

**Closing issues**

Closes #1836 
<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
