### PR TITLE
ThreadsWidget and r2 debugging fixes

### DIFF
--- a/src/Cutter.pro
+++ b/src/Cutter.pro
@@ -327,6 +327,7 @@ SOURCES += \
     dialogs/AsyncTaskDialog.cpp \
     widgets/StackWidget.cpp \
     widgets/RegistersWidget.cpp \
+    widgets/ThreadsWidget.cpp \
     widgets/BacktraceWidget.cpp \
     dialogs/OpenFileDialog.cpp \
     common/CommandTask.cpp \
@@ -456,6 +457,7 @@ HEADERS  += \
     dialogs/AsyncTaskDialog.h \
     widgets/StackWidget.h \
     widgets/RegistersWidget.h \
+    widgets/ThreadsWidget.h \
     widgets/BacktraceWidget.h \
     dialogs/OpenFileDialog.h \
     common/StringsTask.h \
@@ -548,6 +550,7 @@ FORMS    += \
     dialogs/AsyncTaskDialog.ui \
     widgets/StackWidget.ui \
     widgets/RegistersWidget.ui \
+    widgets/ThreadsWidget.ui \
     widgets/BacktraceWidget.ui \
     dialogs/OpenFileDialog.ui \
     dialogs/preferences/DebugOptionsWidget.ui \

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1129,9 +1129,11 @@ void CutterCore::setRegister(QString regName, QString regValue)
 
 void CutterCore::setCurrentDebugThread(int tid)
 {
-    cmdj("dpt=" + QString::number(tid));
+    cmd("dpt=" + QString::number(tid));
     emit registersChanged();
     emit refreshCodeViews();
+    emit stackChanged();
+    syncAndSeekProgramCounter();
 }
 
 void CutterCore::startDebug()
@@ -1228,6 +1230,7 @@ void CutterCore::stopDebug()
 void CutterCore::syncAndSeekProgramCounter()
 {
     QString programCounterValue = cmd("dr?`drn PC`").trimmed();
+    printf("programcountervalue %s\n", programCounterValue.toStdString().c_str());
     seekAndShow(programCounterValue);
     emit registersChanged();
 }

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1230,7 +1230,6 @@ void CutterCore::stopDebug()
 void CutterCore::syncAndSeekProgramCounter()
 {
     QString programCounterValue = cmd("dr?`drn PC`").trimmed();
-    printf("programcountervalue %s\n", programCounterValue.toStdString().c_str());
     seekAndShow(programCounterValue);
     emit registersChanged();
 }

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1027,6 +1027,16 @@ QJsonDocument CutterCore::getStack(int size)
     return cmdj("pxrj " + QString::number(size) + " @ r:SP");
 }
 
+QJsonDocument CutterCore::getProcessThreads(int pid)
+{
+    if (-1 == pid) {
+        // Return threads list of the currently debugged PID
+        return cmdj("dptj");
+    } else {
+        return cmdj("dptj " + QString::number(pid));
+    }
+}
+
 QJsonDocument CutterCore::getRegisterValues()
 {
     return cmdj("drj");
@@ -1113,6 +1123,13 @@ RVA CutterCore::getProgramCounterValue()
 void CutterCore::setRegister(QString regName, QString regValue)
 {
     cmd("dr " + regName + "=" + regValue);
+    emit registersChanged();
+    emit refreshCodeViews();
+}
+
+void CutterCore::setCurrentDebugThread(int tid)
+{
+    cmdj("dpt=" + QString::number(tid));
     emit registersChanged();
     emit refreshCodeViews();
 }

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -219,7 +219,14 @@ public:
     QString getRegisterName(QString registerRole);
     RVA getProgramCounterValue();
     void setRegister(QString regName, QString regValue);
+    void setCurrentDebugThread(int tid);
     QJsonDocument getStack(int size = 0x100);
+    /**
+     * @brief Get a list of a given process's threads
+     * @param pid The pid of the process, -1 for the currently debugged process
+     * @return JSON object result of dptj
+     */
+    QJsonDocument getProcessThreads(int pid);
     QJsonDocument getBacktrace();
     void startDebug();
     void startEmulation();

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -61,6 +61,7 @@
 #include "widgets/RegisterRefsWidget.h"
 #include "widgets/DisassemblyWidget.h"
 #include "widgets/StackWidget.h"
+#include "widgets/ThreadsWidget.h"
 #include "widgets/RegistersWidget.h"
 #include "widgets/BacktraceWidget.h"
 #include "widgets/HexdumpWidget.h"
@@ -310,6 +311,7 @@ void MainWindow::initDocks()
     stringsDock = new StringsWidget(this, ui->actionStrings);
     flagsDock = new FlagsWidget(this, ui->actionFlags);
     stackDock = new StackWidget(this, ui->actionStack);
+    threadsDock = new ThreadsWidget(this, ui->actionThreads);
     backtraceDock = new BacktraceWidget(this, ui->actionBacktrace);
     registersDock = new RegistersWidget(this, ui->actionRegisters);
     memoryMapDock = new MemoryMapWidget(this, ui->actionMemoryMap);
@@ -829,10 +831,11 @@ void MainWindow::restoreDocks()
 
     tabifyDockWidget(sectionsDock, commentsDock);
 
-    // Add Stack, Registers and Backtrace vertically stacked
+    // Add Stack, Registers, Threads and Backtrace vertically stacked
     addDockWidget(Qt::TopDockWidgetArea, stackDock);
     splitDockWidget(stackDock, registersDock, Qt::Vertical);
     tabifyDockWidget(stackDock, backtraceDock);
+    tabifyDockWidget(backtraceDock, threadsDock);
 
     updateDockActionsChecked();
 }
