### PR TITLE
Implement some of w? commands in HexWidget

### DIFF
--- a/docs/source/user-docs/menus/hexdump-context-menu/patching.rst
+++ b/docs/source/user-docs/menus/hexdump-context-menu/patching.rst
@@ -1,0 +1,63 @@
+Patching
+==============================
+
+Write String
+----------------------------------------
+**Description:** Write ASCII string at the current location. If multiple bytes are selected, the string will be written from the start of the selection. Please note, this item won't write a null-terminated nor wide strings. Please see the other items for this features.
+
+**Steps:** Right click on a byte and select ``Edit -> Write string``  
+
+Write Length and String
+----------------------------------------
+**Description:** Write a length prefix followed by ASCII string at the current location. If multiple bytes are selected, the string will be written from the start of the selection. Please note, although similar to BSTR in its concept, this item would not add a null terminator WCHAR at the end of the string.
+
+**Steps:** Right click on a byte and select ``Edit -> Write length and string``  
+
+
+Write Wide String
+----------------------------------------
+**Description:** Write null-terminated wide string at the current location. If multiple bytes are selected, the string will be written from the start of the selection.
+
+**Steps:** Right click on a byte and select ``Edit -> Write wide string``  
+
+
+Write Null-Terminated String
+----------------------------------------
+**Description:** Write a null-terminated ASCII string at the current location. If multiple bytes are selected, the string will be written from the start of the selection.
+
+**Steps:** Right click on a byte and select ``Edit -> Write zero terminated string``  
+
+
+Write Encoded\\Decoded Base64 String
+----------------------------------------
+**Description:** Write an encoded or decoded base64 string at the current location. If multiple bytes are selected, the string will be written from the start of the selection.
+
+**Steps:** Right click on a byte and select ``Edit -> Write De\Encoded Base64 string`` . On the dialog that will open choose whether you want to encode a string or decode one.
+
+
+Write Zeroes
+----------------------------------------
+**Description:** Write null-bytes at the current location. The number of null-bytes is specified by the user. If multiple bytes are selected, the null-bytes will be written from the start of the selection.
+
+**Steps:** Right click on a byte and select ``Edit -> Write zeroes``. On the dialog that will open, specify how many null-bytes you'd like to write.
+
+
+Write Random Bytes
+----------------------------------------
+**Description:** Write random bytes at the current location. The number of bytes is specified by the user. If multiple bytes are selected, the null-bytes will be written from the start of the selection.
+
+**Steps:** Right click on a byte and select ``Edit -> Write random bytes``. On the dialog that will open, specify how many bytes you'd like to write.
+
+
+Duplicate Bytes From Offset
+----------------------------------------
+**Description:** Duplicate N bytes from an offset to the current location. The number of bytes to duplicated and the offset of origin are specified by the user. If multiple bytes are selected, the bytes will be written from the start of the selection. A preview pane will display the bytes to be copied.
+
+**Steps:** Right click on a byte and select ``Edit -> Duplicate from offset``. On the dialog that will open, specify the offset from which to copy, and how many bytes to copy.  
+
+
+Increment/Decrement bytes
+----------------------------------------
+**Description:** Increment or decrement Byte, Word, Dword or Qword at the current location. The value to add or subtract from the location is specified by the user. If multiple bytes are selected, the function will apply on the start of the selection.
+
+**Steps:** Right click on a byte and select ``Edit -> Increment/Decrement``. On the dialog that will open, specify if you'd like to modify a Byte, Word, Dword or Qword, choose the value of the operation, and choose whether you want to increment or decrement.

