### PR TITLE
Fix renaming a function with backslash in the name

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -322,6 +322,10 @@ QString CutterCore::cmdRaw(const QString &str)
 {
     QString cmdStr = str;
     cmdStr.replace('\"', QStringLiteral("\\\""));
+    // If the last token ends in '\', do not escape the end quote.
+    if (cmdStr.endsWith("\\")) {
+        cmdStr.append(" ");
+    }
     return cmd(cmdStr.prepend('\"').append('\"'));
 }
 
@@ -506,7 +510,7 @@ bool CutterCore::openFile(QString path, RVA mapaddr)
 
 void CutterCore::renameFunction(const QString &oldName, const QString &newName)
 {
-    cmdRaw("afn " + newName + " " + oldName + " ");
+    cmdRaw("afn " + newName + " " + oldName);
     emit functionRenamed(oldName, newName);
 }
 

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -506,7 +506,7 @@ bool CutterCore::openFile(QString path, RVA mapaddr)
 
 void CutterCore::renameFunction(const QString &oldName, const QString &newName)
 {
-    cmdRaw("afn " + newName + " " + oldName);
+    cmdRaw("afn " + newName + " " + oldName + " ");
     emit functionRenamed(oldName, newName);
 }
 

--- a/src/dialogs/EditVariablesDialog.cpp
+++ b/src/dialogs/EditVariablesDialog.cpp
@@ -59,7 +59,7 @@ void EditVariablesDialog::applyFields()
 
     QString newName = ui->nameEdit->text().replace(QLatin1Char(' '), QLatin1Char('_'));
     if (newName != desc.name) {
-        Core()->cmdRaw(QString("afvn %1 %2 ").arg(newName).arg(desc.name));
+        Core()->cmdRaw(QString("afvn %1 %2").arg(newName).arg(desc.name));
     }
 
     // Refresh the views to reflect the changes to vars

--- a/src/dialogs/EditVariablesDialog.cpp
+++ b/src/dialogs/EditVariablesDialog.cpp
@@ -59,7 +59,7 @@ void EditVariablesDialog::applyFields()
 
     QString newName = ui->nameEdit->text().replace(QLatin1Char(' '), QLatin1Char('_'));
     if (newName != desc.name) {
-        Core()->cmdRaw(QString("afvn %1 %2").arg(newName).arg(desc.name));
+        Core()->cmdRaw(QString("afvn %1 %2 ").arg(newName).arg(desc.name));
     }
 
     // Refresh the views to reflect the changes to vars


### PR DESCRIPTION
**Detailed description**

When submitting the rename command as `afn newName oldName\` the function `cmdRaw` surrounds the command in escaped double quotes, so the actual string sent to `_core_cmd_str` is `"afn newName\\ oldName\\\"`, either intentionally or as a result of a bug this command throws the error `Missing " in (afn newName oldName\\")` which implies that it is not able to handle the consecutive backslashes at the end of the string. Adding a trailing space allows the command to succeed.

![rename-with-backslash](https://user-images.githubusercontent.com/6268446/66882004-4dcfdd80-efb8-11e9-8eae-15098e2a4e4e.gif)


**Test plan (required)**

*Test Function rename*
1. Rename a function to a name which ends in a backslash.
2. Attempt a second rename of the function to an arbitrary string.
3. Observe that the second rename doesn't result in an error from core and refreshes properly in the view.

*Test Variable rename*
1. Rename a variable to a name which ends in a backslash.
2. Attempt a second rename of the variable to an arbitrary string.
3. Observe that the second rename doesn't result in an error from core and refreshes properly in the view.

**Closing issues**

closes #1729