@@ -1062,6 +1065,7 @@ void MainWindow::showDebugDocks()
                                               stackDock,
                                               registersDock,
                                               backtraceDock,
+                                              threadsDock,
                                               memoryMapDock,
                                               breakpointDock
                                             };

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -253,6 +253,7 @@ private:
     QDockWidget        *asmDock = nullptr;
     QDockWidget        *calcDock = nullptr;
     QDockWidget        *stackDock = nullptr;
+    QDockWidget        *threadsDock = nullptr;
     QDockWidget        *registersDock = nullptr;
     QDockWidget        *backtraceDock = nullptr;
     QDockWidget        *memoryMapDock = nullptr;

--- a/src/core/MainWindow.ui
+++ b/src/core/MainWindow.ui
@@ -152,6 +152,7 @@
      </property>
      <addaction name="actionBacktrace"/>
      <addaction name="actionBreakpoint"/>
+     <addaction name="actionThreads"/>
      <addaction name="actionMemoryMap"/>
      <addaction name="actionRegisters"/>
      <addaction name="actionRegisterRefs"/>
@@ -945,6 +946,14 @@
    </property>
    <property name="text">
     <string>Backtrace</string>
+   </property>
+  </action>
+  <action name="actionThreads">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Threads</string>
    </property>
   </action>
   <action name="actionMemoryMap">

--- a/src/widgets/BacktraceWidget.cpp
+++ b/src/widgets/BacktraceWidget.cpp
@@ -67,6 +67,12 @@ void BacktraceWidget::setBacktraceGrid()
         modelBacktrace->setItem(i, 4, rowFrameSize);
         i++;
     }
+
+    // Remove irrelevant old rows
+    if (modelBacktrace->rowCount() > i) {
+        modelBacktrace->removeRows(i, modelBacktrace->rowCount() - i);
+    }
+
     viewBacktrace->setModel(modelBacktrace);
     viewBacktrace->resizeColumnsToContents();;
 }

--- a/src/widgets/ThreadsWidget.cpp
+++ b/src/widgets/ThreadsWidget.cpp
@@ -1,6 +1,7 @@
 #include "ThreadsWidget.h"
 #include "ui_ThreadsWidget.h"
 #include "common/JsonModel.h"
+#include <r_debug.h>
 
 #include "core/MainWindow.h"
 
@@ -53,6 +54,24 @@ void ThreadsWidget::updateContents()
     setThreadsGrid();
 }
 