--- a/docs/source/user-docs/menus/hexdump-widget-context-menu.rst
+++ b/docs/source/user-docs/menus/hexdump-widget-context-menu.rst
@@ -1,5 +1,10 @@
 Hexdump Widget Context Menu
 ==============================
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   hexdump-context-menu/*
 
 Bytes Per Row
 ----------------------------------------

--- a/src/Cutter.pro
+++ b/src/Cutter.pro
@@ -390,7 +390,8 @@ SOURCES += \
     common/AddressableItemModel.cpp \
     widgets/ListDockWidget.cpp \
     dialogs/MultitypeFileSaveDialog.cpp \
-    widgets/BoolToggleDelegate.cpp
+    widgets/BoolToggleDelegate.cpp \
+    common/IOModesController.cpp
 
 GRAPHVIZ_SOURCES = \
     widgets/GraphvizLayout.cpp

--- a/src/Cutter.pro
+++ b/src/Cutter.pro
@@ -536,7 +536,6 @@ HEADERS  += \
     widgets/AddressableItemList.h \
     dialogs/MultitypeFileSaveDialog.h \
     widgets/BoolToggleDelegate.h \
-    widgets/BoolToggleDelegate.cpp \
     common/IOModesController.h
 
 GRAPHVIZ_HEADERS = widgets/GraphGridLayout.h

--- a/src/Cutter.pro
+++ b/src/Cutter.pro
@@ -537,7 +537,6 @@ HEADERS  += \
     dialogs/MultitypeFileSaveDialog.h \
     widgets/BoolToggleDelegate.h \
     widgets/BoolToggleDelegate.cpp \
-    common/IOModesController.cpp \ 
     common/IOModesController.h
 
 GRAPHVIZ_HEADERS = widgets/GraphGridLayout.h

--- a/src/Cutter.pro
+++ b/src/Cutter.pro
@@ -535,7 +535,10 @@ HEADERS  += \
     widgets/ListDockWidget.h \
     widgets/AddressableItemList.h \
     dialogs/MultitypeFileSaveDialog.h \
-    widgets/BoolToggleDelegate.h
+    widgets/BoolToggleDelegate.h \
+    widgets/BoolToggleDelegate.cpp \
+    common/IOModesController.cpp \ 
+    common/IOModesController.h
 
 GRAPHVIZ_HEADERS = widgets/GraphGridLayout.h
 

--- a/src/Cutter.pro
+++ b/src/Cutter.pro
@@ -262,6 +262,7 @@ SOURCES += \
     Main.cpp \
     core/Cutter.cpp \
     dialogs/EditStringDialog.cpp \
+    dialogs/WriteCommandsDialogs.cpp \
     widgets/DisassemblerGraphView.cpp \
     widgets/OverviewView.cpp \
     common/RichTextPainter.cpp \
@@ -399,6 +400,7 @@ HEADERS  += \
     core/CutterCommon.h \
     core/CutterDescriptions.h \
     dialogs/EditStringDialog.h \
+    dialogs/WriteCommandsDialogs.h \
     widgets/DisassemblerGraphView.h \
     widgets/OverviewView.h \
     common/RichTextPainter.h \
@@ -540,6 +542,9 @@ GRAPHVIZ_HEADERS = widgets/GraphGridLayout.h
 FORMS    += \
     dialogs/AboutDialog.ui \
     dialogs/EditStringDialog.ui \
+    dialogs/Base64EnDecodedWriteDialog.ui \
+    dialogs/DuplicateFromOffsetDialog.ui \
+    dialogs/IncrementDecrementDialog.ui \
     dialogs/preferences/AsmOptionsWidget.ui \
     dialogs/CommentsDialog.ui \
     dialogs/EditInstructionDialog.ui \

--- a/src/common/IOModesController.cpp
+++ b/src/common/IOModesController.cpp
@@ -1,0 +1,43 @@
+#include "IOModesController.h"
+#include "Cutter.h"
+
+#include <QPushButton>
+#include <QObject>
+
+bool IOModesController::canWrite()
+{
+    return Core()->isIOCacheEnabled() || Core()->isWriteModeEnabled();
+}
+
+bool IOModesController::prepareForWriting()
+{
+    if (canWrite()) {
+        return true;
+    }
+
+    QMessageBox msgBox;
+    msgBox.setIcon(QMessageBox::Icon::Critical);
+    msgBox.setWindowTitle(QObject::tr("Write error"));
+    msgBox.setText(
+        QObject::tr("Your file is opened in read-only mode. "
+           "Editing is only available when the file is opened in either Write or Cache modes.\n\n"
+           "WARNING: In Write mode, any changes will be committed to the file on disk. "
+           "For safety, please consider using Cache mode and then commit the changes manually "
+           "via File -> Commit modifications to disk."));
+    msgBox.addButton(QObject::tr("Cancel"), QMessageBox::RejectRole);
+    QAbstractButton *reopenButton = msgBox.addButton(QObject::tr("Reopen in Write mode"),
+                                                     QMessageBox::YesRole);
+    QAbstractButton *iocacheButton = msgBox.addButton(QObject::tr("Enable Cache mode"),
+                                                     QMessageBox::YesRole);
+
+    msgBox.exec();
+
+    if (msgBox.clickedButton() == reopenButton) {
+        Core()->setWriteMode(true);
+    } else if (msgBox.clickedButton() == iocacheButton) {
+        Core()->setIOCache(true);
+    } else {
+        return false;
+    }
+    return true;
+}

--- a/src/common/IOModesController.h
+++ b/src/common/IOModesController.h
@@ -1,0 +1,15 @@
+#ifndef IOMODESCONTROLLER_H
+#define IOMODESCONTROLLER_H
+
+#include "core/Cutter.h"
+
+class IOModesController
+{
+
+
+public:
+    bool prepareForWriting();
+    bool canWrite();
+};
+
+#endif // IOMODESCONTROLLER_H

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -400,7 +400,7 @@ QString CutterCore::cmdRawAt(const char *cmd, RVA address)
 
     {
         CORE_LOCK();
-      	r_cons_push ();
+      r_cons_push ();
 
         // r_cmd_call does not return the output of the command
         r_cmd_call(core->rcmd, cmd);
@@ -408,9 +408,9 @@ QString CutterCore::cmdRawAt(const char *cmd, RVA address)
         // we grab the output straight from r_cons
         res = r_cons_get_buffer();
 
-        // // cleaning up
+        // cleaning up
         r_cons_pop ();
-	    r_cons_echo (NULL);
+        r_cons_echo (NULL);
     }
 
     seekSilent(oldOffset);
@@ -3743,7 +3743,7 @@ void CutterCore::setWriteMode(bool enabled)
     bool writeModeState = isWriteModeEnabled();
 
     if (writeModeState == enabled) {
-        // New mode is the same is current. Do nothing.
+        // New mode is the same as current. Do nothing.
         return;
     }
     
@@ -3840,4 +3840,3 @@ QByteArray CutterCore::ioRead(RVA addr, int len)
 
     return  array;
 }
-

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -400,7 +400,7 @@ QString CutterCore::cmdRawAt(const char *cmd, RVA address)
 
     {
         CORE_LOCK();
-      r_cons_push ();
+        r_cons_push ();
 
         // r_cmd_call does not return the output of the command
         r_cmd_call(core->rcmd, cmd);

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -2473,7 +2473,7 @@ QList<FunctionDescription> CutterCore::getAllFunctions()
         function.nbbs = r_list_length (fcn->bbs);
         function.calltype = fcn->cc ? QString::fromUtf8(fcn->cc) : QString();
         function.name = fcn->name ? QString::fromUtf8(fcn->name) : QString();
-        function.edges = r_anal_fcn_count_edges(fcn, nullptr);
+        function.edges = r_anal_function_count_edges(fcn, nullptr);
         function.stackframe = fcn->maxstack;
         funcList.append(function);
     }

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -3673,17 +3673,16 @@ BasicBlockHighlighter* CutterCore::getBBHighlighter()
     return bbHighlighter;
 }
 
-void CutterCore::setIOCache(bool iocache)
-{
-    Core()->cmd(QString("e io.cache=%1").arg(iocache ? "true" : "false"));
-    this->iocache = iocache;
-    if (iocache) {
-        emit ioCacheChanged(true);
-    }
-}
 BasicInstructionHighlighter* CutterCore::getBIHighlighter()
 {
     return &biHighlighter;
+}
+
+void CutterCore::setIOCache(bool enabled)
+{
+    setConfig("io.cache", enabled);
+    this->iocache = enabled;
+    emit ioCacheChanged(enabled);
 }
 
 bool CutterCore::isIOCacheEnabled() const
@@ -3691,7 +3690,27 @@ bool CutterCore::isIOCacheEnabled() const
     return iocache;
 }
 
-bool CutterCore::isWriteMode()
+// Enable or disable write-mode. Avoid unecessary changes if not need.
+void CutterCore::setWriteMode(bool enabled)
+{
+    bool writeModeState = isWriteModeEnabled();
+
+    if (writeModeState == enabled) {
+        // New mode is the same is current. Do nothing.
+        return;
+    }
+    
+    // Change from read-only to write-mode
+    if (enabled && !writeModeState) {
+        cmd("oo+");
+    // Change from write-mode to read-only
+    } else {
+        cmd("oo");
+    }
+    writeModeChanged (enabled);
+}
+
+bool CutterCore::isWriteModeEnabled()
 {
     using namespace std;
     QJsonArray ans = cmdj("oj").array();

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -3690,6 +3690,17 @@ bool CutterCore::isIOCacheEnabled() const
     return iocache;
 }
 
+void CutterCore::commitWriteCache()
+{
+    if (!isWriteModeEnabled()) {
+        setWriteMode (true);
+        cmd("wci");
+        cmd("oo");
+    } else {
+        cmd("wci");
+    }
+}
+
 // Enable or disable write-mode. Avoid unecessary changes if not need.
 void CutterCore::setWriteMode(bool enabled)
 {

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -3673,9 +3673,31 @@ BasicBlockHighlighter* CutterCore::getBBHighlighter()
     return bbHighlighter;
 }
 
+void CutterCore::setIOCache(bool iocache)
+{
+    Core()->cmd(QString("e io.cache=%1").arg(iocache ? "true" : "false"));
+    this->iocache = iocache;
+    if (iocache) {
+        emit ioCacheChanged(true);
+    }
+}
 BasicInstructionHighlighter* CutterCore::getBIHighlighter()
 {
     return &biHighlighter;
+}
+
+bool CutterCore::isIOCacheEnabled() const
+{
+    return iocache;
+}
+
+bool CutterCore::isWriteMode()
+{
+    using namespace std;
+    QJsonArray ans = cmdj("oj").array();
+    return find_if(begin(ans), end(ans), [](const QJsonValue &v) {
+        return v.toObject().value("raised").toBool();
+    })->toObject().value("writable").toBool();
 }
 
 /**

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -73,6 +73,22 @@ public:
     bool asyncCmd(const char *str, QSharedPointer<R2Task> &task);
     bool asyncCmd(const QString &str, QSharedPointer<R2Task> &task) { return asyncCmd(str.toUtf8().constData(), task); }
     QString cmdRaw(const QString &str);
+
+    /**
+     * @brief Execute a command \a cmd at \a address. The function will preform a silent seek to the address
+     * without triggering the seekChanged event nor adding new entries to the seek history. By nature, the
+     * API is executing raw commands, and thus ignores multiple commands and overcome command injections.
+     * @param cmd - a raw command to execute. If multiple commands will be passed (e.g "px 5; pd 7 && pdf") then
+     * only the first command will be executed.
+     * @param address - an address to which Cutter will temporarily seek.
+     * @return the output of the command
+     */
+    QString cmdRawAt(const char *cmd, RVA address);
+    
+    /**
+     * @brief a wrapper around cmdRawAt(const char *cmd, RVA address).
+     */
+    QString cmdRawAt(const QString &str, RVA address) { return cmdRawAt(str.toUtf8().constData(), address); }
     QJsonDocument cmdj(const char *str);
     QJsonDocument cmdj(const QString &str) { return cmdj(str.toUtf8().constData()); }
     QStringList cmdList(const char *str) { return cmd(str).split(QLatin1Char('\n'), QString::SkipEmptyParts); }
@@ -221,6 +237,8 @@ public:
     /* Seek functions */
     void seek(QString thing);
     void seek(ut64 offset);
+    void seekSilent(ut64 offset);
+    void seekSilent(QString thing) { seekSilent(math(thing)); }
     void seekPrev();
     void seekNext();
     void updateSeek();

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -558,11 +558,18 @@ public:
      * @param enabled
      */
     void setIOCache(bool enabled);
+
     /**
      * @brief Check if Cache mode is enabled.
      * @return true if Cache is enabled, otherwise return false.
      */
     bool isIOCacheEnabled() const;
+
+    /**
+     * @brief Commit write cache to the file on disk.
+     */
+    void commitWriteCache();
+
     /**
      * @brief Enable or disable Write mode. When the file is opened in write mode, any changes to it will be immediately
      * committed to the file on disk, thus modify the file. This function wrap radare2 function which re-open the file with

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -552,6 +552,11 @@ public:
     BasicBlockHighlighter *getBBHighlighter();
     BasicInstructionHighlighter *getBIHighlighter();
 
+    void setIOCache(bool iocache);
+    bool isIOCacheEnabled() const;
+
+    bool isWriteMode();
+
 signals:
     void refreshAll();
 
@@ -586,6 +591,8 @@ signals:
     void attachedRemote(bool successfully);
 
     void projectSaved(bool successfully, const QString &name);
+
+    void ioCacheChanged(bool newval);
 
     /**
      * emitted when debugTask started or finished running
@@ -635,6 +642,7 @@ private:
 
     bool emptyGraph = false;
     BasicBlockHighlighter *bbHighlighter;
+    bool iocache = false;
     BasicInstructionHighlighter biHighlighter;
 
     QSharedPointer<R2Task> debugTask;

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -552,10 +552,29 @@ public:
     BasicBlockHighlighter *getBBHighlighter();
     BasicInstructionHighlighter *getBIHighlighter();
 
-    void setIOCache(bool iocache);
+    /**
+     * @brief Enable or dsiable Cache mode. Cache mode is used to imagine writing to the opened file
+     * without committing the changes to the disk.
+     * @param enabled
+     */
+    void setIOCache(bool enabled);
+    /**
+     * @brief Check if Cache mode is enabled.
+     * @return true if Cache is enabled, otherwise return false.
+     */
     bool isIOCacheEnabled() const;
-
-    bool isWriteMode();
+    /**
+     * @brief Enable or disable Write mode. When the file is opened in write mode, any changes to it will be immediately
+     * committed to the file on disk, thus modify the file. This function wrap radare2 function which re-open the file with
+     * the desired permissions.
+     * @param enabled
+     */
+    void setWriteMode(bool enabled);
+    /**
+     * @brief Check if the file is opened in write mode.
+     * @return true if write mode is enabled, otherwise return false.
+     */
+    bool isWriteModeEnabled();
 
 signals:
     void refreshAll();
