### PR TITLE
Fix decompiler widget not updating xrefs to decompiled function

### DIFF
--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -239,6 +239,7 @@ void DecompilerWidget::updateCursorPosition()
     if (pos == SIZE_MAX) {
         return;
     }
+    mCtxMenu->setOffset(offset);
     connectCursorPositionChanged(true);
     QTextCursor cursor = ui->textEdit->textCursor();
     cursor.setPosition(pos);


### PR DESCRIPTION
**Detailed description**

When the seeking in the decompiler widget, the offset is not getting updating on the `DissassemblyContextMenu`. Updating the offset on seek fixes a handful of issues in the context menu, such as "Copy Address", and "Show In".  

![fix-decompiler-context-menu](https://user-images.githubusercontent.com/6268446/67148696-dc32b080-f291-11e9-81c3-4dd2c32eb4b7.gif)

**Test plan (required)**

1. Seek to a position in the decompiler widget.
2. Show X-Refs from menu or shortcut "X" brings up Xref dialog at correct address.
3. Copy Address copies the correct address.
4. Show In -> Disassembly seeks to correct location in disassembly widget.

**Closing issues**

closes #1751