+QString ThreadsWidget::translateStatus(QString status)
+{
+    switch (status.toStdString().c_str()[0]) {
+    case R_DBG_PROC_STOP:
+        return "Stopped";
+    case R_DBG_PROC_RUN:
+        return "Running";
+    case R_DBG_PROC_SLEEP:
+        return "Sleeping";
+    case R_DBG_PROC_ZOMBIE:
+        return "Zombie";
+    case R_DBG_PROC_DEAD:
+        return "Dead";
+    case R_DBG_PROC_RAISED:
+        return "Raised event";
+    }
+}
+
 void ThreadsWidget::setThreadsGrid()
 {
     QJsonArray threadsValues = Core()->getProcessThreads(DEBUGGED_PID).array();
@@ -60,7 +79,7 @@ void ThreadsWidget::setThreadsGrid()
     for (const QJsonValue &value : threadsValues) {
         QJsonObject threadsItem = value.toObject();
         int pid = threadsItem["pid"].toVariant().toInt();
-        QString status = threadsItem["status"].toString();
+        QString status = translateStatus(threadsItem["status"].toString());
         QString path = threadsItem["path"].toString();
         bool current = threadsItem["current"].toBool();
 

--- a/src/widgets/ThreadsWidget.cpp
+++ b/src/widgets/ThreadsWidget.cpp
@@ -132,13 +132,13 @@ void ThreadsWidget::onActivated(const QModelIndex &index)
     if (!index.isValid())
         return;
 
-    int tid = modelFilter->data(index.siblingAtColumn(COLUMN_PID)).toInt();
+    int tid = modelFilter->data(index.sibling(index.row(), COLUMN_PID)).toInt();
 
     // Verify that the selected tid is still in the threads list since dpt= will
     // attach to any given id. If it isn't found simply update the UI.
     QJsonArray threadsValues = Core()->getProcessThreads(DEBUGGED_PID).array();
     for (QJsonValue value : threadsValues) {
-        if (tid == value["pid"].toInt()) {
+        if (tid == value.toObject()["pid"].toInt()) {
             Core()->setCurrentDebugThread(tid);
             break;
         }

--- a/src/widgets/ThreadsWidget.cpp
+++ b/src/widgets/ThreadsWidget.cpp
@@ -1,0 +1,101 @@
+#include "ThreadsWidget.h"
+#include "ui_ThreadsWidget.h"
+#include "common/JsonModel.h"
+
+#include "core/MainWindow.h"
+
+#define DEBUGGED_PID (-1)
+
+enum ColumnIndex {
+    COLUMN_CURRENT = 0,
+    COLUMN_PID,
+    COLUMN_STATUS,
+    COLUMN_PATH,
+};
+
+ThreadsWidget::ThreadsWidget(MainWindow *main, QAction *action) :
+    CutterDockWidget(main, action),
+    ui(new Ui::ThreadsWidget)
+{
+    ui->setupUi(this);
+
+    // Setup threads model
+    modelThreads->setHorizontalHeaderItem(COLUMN_CURRENT, new QStandardItem(tr("Current")));
+    modelThreads->setHorizontalHeaderItem(COLUMN_PID, new QStandardItem(tr("PID")));
+    modelThreads->setHorizontalHeaderItem(COLUMN_STATUS, new QStandardItem(tr("Status")));
+    modelThreads->setHorizontalHeaderItem(COLUMN_PATH, new QStandardItem(tr("Path")));
+    viewThreads->setFont(Config()->getFont());
+    viewThreads->setModel(modelThreads);
+    viewThreads->setHorizontalScrollMode(QAbstractItemView::ScrollPerPixel);
+    ui->verticalLayout->addWidget(viewThreads);
+
+    refreshDeferrer = createRefreshDeferrer([this]() {
+        updateContents();
+    });
+
+    viewThreads->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    viewThreads->setSortingEnabled(false);
+
+    connect(Core(), &CutterCore::refreshAll, this, &ThreadsWidget::updateContents);
+    connect(Core(), &CutterCore::seekChanged, this, &ThreadsWidget::updateContents);
+    connect(Config(), &Configuration::fontsUpdated, this, &ThreadsWidget::fontsUpdatedSlot);
+    connect(viewThreads, SIGNAL(doubleClicked(const QModelIndex &)), this,
+            SLOT(onDoubleClicked(const QModelIndex &)));
+}
+
+ThreadsWidget::~ThreadsWidget() {}
+
+void ThreadsWidget::updateContents()
+{
+    if (!refreshDeferrer->attemptRefresh(nullptr)) {
+        return;
+    }
+    setThreadsGrid();
+}
+
+void ThreadsWidget::setThreadsGrid()
+{
+    QJsonArray threadsValues = Core()->getProcessThreads(DEBUGGED_PID).array();
+    int i = 0;
+    for (const QJsonValue &value : threadsValues) {
+        QJsonObject threadsItem = value.toObject();
+        int pid = threadsItem["pid"].toVariant().toInt();
+        QString status = threadsItem["status"].toString();
+        QString path = threadsItem["path"].toString();
+        bool current = threadsItem["current"].toBool();
+
+        QStandardItem *rowCurrent = new QStandardItem(QString(current ? "True" : "False"));
+        QStandardItem *rowPid = new QStandardItem(QString::number(pid));
+        QStandardItem *rowStatus = new QStandardItem(status);
+        QStandardItem *rowPath = new QStandardItem(path);
+
+        modelThreads->setItem(i, COLUMN_CURRENT, rowCurrent);
+        modelThreads->setItem(i, COLUMN_PID, rowPid);
+        modelThreads->setItem(i, COLUMN_STATUS, rowStatus);
+        modelThreads->setItem(i, COLUMN_PATH, rowPath);
+        i++;
+    }
+
+    viewThreads->setModel(modelThreads);
+    viewThreads->resizeColumnsToContents();;
+}
+
+void ThreadsWidget::fontsUpdatedSlot()
+{
+    viewThreads->setFont(Config()->getFont());
+}
+
+void ThreadsWidget::onDoubleClicked(const QModelIndex &index)
+{
+    if (!index.isValid())
+        return;
+
+    int row = index.row();
+
+    QJsonArray threadsValues = Core()->getProcessThreads(DEBUGGED_PID).array();
+    int tid = threadsValues[row].toObject()["pid"].toInt();
+
+    Core()->setCurrentDebugThread(tid);
+
+    updateContents();
+}

--- a/src/widgets/ThreadsWidget.h
+++ b/src/widgets/ThreadsWidget.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <QJsonObject>
+#include <memory>
+#include <QStandardItem>
+#include <QTableView>
+
+#include "core/Cutter.h"
+#include "CutterDockWidget.h"
+
+class MainWindow;
+
+namespace Ui {
+class ThreadsWidget;
+}
+
+class ThreadsWidget : public CutterDockWidget
+{
+    Q_OBJECT
+
+public:
+    explicit ThreadsWidget(MainWindow *main, QAction *action = nullptr);
+    ~ThreadsWidget();
+
+private slots:
+    void updateContents();
+    void setThreadsGrid();
+    void fontsUpdatedSlot();
+    void onDoubleClicked(const QModelIndex &index);
+
+private:
+    std::unique_ptr<Ui::ThreadsWidget> ui;
+    QStandardItemModel *modelThreads = new QStandardItemModel(1, 4, this);
+    QTableView *viewThreads = new QTableView;
+    RefreshDeferrer *refreshDeferrer;
+};

--- a/src/widgets/ThreadsWidget.h
+++ b/src/widgets/ThreadsWidget.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <QStandardItem>
 #include <QTableView>
+#include <QSortFilterProxyModel>
 
 #include "core/Cutter.h"
 #include "CutterDockWidget.h"
@@ -13,6 +14,17 @@ class MainWindow;
 namespace Ui {
 class ThreadsWidget;
 }
+
+class ThreadsFilterModel : public QSortFilterProxyModel
+{
+    Q_OBJECT
+
+public:
+    ThreadsFilterModel(QObject *parent = nullptr);
+
+protected:
+    bool filterAcceptsRow(int row, const QModelIndex &parent) const override;
+};
 
 class ThreadsWidget : public CutterDockWidget
 {
@@ -31,6 +43,7 @@ private slots:
 private:
     QString translateStatus(QString status);
     std::unique_ptr<Ui::ThreadsWidget> ui;
-    QStandardItemModel *modelThreads = new QStandardItemModel(1, 4, this);
+    QStandardItemModel *modelThreads;
+    ThreadsFilterModel *modelFilter;
     RefreshDeferrer *refreshDeferrer;
 };

--- a/src/widgets/ThreadsWidget.h
+++ b/src/widgets/ThreadsWidget.h
@@ -29,6 +29,7 @@ private slots:
     void onDoubleClicked(const QModelIndex &index);
 
 private:
+    QString translateStatus(QString status);
     std::unique_ptr<Ui::ThreadsWidget> ui;
     QStandardItemModel *modelThreads = new QStandardItemModel(1, 4, this);
     QTableView *viewThreads = new QTableView;

--- a/src/widgets/ThreadsWidget.h
+++ b/src/widgets/ThreadsWidget.h
@@ -26,12 +26,11 @@ private slots:
     void updateContents();
     void setThreadsGrid();
     void fontsUpdatedSlot();
-    void onDoubleClicked(const QModelIndex &index);
+    void onActivated(const QModelIndex &index);
 
 private:
     QString translateStatus(QString status);
     std::unique_ptr<Ui::ThreadsWidget> ui;
     QStandardItemModel *modelThreads = new QStandardItemModel(1, 4, this);
-    QTableView *viewThreads = new QTableView;
     RefreshDeferrer *refreshDeferrer;
 };

--- a/src/widgets/ThreadsWidget.ui
+++ b/src/widgets/ThreadsWidget.ui
@@ -30,10 +30,13 @@
       <item>
        <widget class="QTableView" name="viewThreads">
         <property name="sortingEnabled">
-         <bool>false</bool>
+         <bool>true</bool>
         </property>
         <property name="cornerButtonEnabled">
          <bool>false</bool>
+        </property>
+        <property name="selectionMode">
+         <enum>QAbstractItemView::SingleSelection</enum>
         </property>
         <property name="editTriggers">
          <enum>QAbstractItemView::NoEditTriggers</enum>
@@ -41,14 +44,29 @@
         <property name="horizontalScrollMode">
          <enum>QAbstractItemView::ScrollPerPixel</enum>
         </property>
-        <attribute name="horizontalHeaderStretchLastSection">
-         <bool>true</bool>
-        </attribute>
+       </widget>
+      </item>
+      <item>
+       <widget class="QuickFilterView" name="quickFilterView" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
        </widget>
       </item>
      </layout>
   </widget>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QuickFilterView</class>
+   <extends>QWidget</extends>
+   <header>widgets/QuickFilterView.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/widgets/ThreadsWidget.ui
+++ b/src/widgets/ThreadsWidget.ui
@@ -27,6 +27,25 @@
       <property name="rightMargin">
        <number>0</number>
       </property>
+      <item>
+       <widget class="QTableView" name="viewThreads">
+        <property name="sortingEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="cornerButtonEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="editTriggers">
+         <enum>QAbstractItemView::NoEditTriggers</enum>
+        </property>
+        <property name="horizontalScrollMode">
+         <enum>QAbstractItemView::ScrollPerPixel</enum>
+        </property>
+        <attribute name="horizontalHeaderStretchLastSection">
+         <bool>true</bool>
+        </attribute>
+       </widget>
+      </item>
      </layout>
   </widget>
  </widget>

--- a/src/widgets/ThreadsWidget.ui
+++ b/src/widgets/ThreadsWidget.ui
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ThreadsWidget</class>
+ <widget class="QDockWidget" name="ThreadsWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>463</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string notr="true">Threads</string>
+  </property>
+  <widget class="QWidget" name="dockWidgetContents">
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <property name="spacing">
+       <number>10</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+     </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
**Detailed description**

Added a widget that shows thread information and allows thread switching. The r2 update also includes a fix to drrj that caused RegistersWidget to print incorrect register values.

For some reason the widget shows up when not in debug mode in window, would appreciate it if you could take a look at it. I followed backtracewidget's and stackwidget's behavior so I am not sure why it would happen.

**Test plan (required)**

Debug multi-threaded processes, see that all threads show up and attempt to switch threads using the UI.

Testing points:
- UI shows the correct position in the disassembly window when switching threads
- Newly created threads are added to the UI
- Thread's data is immediately synced(regs, stack, backtrace, position) when switching without having to step
- ThreadsWidget's UI is cleared after restarting the debugging session

Example binary(play around with the number of threads and thread_func's content as desired):
```
#include <thread>

void thread_func() {
    int64_t counter = 0;
    while(true) {
        ++counter;
    }
}

 int main() {
    std::thread t1(thread_func);
    std::thread t2(thread_func);
    ...
    t1.join();
    t2.join();
    ...
}
```
**Closing issues**

closes #1020 
closes #1019 