@@ -593,6 +612,7 @@ signals:
     void projectSaved(bool successfully, const QString &name);
 
     void ioCacheChanged(bool newval);
+    void writeModeChanged(bool newval);
 
     /**
      * emitted when debugTask started or finished running

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -627,11 +627,11 @@ void MainWindow::setFilename(const QString &fn)
 void MainWindow::closeEvent(QCloseEvent *event)
 {
 
-    // Check if there are uncomitted changes
+    // Check if there are uncommitted changes
     if (core->isIOCacheEnabled() && !core->cmdj("wcj").array().isEmpty()) {
 
         QMessageBox::StandardButton ret = QMessageBox::question(this, APPNAME,
-                                                                tr("It seems that you have changes or patches that are not comitted to the file.\n"
+                                                                tr("It seems that you have changes or patches that are not committed to the file.\n"
                                                                 "Do you want to commit them now?"),
                                                                 (QMessageBox::StandardButtons)(QMessageBox::Save | QMessageBox::Discard | QMessageBox::Cancel));
         if (ret == QMessageBox::Cancel) {

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -139,6 +139,17 @@ void MainWindow::initUI()
     connect(ui->actionExtraGraph, &QAction::triggered, this, &MainWindow::addExtraGraph);
     connect(ui->actionExtraDisassembly, &QAction::triggered, this, &MainWindow::addExtraDisassembly);
     connect(ui->actionExtraHexdump, &QAction::triggered, this, &MainWindow::addExtraHexdump);
+    connect(ui->actionCommitChanges, &QAction::triggered, this, [this]() {
+        if (!Core()->isWriteMode()) {
+            Core()->cmd("oo+");
+            Core()->cmd("wci");
+            Core()->cmd("oo");
+        } else {
+            Core()->cmd("wci");
+        }
+    });
+    ui->actionCommitChanges->setEnabled(false);
+    connect(Core(), &CutterCore::ioCacheChanged, ui->actionCommitChanges, &QAction::setEnabled);
 
     widgetTypeToConstructorMap.insert(GraphWidget::getWidgetType(), getNewInstance<GraphWidget>);
     widgetTypeToConstructorMap.insert(DisassemblyWidget::getWidgetType(), getNewInstance<DisassemblyWidget>);

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -140,7 +140,7 @@ void MainWindow::initUI()
     connect(ui->actionExtraDisassembly, &QAction::triggered, this, &MainWindow::addExtraDisassembly);
     connect(ui->actionExtraHexdump, &QAction::triggered, this, &MainWindow::addExtraHexdump);
     connect(ui->actionCommitChanges, &QAction::triggered, this, [this]() {
-        if (!Core()->isWriteMode()) {
+        if (!Core()->isWriteModeEnabled()) {
             Core()->cmd("oo+");
             Core()->cmd("wci");
             Core()->cmd("oo");

--- a/src/core/MainWindow.ui
+++ b/src/core/MainWindow.ui
@@ -39,7 +39,7 @@
      <x>0</x>
      <y>0</y>
      <width>1013</width>
-     <height>22</height>
+     <height>29</height>
     </rect>
    </property>
    <property name="defaultUp">
@@ -51,10 +51,10 @@
    <widget class="QMenu" name="menuFile">
     <property name="geometry">
      <rect>
-      <x>378</x>
-      <y>100</y>
-      <width>156</width>
-      <height>220</height>
+      <x>328</x>
+      <y>99</y>
+      <width>265</width>
+      <height>364</height>
      </rect>
     </property>
     <property name="title">
@@ -64,6 +64,8 @@
     <addaction name="actionOpen"/>
     <addaction name="separator"/>
     <addaction name="actionImportPDB"/>
+    <addaction name="separator"/>
+    <addaction name="actionCommitChanges"/>
     <addaction name="separator"/>
     <addaction name="actionSave"/>
     <addaction name="actionSaveAs"/>
@@ -1117,6 +1119,11 @@
    </property>
    <property name="shortcutContext">
     <enum>Qt::ApplicationShortcut</enum>
+   </property>
+  </action>
+  <action name="actionCommitChanges">
+   <property name="text">
+    <string>Commit changes</string>
    </property>
   </action>
  </widget>

--- a/src/dialogs/Base64EnDecodedWriteDialog.ui
+++ b/src/dialogs/Base64EnDecodedWriteDialog.ui
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Base64EnDecodedWriteDialog</class>
+ <widget class="QDialog" name="Base64EnDecodedWriteDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>535</width>
+    <height>217</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Base64 Encode/Decode</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_3">
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout_2">
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>String:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="base64LineEdit"/>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <widget class="QRadioButton" name="decodeRB">
+         <property name="text">
+          <string>Decode</string>
+         </property>
+         <attribute name="buttonGroup">
+          <string notr="true">modeButtonGroup</string>
+         </attribute>
+        </widget>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="encodeRB">
+         <property name="text">
+          <string>Encode</string>
+         </property>
+         <attribute name="buttonGroup">
+          <string notr="true">modeButtonGroup</string>
+         </attribute>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>Base64EnDecodedWriteDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>229</x>
+     <y>356</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>Base64EnDecodedWriteDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>297</x>
+     <y>362</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+ <buttongroups>
+  <buttongroup name="modeButtonGroup"/>
+ </buttongroups>
+</ui>

--- a/src/dialogs/DuplicateFromOffsetDialog.ui
+++ b/src/dialogs/DuplicateFromOffsetDialog.ui
@@ -25,7 +25,7 @@
      <item>
       <widget class="QLabel" name="label">
        <property name="text">
-        <string>Offset (Hex):</string>
+        <string>Offset:</string>
        </property>
       </widget>
      </item>
@@ -65,6 +65,9 @@
    <item>
     <widget class="QScrollArea" name="scrollArea">
      <property name="verticalScrollBarPolicy">
+      <enum>Qt::ScrollBarAsNeeded</enum>
+     </property>
+     <property name="horizontalScrollBarPolicy">
       <enum>Qt::ScrollBarAlwaysOff</enum>
      </property>
      <property name="widgetResizable">
@@ -75,8 +78,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>265</width>
-        <height>87</height>
+        <width>269</width>
+        <height>208</height>
        </rect>
       </property>
       <layout class="QHBoxLayout" name="horizontalLayout_3">
@@ -85,24 +88,23 @@
          <property name="text">
           <string/>
          </property>
+         <property name="scaledContents">
+          <bool>true</bool>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
         </widget>
        </item>
       </layout>
      </widget>
     </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>180</height>
-      </size>
-     </property>
-    </spacer>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">

--- a/src/dialogs/DuplicateFromOffsetDialog.ui
+++ b/src/dialogs/DuplicateFromOffsetDialog.ui
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DuplicateFromOffsetDialog</class>
+ <widget class="QDialog" name="DuplicateFromOffsetDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>289</width>
+    <height>323</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Duplicate from offset</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Offset (Hex):</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="offsetLE">
+       <property name="inputMask">
+        <string notr="true"/>
+       </property>
+       <property name="maxLength">
+        <number>16</number>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>N bytes:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSpinBox" name="nBytesSB">
+       <property name="minimum">
+        <number>1</number>
+       </property>
+       <property name="maximum">
+        <number>999999999</number>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="verticalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>265</width>
+        <height>87</height>
+       </rect>
+      </property>
+      <layout class="QHBoxLayout" name="horizontalLayout_3">
+       <item>
+        <widget class="QLabel" name="bytesLabel">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>180</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>DuplicateFromOffsetDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>DuplicateFromOffsetDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/dialogs/IncrementDecrementDialog.ui
+++ b/src/dialogs/IncrementDecrementDialog.ui
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>IncrementDecrementDialog</class>
+ <widget class="QDialog" name="IncrementDecrementDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>241</width>
+    <height>258</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Increment/Decrement</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>Interpret as</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QComboBox" name="nBytesCB"/>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <item>
+        <widget class="QLabel" name="valueLabel">
+         <property name="text">
+          <string>Value:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="valueLE">
+         <property name="inputMask">
+          <string notr="true"/>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="incrementRB">
+       <property name="text">
+        <string>Increment</string>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">buttonGroup</string>
+       </attribute>
+      </widget>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="decrementRB">
+       <property name="text">
+        <string>Decrement</string>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">buttonGroup</string>
+       </attribute>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>IncrementDecrementDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>IncrementDecrementDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+ <buttongroups>
+  <buttongroup name="buttonGroup"/>
+ </buttongroups>
+</ui>

--- a/src/dialogs/WriteCommandsDialogs.cpp
+++ b/src/dialogs/WriteCommandsDialogs.cpp
@@ -1,0 +1,99 @@
+#include "WriteCommandsDialogs.h"
+#include "ui_Base64EnDecodedWriteDialog.h"
+#include "ui_IncrementDecrementDialog.h"
+#include "ui_DuplicateFromOffsetDialog.h"
+#include "Cutter.h"
+
+#include <cmath>
+
+Base64EnDecodedWriteDialog::Base64EnDecodedWriteDialog(QWidget* parent) : QDialog(parent),
+    ui(new Ui::Base64EnDecodedWriteDialog)
+{
+    ui->setupUi(this);
+    ui->decodeRB->click();
+}
+
+Base64EnDecodedWriteDialog::Mode Base64EnDecodedWriteDialog::getMode() const
+{
+    return ui->decodeRB->isChecked() ? Decode : Encode;
+}
+
+QByteArray Base64EnDecodedWriteDialog::getData() const
+{
+    return ui->base64LineEdit->text().toUtf8();
+}
+
+IncrementDecrementDialog::IncrementDecrementDialog(QWidget* parent) : QDialog(parent),
+    ui(new Ui::IncrementDecrementDialog)
+{
+    ui->setupUi(this);
+    ui->incrementRB->click();
+
+    ui->nBytesCB->addItems(QStringList()
+                           << tr("byte")
+                           << tr("word")
+                           << tr("dword")
+                           << tr("qword"));
+
+    ui->valueLE->setValidator(new QRegularExpressionValidator(QRegularExpression("[0-9a-fA-Fx]{1,18}"), ui->valueLE));
+}
+
+IncrementDecrementDialog::Mode IncrementDecrementDialog::getMode() const
+{
+    return ui->incrementRB->isChecked() ? Increase : Decrease;
+}
+
+uint8_t IncrementDecrementDialog::getNBytes() const
+{
+    return static_cast<uint8_t>(std::pow(2, ui->nBytesCB->currentIndex()));
+}
+
+uint64_t IncrementDecrementDialog::getValue() const
+{
+    bool ok;
+    uint64_t val = ui->valueLE->text().toULongLong(&ok, 16);
+    return ok ? val : 0;
+}
+
+DuplicateFromOffsetDialog::DuplicateFromOffsetDialog(QWidget* parent) : QDialog(parent),
+    ui(new Ui::DuplicateFromOffsetDialog)
+{
+    ui->setupUi(this);
+    ui->bytesLabel->setFont(QFont("Monospace"));
+    ui->offsetLE->setValidator(new QRegularExpressionValidator(QRegularExpression("[0-9a-fA-Fx]{1,18}"), ui->offsetLE));
+    connect(ui->offsetLE, &QLineEdit::textChanged, this, &DuplicateFromOffsetDialog::refresh);
+    connect(ui->nBytesSB, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &DuplicateFromOffsetDialog::refresh);
+}
+
+RVA DuplicateFromOffsetDialog::getOffset() const
+{
+    bool ok;
+    uint64_t val = ui->offsetLE->text().toULongLong(&ok, 16);
+    return ok ? val : 0;
+}
+
+size_t DuplicateFromOffsetDialog::getNBytes() const
+{
+    return static_cast<size_t>(ui->nBytesSB->value());
+}
+
+void DuplicateFromOffsetDialog::refresh()
+{
+    RVA newOffset = getOffset();
+    if (newOffset != 0) {
+        QSignalBlocker sb(Core());
+        RVA bo = Core()->getOffset();
+        Core()->seek(newOffset);
+        QString s = Core()->cmd("p8 " + QString::number(getNBytes()));
+        Core()->seek(bo);
+        QStringList sl;
+        for (int i = 0; i < s.size(); i += 16) {
+            QString ss = "";
+            for (int j = i; j < i + 16 && j < s.size(); j++) {
+                ss += QString(s.at(j)) + ((j % 2 == 1) ? " " : "");
+            }
+            sl.push_back(ss);
+        }
+        ui->bytesLabel->setText(sl.join("\n"));
+    }
+}

--- a/src/dialogs/WriteCommandsDialogs.cpp
+++ b/src/dialogs/WriteCommandsDialogs.cpp
@@ -5,6 +5,7 @@
 #include "Cutter.h"
 
 #include <cmath>
+#include <QFontDatabase>
 
 Base64EnDecodedWriteDialog::Base64EnDecodedWriteDialog(QWidget* parent) : QDialog(parent),
     ui(new Ui::Base64EnDecodedWriteDialog)
@@ -30,10 +31,10 @@ IncrementDecrementDialog::IncrementDecrementDialog(QWidget* parent) : QDialog(pa
     ui->incrementRB->click();
 
     ui->nBytesCB->addItems(QStringList()
-                           << tr("byte")
-                           << tr("word")
-                           << tr("dword")
-                           << tr("qword"));
+                           << tr("Byte")
+                           << tr("Word")
+                           << tr("Dword")
+                           << tr("Qword"));
 
     ui->valueLE->setValidator(new QRegularExpressionValidator(QRegularExpression("[0-9a-fA-Fx]{1,18}"), ui->valueLE));
 }
@@ -45,13 +46,15 @@ IncrementDecrementDialog::Mode IncrementDecrementDialog::getMode() const
 
 uint8_t IncrementDecrementDialog::getNBytes() const
 {
-    return static_cast<uint8_t>(std::pow(2, ui->nBytesCB->currentIndex()));
+    // Shift left to keep index powered by two
+    // This is used to create the w1, w2, w4 and w8 commands based on the selected index.
+    return static_cast<uint8_t>(1 << ui->nBytesCB->currentIndex());
 }
 
 uint64_t IncrementDecrementDialog::getValue() const
 {
     bool ok;
-    uint64_t val = ui->valueLE->text().toULongLong(&ok, 16);
+    uint64_t val = Core()->math(ui->valueLE->text());
     return ok ? val : 0;
 }
 
@@ -59,7 +62,7 @@ DuplicateFromOffsetDialog::DuplicateFromOffsetDialog(QWidget* parent) : QDialog(
     ui(new Ui::DuplicateFromOffsetDialog)
 {
     ui->setupUi(this);
-    ui->bytesLabel->setFont(QFont("Monospace"));
+    ui->bytesLabel->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
     ui->offsetLE->setValidator(new QRegularExpressionValidator(QRegularExpression("[0-9a-fA-Fx]{1,18}"), ui->offsetLE));
     connect(ui->offsetLE, &QLineEdit::textChanged, this, &DuplicateFromOffsetDialog::refresh);
     connect(ui->nBytesSB, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &DuplicateFromOffsetDialog::refresh);

--- a/src/dialogs/WriteCommandsDialogs.cpp
+++ b/src/dialogs/WriteCommandsDialogs.cpp
@@ -53,9 +53,7 @@ uint8_t IncrementDecrementDialog::getNBytes() const
 
 uint64_t IncrementDecrementDialog::getValue() const
 {
-    bool ok;
-    uint64_t val = Core()->math(ui->valueLE->text());
-    return ok ? val : 0;
+    return Core()->math(ui->valueLE->text());
 }
 
 DuplicateFromOffsetDialog::DuplicateFromOffsetDialog(QWidget* parent) : QDialog(parent),

--- a/src/dialogs/WriteCommandsDialogs.h
+++ b/src/dialogs/WriteCommandsDialogs.h
@@ -1,0 +1,55 @@
+#ifndef WRITECOMMANDSDIALOGS_H
+#define WRITECOMMANDSDIALOGS_H
+
+#include <QDialog>
+#include "CutterCommon.h"
+
+namespace Ui {
+class Base64EnDecodedWriteDialog;
+class IncrementDecrementDialog;
+class DuplicateFromOffsetDialog;
+}
+
+class Base64EnDecodedWriteDialog : public QDialog
+{
+    Q_OBJECT
+public:
+    explicit Base64EnDecodedWriteDialog(QWidget *parent = nullptr);
+    enum Mode { Encode, Decode };
+    Mode getMode() const;
+    QByteArray getData() const;
+
+private:
+    Ui::Base64EnDecodedWriteDialog* ui;
+};
+
+class IncrementDecrementDialog : public QDialog
+{
+    Q_OBJECT
+public:
+    explicit IncrementDecrementDialog(QWidget *parent = nullptr);
+    enum Mode { Increase, Decrease };
+    Mode getMode() const;
+    uint8_t getNBytes() const;
+    uint64_t getValue() const;
+
+private:
+    Ui::IncrementDecrementDialog* ui;
+};
+
+class DuplicateFromOffsetDialog : public QDialog
+{
+    Q_OBJECT
+public:
+    explicit DuplicateFromOffsetDialog(QWidget *parent = nullptr);
+    RVA getOffset() const;
+    size_t getNBytes() const;
+
+private:
+    Ui::DuplicateFromOffsetDialog* ui;
+
+private slots:
+    void refresh();
+};
+
+#endif // WRITECOMMANDSDIALOGS_H

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -388,43 +388,6 @@ void DisassemblyContextMenu::updateTargetMenuActions(const QVector<ThingUsedHere
     insertActions(copySeparator, showTargetMenuActions);
 }
 
-bool DisassemblyContextMenu::canWrite() const
-{
-    bool iocache = Core()->isIOCacheEnabled();
-    bool writeMode = Core()->isWriteMode();
-
-    if (iocache || writeMode) {
-        return true;
-    }
-
-    QMessageBox msgBox;
-    msgBox.setIcon(QMessageBox::Icon::Critical);
-    msgBox.setWindowTitle(tr("Write error"));
-    msgBox.setText(
-        tr("Your file is opened in read-only mode. "
-           "Editing is only available when the file is opened in either Write or Cache modes.\n\n"
-           "WARNING: In Write mode, any changes will be committed to the file on disk. "
-           "For safety, please consider using Cache mode and then commit the changes manually "
-           "via File -> Commit modifications to disk"));
-    msgBox.addButton(tr("OK"), QMessageBox::NoRole);
-    QAbstractButton *reopenButton = msgBox.addButton(tr("Reopen in write mode"),
-                                                     QMessageBox::YesRole);
-    QAbstractButton *iocacheButton = msgBox.addButton(tr("Enable 'io.cache' mode"),
-                                                     QMessageBox::YesRole);
-
-    msgBox.exec();
-
-
-    if (msgBox.clickedButton() == reopenButton) {
-        Core()->cmd("oo+");
-    } else if (msgBox.clickedButton() == iocacheButton) {
-        Core()->setIOCache(true);
-    } else {
-        return false;
-    }
-    return true;
-}
-
 void DisassemblyContextMenu::setOffset(RVA offset)
 {
     this->offset = offset;
@@ -691,7 +654,7 @@ QKeySequence DisassemblyContextMenu::getUndefineFunctionSequence() const
 
 void DisassemblyContextMenu::on_actionEditInstruction_triggered()
 {
-    if (!canWrite()) {
+    if (!ioModesController.prepareForWriting()) {
         return;
     }
     EditInstructionDialog e(EDIT_TEXT, this);
@@ -712,7 +675,7 @@ void DisassemblyContextMenu::on_actionEditInstruction_triggered()
 
 void DisassemblyContextMenu::on_actionNopInstruction_triggered()
 {
-    if (!canWrite()) {
+    if (!ioModesController.prepareForWriting()) {
         return;
     }
     Core()->nopInstruction(offset);
@@ -737,7 +700,7 @@ void DisassemblyContextMenu::showReverseJmpQuery()
 
 void DisassemblyContextMenu::on_actionJmpReverse_triggered()
 {
-    if (!canWrite()) {
+    if (!ioModesController.prepareForWriting()) {
         return;
     }
     Core()->jmpReverse(offset);
@@ -745,7 +708,7 @@ void DisassemblyContextMenu::on_actionJmpReverse_triggered()
 
 void DisassemblyContextMenu::on_actionEditBytes_triggered()
 {
-    if (!canWrite()) {
+    if (!ioModesController.prepareForWriting()) {
         return;
     }
     EditInstructionDialog e(EDIT_BYTES, this);

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -388,6 +388,43 @@ void DisassemblyContextMenu::updateTargetMenuActions(const QVector<ThingUsedHere
     insertActions(copySeparator, showTargetMenuActions);
 }
 
+bool DisassemblyContextMenu::canWrite() const
+{
+    bool iocache = Core()->isIOCacheEnabled();
+    bool writeMode = Core()->isWriteMode();
+
+    if (iocache || writeMode) {
+        return true;
+    }
+
+    QMessageBox msgBox;
+    msgBox.setIcon(QMessageBox::Icon::Critical);
+    msgBox.setWindowTitle(tr("Write error"));
+    msgBox.setText(
+        tr("Your file is opened in read-only mode. "
+           "Editing is only available when the file is opened in either Write or Cache modes.\n\n"
+           "WARNING: In Write mode, any changes will be committed to the file on disk. "
+           "For safety, please consider using Cache mode and then commit the changes manually "
+           "via File -> Commit modifications to disk"));
+    msgBox.addButton(tr("OK"), QMessageBox::NoRole);
+    QAbstractButton *reopenButton = msgBox.addButton(tr("Reopen in write mode"),
+                                                     QMessageBox::YesRole);
+    QAbstractButton *iocacheButton = msgBox.addButton(tr("Enable 'io.cache' mode"),
+                                                     QMessageBox::YesRole);
+
+    msgBox.exec();
+
+
+    if (msgBox.clickedButton() == reopenButton) {
+        Core()->cmd("oo+");
+    } else if (msgBox.clickedButton() == iocacheButton) {
+        Core()->setIOCache(true);
+    } else {
+        return false;
+    }
+    return true;
+}
+
 void DisassemblyContextMenu::setOffset(RVA offset)
 {
     this->offset = offset;
@@ -654,6 +691,9 @@ QKeySequence DisassemblyContextMenu::getUndefineFunctionSequence() const
 
 void DisassemblyContextMenu::on_actionEditInstruction_triggered()
 {
+    if (!canWrite()) {
+        return;
+    }
     EditInstructionDialog e(EDIT_TEXT, this);
     e.setWindowTitle(tr("Edit Instruction at %1").arg(RAddressString(offset)));
 
@@ -666,30 +706,16 @@ void DisassemblyContextMenu::on_actionEditInstruction_triggered()
         QString userInstructionOpcode = e.getInstruction();
         if (userInstructionOpcode != oldInstructionOpcode) {
             Core()->editInstruction(offset, userInstructionOpcode);
-
-            // Check if the write failed
-            auto newInstructionBytes = Core()->getInstructionBytes(offset);
-            if (newInstructionBytes == oldInstructionBytes) {
-                if (!writeFailed()) {
-                    Core()->editInstruction(offset, userInstructionOpcode);
-                }
-            }
         }
     }
 }
 
 void DisassemblyContextMenu::on_actionNopInstruction_triggered()
 {
-    QString oldBytes = Core()->getInstructionBytes(offset);
-
-    Core()->nopInstruction(offset);
-
-    QString newBytes = Core()->getInstructionBytes(offset);
-    if (oldBytes == newBytes) {
-        if (!writeFailed()) {
-            Core()->nopInstruction(offset);
-        }
+    if (!canWrite()) {
+        return;
     }
+    Core()->nopInstruction(offset);
 }
 
 void DisassemblyContextMenu::showReverseJmpQuery()
@@ -711,20 +737,17 @@ void DisassemblyContextMenu::showReverseJmpQuery()
 
 void DisassemblyContextMenu::on_actionJmpReverse_triggered()
 {
-    QString oldBytes = Core()->getInstructionBytes(offset);
-
-    Core()->jmpReverse(offset);
-
-    QString newBytes = Core()->getInstructionBytes(offset);
-    if (oldBytes == newBytes) {
-        if (!writeFailed()) {
-            Core()->jmpReverse(offset);
-        }
+    if (!canWrite()) {
+        return;
     }
+    Core()->jmpReverse(offset);
 }
 
 void DisassemblyContextMenu::on_actionEditBytes_triggered()
 {
+    if (!canWrite()) {
+        return;
+    }
     EditInstructionDialog e(EDIT_BYTES, this);
     e.setWindowTitle(tr("Edit Bytes at %1").arg(RAddressString(offset)));
 
@@ -735,36 +758,8 @@ void DisassemblyContextMenu::on_actionEditBytes_triggered()
         QString bytes = e.getInstruction();
         if (bytes != oldBytes) {
             Core()->editBytes(offset, bytes);
-
-            QString newBytes = Core()->getInstructionBytes(offset);
-            if (oldBytes == newBytes) {
-                if (!writeFailed()) {
-                    Core()->editBytes(offset, bytes);
-                }
-            }
         }
     }
-}
-
-bool DisassemblyContextMenu::writeFailed()
-{
-    QMessageBox msgBox;
-    msgBox.setIcon(QMessageBox::Icon::Critical);
-    msgBox.setWindowTitle(tr("Write error"));
-    msgBox.setText(
-        tr("Unable to complete write operation. Consider opening in write mode. \n\nWARNING: In write mode any changes will be committed to disk"));
-    msgBox.addButton(tr("OK"), QMessageBox::NoRole);
-    QAbstractButton *reopenButton = msgBox.addButton(tr("Reopen in write mode and try again"),
-                                                     QMessageBox::YesRole);
-
-    msgBox.exec();
-
-    if (msgBox.clickedButton() == reopenButton) {
-        Core()->cmd("oo+");
-        return false;
-    }
-
-    return true;
 }
 
 void DisassemblyContextMenu::on_actionCopy_triggered()

--- a/src/menus/DisassemblyContextMenu.h
+++ b/src/menus/DisassemblyContextMenu.h
@@ -35,7 +35,6 @@ private slots:
     void on_actionJmpReverse_triggered();
     void on_actionEditBytes_triggered();
     void showReverseJmpQuery();
-    bool writeFailed();
 
     void on_actionCopy_triggered();
     void on_actionCopyAddr_triggered();
@@ -216,5 +215,7 @@ private:
     QVector<ThingUsedHere> getThingUsedHere(RVA offset);
 
     void updateTargetMenuActions(const QVector<ThingUsedHere> &targets);
+
+    bool canWrite() const;
 };
 #endif // DISASSEMBLYCONTEXTMENU_H

--- a/src/menus/DisassemblyContextMenu.h
+++ b/src/menus/DisassemblyContextMenu.h
@@ -2,6 +2,7 @@
 #define DISASSEMBLYCONTEXTMENU_H
 
 #include "core/Cutter.h"
+#include "common/IOModesController.h"
 #include <QMenu>
 #include <QKeySequence>
 
@@ -107,6 +108,7 @@ private:
     bool canCopy;
     QString curHighlightedWord; // The current highlighted word
     MainWindow *mainWindow;
+    IOModesController ioModesController;
 
     QList<QAction *> anonymousActions;
 
@@ -215,7 +217,5 @@ private:
     QVector<ThingUsedHere> getThingUsedHere(RVA offset);
 
     void updateTargetMenuActions(const QVector<ThingUsedHere> &targets);
-
-    bool canWrite() const;
 };
 #endif // DISASSEMBLYCONTEXTMENU_H

--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -728,9 +728,14 @@ void HexWidget::w_writeZeros()
     }
     bool ok = false;
     QInputDialog d;
-    d.setInputMode(QInputDialog::InputMode::TextInput);
+
+    int size = 1;
+    if (!selection.isEmpty() && selection.size() <= INT_MAX) {
+        size = static_cast<int>(selection.size());
+    }
+
     QString str = QString::number(d.getInt(this, tr("Write zeros"),
-                                           tr("Number of zeros:"), 1, 1, 0x7FFFFFFF, 1, &ok));
+                                           tr("Number of zeros:"), size, 1, 0x7FFFFFFF, 1, &ok));
     if (ok && !str.isEmpty()) {
         Core()->cmdRawAt(QString("w0 %1")
                             .arg(str),
@@ -774,9 +779,13 @@ void HexWidget::w_writeRandom()
     }
     bool ok = false;
     QInputDialog d;
-    d.setInputMode(QInputDialog::InputMode::TextInput);
+
+    int size = 1;
+    if (!selection.isEmpty() && selection.size() <= INT_MAX) {
+        size = static_cast<int>(selection.size());
+    }
     QString nbytes = QString::number(d.getInt(this, tr("Write random"),
-                                           tr("Number of bytes:"), 1, 1, 0x7FFFFFFF, 1, &ok));
+                                           tr("Number of bytes:"), size, 1, 0x7FFFFFFF, 1, &ok));
     if (ok && !nbytes.isEmpty()) {
         Core()->cmdRawAt(QString("wr %1")
                             .arg(nbytes),

--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -654,11 +654,14 @@ void HexWidget::copy()
         return;
 
     QClipboard *clipboard = QApplication::clipboard();
-    QString range = QString("%1@0x%2").arg(selection.size()).arg(selection.start(), 0, 16);
     if (cursorOnAscii) {
-        clipboard->setText(Core()->cmd("psx " + range));
+        clipboard->setText(Core()->cmdRawAt(QString("psx %1")
+                                    .arg(selection.size()),
+                                    selection.start()).trimmed());
     } else {
-        clipboard->setText(Core()->cmd("p8 " + range)); //TODO: copy in the format shown
+        clipboard->setText(Core()->cmdRawAt(QString("p8 %1")
+                                    .arg(selection.size()),
+                                    selection.start()).trimmed()); //TODO: copy in the format shown
     }
 }
 
@@ -692,9 +695,9 @@ void HexWidget::w_writeString()
     QString str = d.getText(this, tr("Write string"),
                             tr("String:"), QLineEdit::Normal, "", &ok);
     if (ok && !str.isEmpty()) {
-        Core()->cmd(QString("w %1 @ %2")
-                            .arg(str)
-                            .arg(getLocationAddress()));
+        Core()->cmdRawAt(QString("w %1")
+                            .arg(str),
+                            getLocationAddress());
         refresh();
     }
 }
@@ -710,11 +713,11 @@ void HexWidget::w_increaseDecrease()
         return;
     }
     QString mode = d.getMode() == IncrementDecrementDialog::Increase ? "+" : "-";
-    Core()->cmd(QString("w%1%2 %3 @ %4")
+    Core()->cmdRawAt(QString("w%1%2 %3")
                         .arg(QString::number(d.getNBytes()))
                         .arg(mode)
-                        .arg(QString::number(d.getValue()))
-                        .arg(getLocationAddress()));
+                        .arg(QString::number(d.getValue())),
+                        getLocationAddress());
     refresh();
 }
 
@@ -729,9 +732,9 @@ void HexWidget::w_writeZeros()
     QString str = QString::number(d.getInt(this, tr("Write zeros"),
                                            tr("Number of zeros:"), 1, 1, 0x7FFFFFFF, 1, &ok));
     if (ok && !str.isEmpty()) {
-        Core()->cmd(QString("w0 %1 @ %2")
-                            .arg(str)
-                            .arg(getLocationAddress()));
+        Core()->cmdRawAt(QString("w0 %1")
+                            .arg(str),
+                            getLocationAddress());
         refresh();
     }
 }
@@ -757,10 +760,10 @@ void HexWidget::w_write64()
         return;
     }
 
-    Core()->cmd(QString("w6%1 %2 @ %3")
+    Core()->cmdRawAt(QString("w6%1 %2")
                         .arg(mode)
-                        .arg((mode == "e" ? str.toHex() : str).toStdString().c_str())
-                        .arg(getLocationAddress()));
+                        .arg((mode == "e" ? str.toHex() : str).toStdString().c_str()),
+                        getLocationAddress());
     refresh();
 }
 
@@ -775,9 +778,9 @@ void HexWidget::w_writeRandom()
     QString nbytes = QString::number(d.getInt(this, tr("Write random"),
                                            tr("Number of bytes:"), 1, 1, 0x7FFFFFFF, 1, &ok));
     if (ok && !nbytes.isEmpty()) {
-        Core()->cmd(QString("wr %1 @ %2")
-                            .arg(nbytes)
-                            .arg(getLocationAddress()));
+        Core()->cmdRawAt(QString("wr %1")
+                            .arg(nbytes),
+                            getLocationAddress());
         refresh();
     }
 }
@@ -794,10 +797,10 @@ void HexWidget::w_duplFromOffset()
     }
     RVA copyFrom = d.getOffset();
     QString nBytes = QString::number(d.getNBytes());
-    Core()->cmd(QString("wd %1 %2 %3")
+    Core()->cmdRawAt(QString("wd %1 %2")
                             .arg(copyFrom)
-                            .arg(nBytes)
-                            .arg(getLocationAddress()));
+                            .arg(nBytes),
+                            getLocationAddress());
     refresh();
 }
 
@@ -812,9 +815,9 @@ void HexWidget::w_writePascalString()
     QString str = d.getText(this, tr("Write Pascal string"),
                             tr("String:"), QLineEdit::Normal, "", &ok);
     if (ok && !str.isEmpty()) {
-        Core()->cmd(QString("ws %1 @ %2")
-                            .arg(str)
-                            .arg(getLocationAddress()));
+        Core()->cmdRawAt(QString("ws %1")
+                            .arg(str),
+                            getLocationAddress());
         refresh();
     }
 }
@@ -830,9 +833,9 @@ void HexWidget::w_writeWideString()
     QString str = d.getText(this, tr("Write wide string"),
                             tr("String:"), QLineEdit::Normal, "", &ok);
     if (ok && !str.isEmpty()) {
-        Core()->cmd(QString("ww %1 @ %2")
-                            .arg(str)
-                            .arg(getLocationAddress()));
+        Core()->cmdRawAt(QString("ww %1")
+                            .arg(str),
+                            getLocationAddress());
         refresh();
     }
 }
@@ -848,9 +851,9 @@ void HexWidget::w_writeCString()
     QString str = d.getText(this, tr("Write zero-terminated string"),
                             tr("String:"), QLineEdit::Normal, "", &ok);
     if (ok && !str.isEmpty()) {
-        Core()->cmd(QString("wz %1 @ %2")
-                            .arg(str)
-                            .arg(getLocationAddress()));
+        Core()->cmdRawAt(QString("wz %1")
+                            .arg(str),
+                            getLocationAddress());
         refresh();
     }
 }
@@ -1527,8 +1530,6 @@ QRectF HexWidget::asciiRectangle(uint offset)
 
     return QRectF(p, QSizeF(charWidth, lineHeight));
 }
-
-
 
 RVA HexWidget::getLocationAddress() {
     return !selection.isEmpty() ? selection.start() : cursor.address;

--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -692,7 +692,7 @@ void HexWidget::w_writeString()
     QString str = d.getText(this, tr("Write string"),
                             tr("String:"), QLineEdit::Normal, "", &ok);
     if (ok && !str.isEmpty()) {
-        Core()->cmdRaw(QString("w %1 @ %2")
+        Core()->cmd(QString("w %1 @ %2")
                             .arg(str)
                             .arg(getLocationAddress()));
         refresh();
@@ -710,7 +710,7 @@ void HexWidget::w_increaseDecrease()
         return;
     }
     QString mode = d.getMode() == IncrementDecrementDialog::Increase ? "+" : "-";
-    Core()->cmdRaw(QString("w%1 %2 %3 @ %4")
+    Core()->cmd(QString("w%1%2 %3 @ %4")
                         .arg(QString::number(d.getNBytes()))
                         .arg(mode)
                         .arg(QString::number(d.getValue()))
@@ -729,7 +729,7 @@ void HexWidget::w_writeZeros()
     QString str = QString::number(d.getInt(this, tr("Write zeros"),
                                            tr("Number of zeros:"), 1, 1, 0x7FFFFFFF, 1, &ok));
     if (ok && !str.isEmpty()) {
-        Core()->cmdRaw(QString("w0 %1 @ %2")
+        Core()->cmd(QString("w0 %1 @ %2")
                             .arg(str)
                             .arg(getLocationAddress()));
         refresh();
@@ -757,7 +757,7 @@ void HexWidget::w_write64()
         return;
     }
 
-    Core()->cmdRaw(QString("w6%1 %2 @ %3")
+    Core()->cmd(QString("w6%1 %2 @ %3")
                         .arg(mode)
                         .arg((mode == "e" ? str.toHex() : str).toStdString().c_str())
                         .arg(getLocationAddress()));
@@ -775,7 +775,7 @@ void HexWidget::w_writeRandom()
     QString nbytes = QString::number(d.getInt(this, tr("Write random"),
                                            tr("Number of bytes:"), 1, 1, 0x7FFFFFFF, 1, &ok));
     if (ok && !nbytes.isEmpty()) {
-        Core()->cmdRaw(QString("wr %1 @ %2")
+        Core()->cmd(QString("wr %1 @ %2")
                             .arg(nbytes)
                             .arg(getLocationAddress()));
         refresh();
@@ -794,7 +794,7 @@ void HexWidget::w_duplFromOffset()
     }
     RVA copyFrom = d.getOffset();
     QString nBytes = QString::number(d.getNBytes());
-    Core()->cmdRaw(QString("wd %1 %2 %3")
+    Core()->cmd(QString("wd %1 %2 %3")
                             .arg(copyFrom)
                             .arg(nBytes)
                             .arg(getLocationAddress()));
@@ -812,7 +812,7 @@ void HexWidget::w_writePascalString()
     QString str = d.getText(this, tr("Write Pascal string"),
                             tr("String:"), QLineEdit::Normal, "", &ok);
     if (ok && !str.isEmpty()) {
-        Core()->cmdRaw(QString("ws %1 @ %2")
+        Core()->cmd(QString("ws %1 @ %2")
                             .arg(str)
                             .arg(getLocationAddress()));
         refresh();
@@ -830,7 +830,7 @@ void HexWidget::w_writeWideString()
     QString str = d.getText(this, tr("Write wide string"),
                             tr("String:"), QLineEdit::Normal, "", &ok);
     if (ok && !str.isEmpty()) {
-        Core()->cmdRaw(QString("ww %1 @ %2")
+        Core()->cmd(QString("ww %1 @ %2")
                             .arg(str)
                             .arg(getLocationAddress()));
         refresh();
@@ -848,7 +848,7 @@ void HexWidget::w_writeCString()
     QString str = d.getText(this, tr("Write zero-terminated string"),
                             tr("String:"), QLineEdit::Normal, "", &ok);
     if (ok && !str.isEmpty()) {
-        Core()->cmdRaw(QString("wz %1 @ %2")
+        Core()->cmd(QString("wz %1 @ %2")
                             .arg(str)
                             .arg(getLocationAddress()));
         refresh();

--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -810,16 +810,14 @@ void HexWidget::w_duplFromOffset()
     if (ret == QDialog::Rejected) {
         return;
     }
-    QString offset = QString::number(d.getOffset());
+    RVA copyFrom = d.getOffset();
     QString nBytes = QString::number(d.getNBytes());
-
+    RVA copyTo = !selection.isEmpty() ? selection.start() : Core()->getOffset();
     QSignalBlocker blocker(Core());
-    RVA bs = Core()->getOffset();
-    if (!selection.isEmpty()) {
-        Core()->seek(selection.start());
-    }
-    Core()->cmdRaw("wd " + offset + " " + nBytes);
-    Core()->seek(bs);
+    Core()->cmdRaw(QString("wd %1 %2 %3")
+                            .arg(copyFrom)
+                            .arg(nBytes)
+                            .arg(copyTo));
     refresh();
 }
 

--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -715,12 +715,17 @@ void HexWidget::w_increaseDecrease()
     }
     QString mode = d.getMode() == IncrementDecrementDialog::Increase ? "+" : "-";
     QSignalBlocker blocker(Core());
-    RVA bs = Core()->getOffset();
+    RVA destinationAddr = !selection.isEmpty() ? selection.start() : Core()->getOffset();
+
     if (!selection.isEmpty()) {
         Core()->seek(selection.start());
     }
-    Core()->cmdRaw("w" + QString::number(d.getNBytes()) + mode + QString::number(d.getValue()));
-    Core()->seek(bs);
+
+    Core()->cmdRaw(QString("w%1 %2 %3 @ %4")
+                        .arg(QString::number(d.getNBytes()))
+                        .arg(mode)
+                        .arg(QString::number(d.getValue()))
+                        .arg(destinationAddr));
     refresh();
 }
 

--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -692,13 +692,9 @@ void HexWidget::w_writeString()
     QString str = d.getText(this, tr("Write string"),
                             tr("String:"), QLineEdit::Normal, "", &ok);
     if (ok && !str.isEmpty()) {
-        QSignalBlocker blocker(Core());
-        RVA bs = Core()->getOffset();
-        if (!selection.isEmpty()) {
-            Core()->seek(selection.start());
-        }
-        Core()->cmdRaw("w " + str);
-        Core()->seek(bs);
+        Core()->cmdRaw(QString("w %1 @ %2")
+                            .arg(str)
+                            .arg(getLocationAddress()));
         refresh();
     }
 }
@@ -714,18 +710,11 @@ void HexWidget::w_increaseDecrease()
         return;
     }
     QString mode = d.getMode() == IncrementDecrementDialog::Increase ? "+" : "-";
-    QSignalBlocker blocker(Core());
-    RVA destinationAddr = !selection.isEmpty() ? selection.start() : Core()->getOffset();
-
-    if (!selection.isEmpty()) {
-        Core()->seek(selection.start());
-    }
-
     Core()->cmdRaw(QString("w%1 %2 %3 @ %4")
                         .arg(QString::number(d.getNBytes()))
                         .arg(mode)
                         .arg(QString::number(d.getValue()))
-                        .arg(destinationAddr));
+                        .arg(getLocationAddress()));
     refresh();
 }
 
@@ -740,13 +729,9 @@ void HexWidget::w_writeZeros()
     QString str = QString::number(d.getInt(this, tr("Write zeros"),
                                            tr("Number of zeros:"), 1, 1, 0x7FFFFFFF, 1, &ok));
     if (ok && !str.isEmpty()) {
-        QSignalBlocker blocker(Core());
-        RVA bs = Core()->getOffset();
-        if (!selection.isEmpty()) {
-            Core()->seek(selection.start());
-        }
-        Core()->cmdRaw("w0 " + str);
-        Core()->seek(bs);
+        Core()->cmdRaw(QString("w0 %1 @ %2")
+                            .arg(str)
+                            .arg(getLocationAddress()));
         refresh();
     }
 }
@@ -772,14 +757,10 @@ void HexWidget::w_write64()
         return;
     }
 
-    str = QString("w6" + mode + " ").toUtf8() + (mode == "e" ? str.toHex() : str);
-    QSignalBlocker blocker(Core());
-    RVA bs = Core()->getOffset();
-    if (!selection.isEmpty()) {
-        Core()->seek(selection.start());
-    }
-    Core()->cmdRaw(str.toStdString().c_str());
-    Core()->seek(bs);
+    Core()->cmdRaw(QString("w6%1 %2 @ %3")
+                        .arg(mode)
+                        .arg((mode == "e" ? str.toHex() : str).toStdString().c_str())
+                        .arg(getLocationAddress()));
     refresh();
 }
 
@@ -794,13 +775,9 @@ void HexWidget::w_writeRandom()
     QString nbytes = QString::number(d.getInt(this, tr("Write random"),
                                            tr("Number of bytes:"), 1, 1, 0x7FFFFFFF, 1, &ok));
     if (ok && !nbytes.isEmpty()) {
-        QSignalBlocker blocker(Core());
-        RVA bs = Core()->getOffset();
-        if (!selection.isEmpty()) {
-            Core()->seek(selection.start());
-        }
-        Core()->cmdRaw("wr " + nbytes);
-        Core()->seek(bs);
+        Core()->cmdRaw(QString("wr %1 @ %2")
+                            .arg(nbytes)
+                            .arg(getLocationAddress()));
         refresh();
     }
 }
@@ -817,12 +794,10 @@ void HexWidget::w_duplFromOffset()
     }
     RVA copyFrom = d.getOffset();
     QString nBytes = QString::number(d.getNBytes());
-    RVA copyTo = !selection.isEmpty() ? selection.start() : Core()->getOffset();
-    QSignalBlocker blocker(Core());
     Core()->cmdRaw(QString("wd %1 %2 %3")
                             .arg(copyFrom)
                             .arg(nBytes)
-                            .arg(copyTo));
+                            .arg(getLocationAddress()));
     refresh();
 }
 
@@ -837,13 +812,9 @@ void HexWidget::w_writePascalString()
     QString str = d.getText(this, tr("Write Pascal string"),
                             tr("String:"), QLineEdit::Normal, "", &ok);
     if (ok && !str.isEmpty()) {
-        QSignalBlocker blocker(Core());
-        RVA bs = Core()->getOffset();
-        if (!selection.isEmpty()) {
-            Core()->seek(selection.start());
-        }
-        Core()->cmdRaw("ws " + str);
-        Core()->seek(bs);
+        Core()->cmdRaw(QString("ws %1 @ %2")
+                            .arg(str)
+                            .arg(getLocationAddress()));
         refresh();
     }
 }
@@ -859,13 +830,9 @@ void HexWidget::w_writeWideString()
     QString str = d.getText(this, tr("Write wide string"),
                             tr("String:"), QLineEdit::Normal, "", &ok);
     if (ok && !str.isEmpty()) {
-        QSignalBlocker blocker(Core());
-        RVA bs = Core()->getOffset();
-        if (!selection.isEmpty()) {
-            Core()->seek(selection.start());
-        }
-        Core()->cmdRaw("ww " + str);
-        Core()->seek(bs);
+        Core()->cmdRaw(QString("ww %1 @ %2")
+                            .arg(str)
+                            .arg(getLocationAddress()));
         refresh();
     }
 }
@@ -881,13 +848,9 @@ void HexWidget::w_writeCString()
     QString str = d.getText(this, tr("Write zero-terminated string"),
                             tr("String:"), QLineEdit::Normal, "", &ok);
     if (ok && !str.isEmpty()) {
-        QSignalBlocker blocker(Core());
-        RVA bs = Core()->getOffset();
-        if (!selection.isEmpty()) {
-            Core()->seek(selection.start());
-        }
-        Core()->cmdRaw("wz " + str);
-        Core()->seek(bs);
+        Core()->cmdRaw(QString("wz %1 @ %2")
+                            .arg(str)
+                            .arg(getLocationAddress()));
         refresh();
     }
 }
@@ -1563,4 +1526,10 @@ QRectF HexWidget::asciiRectangle(uint offset)
     p += asciiArea.topLeft();
 
     return QRectF(p, QSizeF(charWidth, lineHeight));
+}
+
+
+
+RVA HexWidget::getLocationAddress() {
+    return !selection.isEmpty() ? selection.start() : cursor.address;
 }

--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -683,7 +683,7 @@ void HexWidget::onRangeDialogAccepted()
 
 void HexWidget::w_writeString()
 {
-    if (!canWrite()) {
+    if (!ioModesController.prepareForWriting()) {
         return;
     }
     bool ok = false;
@@ -705,7 +705,7 @@ void HexWidget::w_writeString()
 
 void HexWidget::w_increaseDecrease()
 {
-    if (!canWrite()) {
+    if (!ioModesController.prepareForWriting()) {
         return;
     }
     IncrementDecrementDialog d;
@@ -726,7 +726,7 @@ void HexWidget::w_increaseDecrease()
 
 void HexWidget::w_writeZeros()
 {
-    if (!canWrite()) {
+    if (!ioModesController.prepareForWriting()) {
         return;
     }
     bool ok = false;
@@ -748,7 +748,7 @@ void HexWidget::w_writeZeros()
 
 void HexWidget::w_write64()
 {
-    if (!canWrite()) {
+    if (!ioModesController.prepareForWriting()) {
         return;
     }
     Base64EnDecodedWriteDialog d;
@@ -780,7 +780,7 @@ void HexWidget::w_write64()
 
 void HexWidget::w_writeRandom()
 {
-    if (!canWrite()) {
+    if (!ioModesController.prepareForWriting()) {
         return;
     }
     bool ok = false;
@@ -802,7 +802,7 @@ void HexWidget::w_writeRandom()
 
 void HexWidget::w_duplFromOffset()
 {
-    if (!canWrite()) {
+    if (!ioModesController.prepareForWriting()) {
         return;
     }
     DuplicateFromOffsetDialog d;
@@ -825,7 +825,7 @@ void HexWidget::w_duplFromOffset()
 
 void HexWidget::w_writePascalString()
 {
-    if (!canWrite()) {
+    if (!ioModesController.prepareForWriting()) {
         return;
     }
     bool ok = false;
@@ -847,7 +847,7 @@ void HexWidget::w_writePascalString()
 
 void HexWidget::w_writeWideString()
 {
-    if (!canWrite()) {
+    if (!ioModesController.prepareForWriting()) {
         return;
     }
     bool ok = false;
@@ -869,7 +869,7 @@ void HexWidget::w_writeWideString()
 
 void HexWidget::w_writeCString()
 {
-    if (!canWrite()) {
+    if (!ioModesController.prepareForWriting()) {
         return;
     }
     bool ok = false;
@@ -887,40 +887,6 @@ void HexWidget::w_writeCString()
         Core()->seek(bs);
         refresh();
     }
-}
-
-bool HexWidget::canWrite()
-{
-    bool iocache = Core()->isIOCacheEnabled();
-    bool writeMode = Core()->isWriteMode();
-
-    if (iocache || writeMode) {
-        return true;
-    }
-
-    QMessageBox msgBox;
-    msgBox.setIcon(QMessageBox::Icon::Critical);
-    msgBox.setWindowTitle(tr("Write error"));
-    msgBox.setText(
-        tr("Unable to complete write operation. Consider opening in write mode or enable 'io.cahce'. \n\n"
-           "WARNING: In write mode any changes will be commited to disk"));
-    msgBox.addButton(tr("OK"), QMessageBox::NoRole);
-    QAbstractButton *reopenButton = msgBox.addButton(tr("Reopen in write mode"),
-                                                     QMessageBox::YesRole);
-    QAbstractButton *iocacheButton = msgBox.addButton(tr("Enable 'io.cache' mode"),
-                                                     QMessageBox::YesRole);
-
-    msgBox.exec();
-
-
-    if (msgBox.clickedButton() == reopenButton) {
-        Core()->cmd("oo+");
-    } else if (msgBox.clickedButton() == iocacheButton) {
-        Core()->setIOCache(true);
-    } else {
-        return false;
-    }
-    return true;
 }
 
 void HexWidget::updateItemLength()

--- a/src/widgets/HexWidget.h
+++ b/src/widgets/HexWidget.h
@@ -329,6 +329,12 @@ private:
     QVariant readItem(int offset, QColor *color = nullptr);
     QString renderItem(int offset, QColor *color = nullptr);
     QChar renderAscii(int offset, QColor *color = nullptr);
+    /**
+     * @brief Get the location on which operations such as Writing should apply.
+     * @return Start of selection if multiple bytes are selected. Otherwise, the curren seek of the widget.
+     */
+    RVA getLocationAddress();
+
     void fetchData();
     /**
      * @brief Convert mouse position to address.

--- a/src/widgets/HexWidget.h
+++ b/src/widgets/HexWidget.h
@@ -3,6 +3,8 @@
 
 #include "Cutter.h"
 #include "dialogs/HexdumpRangeDialog.h"
+#include "common/IOModesController.h"
+
 #include <QScrollArea>
 #include <QTimer>
 #include <QMenu>
@@ -305,7 +307,6 @@ private slots:
     void w_writePascalString();
     void w_writeWideString();
     void w_writeCString();
-    bool canWrite();
 
 private:
     void updateItemLength();
@@ -500,6 +501,8 @@ private:
 
     std::unique_ptr<AbstractData> oldData;
     std::unique_ptr<AbstractData> data;
+    IOModesController ioModesController;
+
 };
 
 #endif // HEXWIDGET_H

--- a/src/widgets/HexWidget.h
+++ b/src/widgets/HexWidget.h
@@ -295,6 +295,18 @@ private slots:
     void copyAddress();
     void onRangeDialogAccepted();
 
+    // Write command slots
+    void w_writeString();
+    void w_increaseDecrease();
+    void w_writeZeros();
+    void w_write64();
+    void w_writeRandom();
+    void w_duplFromOffset();
+    void w_writePascalString();
+    void w_writeWideString();
+    void w_writeCString();
+    bool canWrite();
+
 private:
     void updateItemLength();
     void updateCounts();
@@ -483,6 +495,8 @@ private:
     QAction *actionCopy;
     QAction *actionCopyAddress;
     QAction *actionSelectRange;
+    QList<QAction *> actionsWriteString;
+    QList<QAction *> actionsWriteOther;
 
     std::unique_ptr<AbstractData> oldData;
     std::unique_ptr<AbstractData> data;

--- a/src/widgets/HexdumpWidget.cpp
+++ b/src/widgets/HexdumpWidget.cpp
@@ -84,7 +84,7 @@ HexdumpWidget::HexdumpWidget(MainWindow *main, QAction *action) :
 
     this->ui->hexTextView->addAction(&syncAction);
 
-    connect(Config(), SIGNAL(fontsUpdated()), this, SLOT(fontsUpdated()));
+    connect(Config(), &Configuration::fontsUpdated, this, &HexdumpWidget::fontsUpdated);
     connect(Core(), &CutterCore::refreshAll, this, [this]() { refresh(); });
     connect(Core(), &CutterCore::instructionChanged, this, [this]() { refresh(); });
     connect(Core(), &CutterCore::stackChanged, this, [this]() { refresh(); });


### PR DESCRIPTION
 <!-- Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request. -->


**Detailed description**
This PR is a first step in implementing "edit features" in Cutter. Now it only works with context menu.
Next step is to implement on-type edit and undo, redo commands and commiting changes in io.cache mode (last two can be implemented in this PR).

<!-- Explain the **details** for making this change. What existing problem does the pull request solve? Please provide enough information so that others can review your pull request -->


**Test plan (required)**
1. Open HexWidget
2. Trigger each edit command
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**
closes #715 
<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
