### PR TITLE
Detach Cutter interface from debug command execution

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1246,6 +1246,11 @@ void CutterCore::attachDebug(int pid)
     emit debugTaskStateChanged();
 }
 
+void CutterCore::suspendDebug()
+{
+    commandTask->breakTask(); 
+}
+
 void CutterCore::stopDebug()
 {
     if (currentlyDebugging) {

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1300,7 +1300,7 @@ void CutterCore::continueDebug()
         if (!debugTask.isNull()) {
             emit debugTaskStateChanged();
             connect(debugTask.data(), &R2Task::finished, this, [this] () {
-                debugTask = nullptr;
+                debugTask.clear();
                 syncAndSeekProgramCounter();
                 emit registersChanged();
                 emit refreshCodeViews();
@@ -1322,7 +1322,7 @@ void CutterCore::continueUntilDebug(QString offset)
         if (!debugTask.isNull()) {
             emit debugTaskStateChanged();
             connect(debugTask.data(), &R2Task::finished, this, [this] () {
-                debugTask = nullptr;
+                debugTask.clear();
                 syncAndSeekProgramCounter();
                 emit registersChanged();
                 emit stackChanged();
@@ -1344,7 +1344,7 @@ void CutterCore::continueUntilCall()
         if (!debugTask.isNull()) {
             emit debugTaskStateChanged();
             connect(debugTask.data(), &R2Task::finished, this, [this] () {
-                debugTask = nullptr;
+                debugTask.clear();
                 syncAndSeekProgramCounter();
                 emit debugTaskStateChanged();
             });
@@ -1363,7 +1363,7 @@ void CutterCore::continueUntilSyscall()
         if (!debugTask.isNull()) {
             emit debugTaskStateChanged();
             connect(debugTask.data(), &R2Task::finished, this, [this] () {
-                debugTask = nullptr;
+                debugTask.clear();
                 syncAndSeekProgramCounter();
                 emit debugTaskStateChanged();
             });
@@ -1382,7 +1382,7 @@ void CutterCore::stepDebug()
         if (!debugTask.isNull()) {
             emit debugTaskStateChanged();
             connect(debugTask.data(), &R2Task::finished, this, [this] () {
-                debugTask = nullptr;
+                debugTask.clear();
                 syncAndSeekProgramCounter();
                 emit debugTaskStateChanged();
             });
@@ -1401,7 +1401,7 @@ void CutterCore::stepOverDebug()
         if (!debugTask.isNull()) {
             emit debugTaskStateChanged();
             connect(debugTask.data(), &R2Task::finished, this, [this] () {
-                debugTask = nullptr;
+                debugTask.clear();
                 syncAndSeekProgramCounter();
                 emit debugTaskStateChanged();
             });
@@ -1416,7 +1416,7 @@ void CutterCore::stepOutDebug()
         asyncCmd("dsf", debugTask);
         if (!debugTask.isNull()) {
             connect(debugTask.data(), &R2Task::finished, this, [this] () {
-                debugTask = nullptr;
+                debugTask.clear();
                 syncAndSeekProgramCounter();
                 emit debugTaskStateChanged();
             });

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -312,6 +312,15 @@ QString CutterCore::cmd(const char *str)
     return o;
 }
 
+bool CutterCore::isDebugTaskInProgress()
+{
+    if (!commandTask.isNull()) {
+        return true;
+    }
+
+    return false;
+}
+
 QSharedPointer<R2Task> CutterCore::asyncCmdEsil(const char *command)
 {
     QSharedPointer<R2Task> task = asyncCmd(command);
@@ -1162,13 +1171,13 @@ void CutterCore::setRegister(QString regName, QString regValue)
 
 void CutterCore::setCurrentDebugThread(int tid)
 {
-    emit disableDebugToolbar();
+    emit debugTaskStateChanged();
     cmd("dpt=" + QString::number(tid));
     emit registersChanged();
     emit refreshCodeViews();
     emit stackChanged();
     syncAndSeekProgramCounter();
-    emit enableDebugToolbar();
+    emit debugTaskStateChanged();
 }
 
 void CutterCore::startDebug()
@@ -1187,7 +1196,7 @@ void CutterCore::startDebug()
         emit refreshCodeViews();
     }
     emit stackChanged();
-    emit enableDebugToolbar();
+    emit debugTaskStateChanged();
 }
 
 void CutterCore::startEmulation()
@@ -1210,7 +1219,7 @@ void CutterCore::startEmulation()
     emit registersChanged();
     emit stackChanged();
     emit refreshCodeViews();
-    emit enableDebugToolbar();
+    emit debugTaskStateChanged();
 }
 
 void CutterCore::attachDebug(int pid)
@@ -1234,13 +1243,13 @@ void CutterCore::attachDebug(int pid)
         emit changeDebugView();
     }
 
-    emit enableDebugToolbar();
+    emit debugTaskStateChanged();
 }
 
 void CutterCore::stopDebug()
 {
     if (currentlyDebugging) {
-        emit disableDebugToolbar();
+        emit debugTaskStateChanged();
         if (currentlyEmulating) {
             cmd("aeim-; aei-; wcr; .ar-");
             currentlyEmulating = false;
@@ -1286,12 +1295,12 @@ void CutterCore::continueDebug()
             task = asyncCmd("dc");
         }
         if (task) {
-            emit disableDebugToolbar();
+            emit debugTaskStateChanged();
             connect(task.data(), &R2Task::finished, this, [this] () {
                 syncAndSeekProgramCounter();
                 emit registersChanged();
                 emit refreshCodeViews();
-                emit enableDebugToolbar();
+                emit debugTaskStateChanged();
             });
         }
     }
@@ -1309,13 +1318,13 @@ void CutterCore::continueUntilDebug(QString offset)
             task = asyncCmd("dcu " + offset);
         }
         if (task) {
-            emit disableDebugToolbar();
+            emit debugTaskStateChanged();
             connect(task.data(), &R2Task::finished, this, [this] () {
                 syncAndSeekProgramCounter();
                 emit registersChanged();
                 emit stackChanged();
                 emit refreshCodeViews();
-                emit enableDebugToolbar();
+                emit debugTaskStateChanged();
             });
         }
     }
@@ -1332,10 +1341,10 @@ void CutterCore::continueUntilCall()
             task = asyncCmd("dcc");
         }
         if (task) {
-            emit disableDebugToolbar();
+            emit debugTaskStateChanged();
             connect(task.data(), &R2Task::finished, this, [this] () {
                 syncAndSeekProgramCounter();
-                emit enableDebugToolbar();
+                emit debugTaskStateChanged();
             });
         }
     }
@@ -1352,10 +1361,10 @@ void CutterCore::continueUntilSyscall()
             task = asyncCmd("dcs");
         }
         if (task) {
-            emit disableDebugToolbar();
+            emit debugTaskStateChanged();
             connect(task.data(), &R2Task::finished, this, [this] () {
                 syncAndSeekProgramCounter();
-                emit enableDebugToolbar();
+                emit debugTaskStateChanged();
             });
         }
     }
@@ -1372,10 +1381,10 @@ void CutterCore::stepDebug()
             task = asyncCmd("ds");
         }
         if (task) {
-            emit disableDebugToolbar();
+            emit debugTaskStateChanged();
             connect(task.data(), &R2Task::finished, this, [this] () {
                 syncAndSeekProgramCounter();
-                emit enableDebugToolbar();
+                emit debugTaskStateChanged();
             });
         }
     }
@@ -1392,10 +1401,10 @@ void CutterCore::stepOverDebug()
             task = asyncCmd("dso");
         }
         if (task) {
-            emit disableDebugToolbar();
+            emit debugTaskStateChanged();
             connect(task.data(), &R2Task::finished, this, [this] () {
                 syncAndSeekProgramCounter();
-                emit enableDebugToolbar();
+                emit debugTaskStateChanged();
             });
         }
     }
@@ -1406,12 +1415,12 @@ void CutterCore::stepOutDebug()
     QSharedPointer<R2Task> task;
 
     if (currentlyDebugging) {
-        emit disableDebugToolbar();
+        emit debugTaskStateChanged();
         task = asyncCmd("dsf");
         if (task) {
             connect(task.data(), &R2Task::finished, this, [this] () {
                 syncAndSeekProgramCounter();
-                emit enableDebugToolbar();
+                emit debugTaskStateChanged();
             });
         }
     }

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -312,7 +312,7 @@ QString CutterCore::cmd(const char *str)
     return o;
 }
 
-QSharedPointer<CommandTask> CutterCore::asyncCmd(const char *str)
+QSharedPointer<R2Task> CutterCore::asyncCmd(const char *str)
 {
     if (!commandTask.isNull()) {
         return nullptr;
@@ -322,8 +322,8 @@ QSharedPointer<CommandTask> CutterCore::asyncCmd(const char *str)
 
     RVA offset = core->offset;
 
-    commandTask = QSharedPointer<CommandTask>(new CommandTask(str, CommandTask::ColorMode::MODE_256, true));
-    connect(commandTask.data(), &CommandTask::finished, this, [this, offset] (const QString &result) {
+    commandTask = QSharedPointer<R2Task>(new R2Task(str, true));
+    connect(commandTask.data(), &R2Task::finished, this, [this, offset] () {
         CORE_LOCK();
 
         commandTask = nullptr;
@@ -333,7 +333,7 @@ QSharedPointer<CommandTask> CutterCore::asyncCmd(const char *str)
         }
     });
 
-    getAsyncTaskManager()->start(commandTask);
+    commandTask->startTask();
     return commandTask;
 }
 
@@ -1263,7 +1263,7 @@ void CutterCore::syncAndSeekProgramCounter()
 
 void CutterCore::continueDebug()
 {
-    QSharedPointer<CommandTask> task;
+    QSharedPointer<R2Task> task;
 
     if (currentlyDebugging) {
         if (currentlyEmulating) {
@@ -1273,7 +1273,7 @@ void CutterCore::continueDebug()
             task = asyncCmd("dc");
         }
         if (task) {
-            connect(task.data(), &CommandTask::finished, this, [this] (const QString &result) {
+            connect(task.data(), &R2Task::finished, this, [this] () {
                 syncAndSeekProgramCounter();
                 emit registersChanged();
                 emit refreshCodeViews();
@@ -1285,7 +1285,7 @@ void CutterCore::continueDebug()
 
 void CutterCore::continueUntilDebug(QString offset)
 {
-    QSharedPointer<CommandTask> task;
+    QSharedPointer<R2Task> task;
 
     if (currentlyDebugging) {
         if (currentlyEmulating) {
@@ -1295,7 +1295,7 @@ void CutterCore::continueUntilDebug(QString offset)
             task = asyncCmd("dcu " + offset);
         }
         if (task) {
-            connect(task.data(), &CommandTask::finished, this, [this] (const QString &result) {
+            connect(task.data(), &R2Task::finished, this, [this] () {
                 syncAndSeekProgramCounter();
                 emit registersChanged();
                 emit stackChanged();
@@ -1308,7 +1308,7 @@ void CutterCore::continueUntilDebug(QString offset)
 
 void CutterCore::continueUntilCall()
 {
-    QSharedPointer<CommandTask> task;
+    QSharedPointer<R2Task> task;
 
     if (currentlyDebugging) {
         if (currentlyEmulating) {
@@ -1318,7 +1318,7 @@ void CutterCore::continueUntilCall()
             task = asyncCmd("dcc");
         }
         if (task) {
-            connect(task.data(), &CommandTask::finished, this, [this] (const QString &result) {
+            connect(task.data(), &R2Task::finished, this, [this] () {
                 syncAndSeekProgramCounter();
                 emit enableDebugToolbar();
             });
@@ -1328,7 +1328,7 @@ void CutterCore::continueUntilCall()
 
 void CutterCore::continueUntilSyscall()
 {
-    QSharedPointer<CommandTask> task;
+    QSharedPointer<R2Task> task;
 
     if (currentlyDebugging) {
         if (currentlyEmulating) {
@@ -1338,7 +1338,7 @@ void CutterCore::continueUntilSyscall()
             task = asyncCmd("dcs");
         }
         if (task) {
-            connect(task.data(), &CommandTask::finished, this, [this] (const QString &result) {
+            connect(task.data(), &R2Task::finished, this, [this] () {
                 syncAndSeekProgramCounter();
                 emit enableDebugToolbar();
             });
@@ -1348,7 +1348,7 @@ void CutterCore::continueUntilSyscall()
 
 void CutterCore::stepDebug()
 {
-    QSharedPointer<CommandTask> task;
+    QSharedPointer<R2Task> task;
 
     if (currentlyDebugging) {
         if (currentlyEmulating) {
@@ -1358,7 +1358,7 @@ void CutterCore::stepDebug()
             task = asyncCmd("ds");
         }
         if (task) {
-            connect(task.data(), &CommandTask::finished, this, [this] (const QString &result) {
+            connect(task.data(), &R2Task::finished, this, [this] () {
                 syncAndSeekProgramCounter();
                 emit enableDebugToolbar();
             });
@@ -1368,7 +1368,7 @@ void CutterCore::stepDebug()
 
 void CutterCore::stepOverDebug()
 {
-    QSharedPointer<CommandTask> task;
+    QSharedPointer<R2Task> task;
 
     if (currentlyDebugging) {
         if (currentlyEmulating) {
@@ -1378,7 +1378,7 @@ void CutterCore::stepOverDebug()
             task = asyncCmd("dso");
         }
         if (task) {
-            connect(task.data(), &CommandTask::finished, this, [this] (const QString &result) {
+            connect(task.data(), &R2Task::finished, this, [this] () {
                 syncAndSeekProgramCounter();
                 emit enableDebugToolbar();
             });
@@ -1388,13 +1388,13 @@ void CutterCore::stepOverDebug()
 
 void CutterCore::stepOutDebug()
 {
-    QSharedPointer<CommandTask> task;
+    QSharedPointer<R2Task> task;
 
     if (currentlyDebugging) {
         emit disableDebugToolbar();
         task = asyncCmd("dsf");
         if (task) {
-            connect(task.data(), &CommandTask::finished, this, [this] (const QString &result) {
+            connect(task.data(), &R2Task::finished, this, [this] () {
                 syncAndSeekProgramCounter();
                 emit enableDebugToolbar();
             });

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1254,6 +1254,8 @@ void CutterCore::suspendDebug()
 void CutterCore::stopDebug()
 {
     if (currentlyDebugging) {
+        currentlyDebugging = false;
+        emit debugTaskStateChanged();
         if (currentlyEmulating) {
             cmd("aeim-; aei-; wcr; .ar-");
             currentlyEmulating = false;
@@ -1275,7 +1277,6 @@ void CutterCore::stopDebug()
         seekAndShow(offsetPriorDebugging);
         setConfig("asm.flags", true);
         setConfig("io.cache", false);
-        currentlyDebugging = false;
         emit flagsChanged();
         emit changeDefinedView();
     }

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -312,6 +312,20 @@ QString CutterCore::cmd(const char *str)
     return o;
 }
 
+QSharedPointer<R2Task> CutterCore::asyncCmdEsil(const char *command)
+{
+    QSharedPointer<R2Task> task = asyncCmd(command);
+    connect(task.data(), &R2Task::finished, this, [this, task] () {
+        QString res = task.data()->getResult();
+
+        if (res.contains(QStringLiteral("[ESIL] Stopped execution in an invalid instruction"))) {
+            msgBox.showMessage("Stopped when attempted to run an invalid instruction. You can disable this in Preferences");
+        }
+    });
+    
+    return task;
+}
+
 QSharedPointer<R2Task> CutterCore::asyncCmd(const char *str)
 {
     if (!commandTask.isNull()) {
@@ -1263,16 +1277,16 @@ void CutterCore::syncAndSeekProgramCounter()
 
 void CutterCore::continueDebug()
 {
-    QSharedPointer<R2Task> task;
-
     if (currentlyDebugging) {
+        QSharedPointer<R2Task> task;
+
         if (currentlyEmulating) {
-            cmdEsil("aec");
+            task = asyncCmdEsil("aec");
         } else {
-            emit disableDebugToolbar();
             task = asyncCmd("dc");
         }
         if (task) {
+            emit disableDebugToolbar();
             connect(task.data(), &R2Task::finished, this, [this] () {
                 syncAndSeekProgramCounter();
                 emit registersChanged();
@@ -1285,16 +1299,17 @@ void CutterCore::continueDebug()
 
 void CutterCore::continueUntilDebug(QString offset)
 {
-    QSharedPointer<R2Task> task;
 
     if (currentlyDebugging) {
+        QSharedPointer<R2Task> task;
+
         if (currentlyEmulating) {
-            cmdEsil("aecu " + offset);
+            task = asyncCmdEsil("aecu " + offset);
         } else {
-            emit disableDebugToolbar();
             task = asyncCmd("dcu " + offset);
         }
         if (task) {
+            emit disableDebugToolbar();
             connect(task.data(), &R2Task::finished, this, [this] () {
                 syncAndSeekProgramCounter();
                 emit registersChanged();
@@ -1308,16 +1323,16 @@ void CutterCore::continueUntilDebug(QString offset)
 
 void CutterCore::continueUntilCall()
 {
-    QSharedPointer<R2Task> task;
-
     if (currentlyDebugging) {
+        QSharedPointer<R2Task> task;
+
         if (currentlyEmulating) {
-            cmdEsil("aecc");
+            task = asyncCmdEsil("aecc");
         } else {
-            emit disableDebugToolbar();
             task = asyncCmd("dcc");
         }
         if (task) {
+            emit disableDebugToolbar();
             connect(task.data(), &R2Task::finished, this, [this] () {
                 syncAndSeekProgramCounter();
                 emit enableDebugToolbar();
@@ -1328,16 +1343,16 @@ void CutterCore::continueUntilCall()
 
 void CutterCore::continueUntilSyscall()
 {
-    QSharedPointer<R2Task> task;
-
     if (currentlyDebugging) {
+        QSharedPointer<R2Task> task;
+
         if (currentlyEmulating) {
-            cmdEsil("aecs");
+            task = asyncCmdEsil("aecs");
         } else {
-            emit disableDebugToolbar();
             task = asyncCmd("dcs");
         }
         if (task) {
+            emit disableDebugToolbar();
             connect(task.data(), &R2Task::finished, this, [this] () {
                 syncAndSeekProgramCounter();
                 emit enableDebugToolbar();
@@ -1348,16 +1363,16 @@ void CutterCore::continueUntilSyscall()
 
 void CutterCore::stepDebug()
 {
-    QSharedPointer<R2Task> task;
-
     if (currentlyDebugging) {
+        QSharedPointer<R2Task> task;
+
         if (currentlyEmulating) {
-            cmdEsil("aes");
+            task = asyncCmdEsil("aes");
         } else {
-            emit disableDebugToolbar();
             task = asyncCmd("ds");
         }
         if (task) {
+            emit disableDebugToolbar();
             connect(task.data(), &R2Task::finished, this, [this] () {
                 syncAndSeekProgramCounter();
                 emit enableDebugToolbar();
@@ -1368,16 +1383,16 @@ void CutterCore::stepDebug()
 
 void CutterCore::stepOverDebug()
 {
-    QSharedPointer<R2Task> task;
-
     if (currentlyDebugging) {
+        QSharedPointer<R2Task> task;
+
         if (currentlyEmulating) {
-            cmdEsil("aeso");
+            task = asyncCmdEsil("aeso");
         } else {
-            emit disableDebugToolbar();
             task = asyncCmd("dso");
         }
         if (task) {
+            emit disableDebugToolbar();
             connect(task.data(), &R2Task::finished, this, [this] () {
                 syncAndSeekProgramCounter();
                 emit enableDebugToolbar();

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1171,13 +1171,18 @@ void CutterCore::setRegister(QString regName, QString regValue)
 
 void CutterCore::setCurrentDebugThread(int tid)
 {
-    emit debugTaskStateChanged();
-    cmd("dpt=" + QString::number(tid));
-    emit registersChanged();
-    emit refreshCodeViews();
-    emit stackChanged();
-    syncAndSeekProgramCounter();
-    emit debugTaskStateChanged();
+    asyncCmd("dpt=" + QString::number(tid), debugTask);
+    if (!debugTask.isNull()) {
+        emit debugTaskStateChanged();
+        connect(debugTask.data(), &R2Task::finished, this, [this] () {
+            debugTask.clear();
+            emit registersChanged();
+            emit refreshCodeViews();
+            emit stackChanged();
+            syncAndSeekProgramCounter();
+            emit debugTaskStateChanged();
+        });
+    }
 }
 
 void CutterCore::startDebug()

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -75,6 +75,8 @@ public:
     QJsonDocument cmdjTask(const QString &str);
     void cmdEsil(const char *command);
     void cmdEsil(const QString &command) { cmdEsil(command.toUtf8().constData()); }
+    QSharedPointer<R2Task> asyncCmdEsil(const char *command);
+    QSharedPointer<R2Task> asyncCmdEsil(const QString &command) { return asyncCmdEsil(command.toUtf8().constData()); }
     QString getVersionInformation();
 
     QJsonDocument parseJson(const char *res, const char *cmd = nullptr);

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -16,11 +16,11 @@
 class AsyncTaskManager;
 class CutterCore;
 class Decompiler;
-class CommandTask;
+class R2Task;
 
 #include "plugins/CutterPlugin.h"
 #include "common/BasicBlockHighlighter.h"
-#include "common/CommandTask.h"
+#include "common/R2Task.h"
 
 #define Core() (CutterCore::instance())
 
@@ -60,11 +60,12 @@ public:
      * @param str the command you want to execute
      * @return a shared pointer to the async command task 
      * @note connect to the &CommandTask::finished signal to add your own logic once
-     *       the command is finished.
+     *       the command is finished. Use task->getResult()/getResultJson() for the 
+     *       return value.
      *       If you want to seek to an address, you should use CutterCore::seek.
      */
-    QSharedPointer<CommandTask> asyncCmd(const char *str);
-    QSharedPointer<CommandTask> asyncCmd(const QString &str) { return asyncCmd(str.toUtf8().constData()); }
+    QSharedPointer<R2Task> asyncCmd(const char *str);
+    QSharedPointer<R2Task> asyncCmd(const QString &str) { return asyncCmd(str.toUtf8().constData()); }
     QString cmdRaw(const QString &str);
     QJsonDocument cmdj(const char *str);
     QJsonDocument cmdj(const QString &str) { return cmdj(str.toUtf8().constData()); }
@@ -501,7 +502,7 @@ private:
     bool emptyGraph = false;
     BasicBlockHighlighter *bbHighlighter;
 
-    QSharedPointer<CommandTask> commandTask;
+    QSharedPointer<R2Task> commandTask;
 };
 
 class RCoreLocked

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -253,6 +253,7 @@ public:
     void startEmulation();
     void attachDebug(int pid);
     void stopDebug();
+    void suspendDebug();
     void syncAndSeekProgramCounter();
     void continueDebug();
     void continueUntilCall();

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -272,6 +272,7 @@ public:
     QString getActiveDebugPlugin();
     QStringList getDebugPlugins();
     void setDebugPlugin(QString plugin);
+    bool isDebugTaskInProgress();
     bool currentlyDebugging = false;
     bool currentlyEmulating = false;
     int currentlyAttachedToPID = -1;
@@ -456,8 +457,7 @@ signals:
 
     void projectSaved(bool successfully, const QString &name);
 
-    void disableDebugToolbar();
-    void enableDebugToolbar();
+    void debugTaskStateChanged();
 
     /**
      * emitted when config regarding disassembly display changes

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -16,9 +16,11 @@
 class AsyncTaskManager;
 class CutterCore;
 class Decompiler;
+class CommandTask;
 
 #include "plugins/CutterPlugin.h"
 #include "common/BasicBlockHighlighter.h"
+#include "common/CommandTask.h"
 
 #define Core() (CutterCore::instance())
 
@@ -45,8 +47,24 @@ public:
 
     /* Core functions (commands) */
     static QString sanitizeStringForCommand(QString s);
+    /**
+     * @brief send a command to radare2
+     * @param str the command you want to execute
+     * @return command output
+     * @note if you want to seek to an address, you should use CutterCore::seek.
+     */
     QString cmd(const char *str);
     QString cmd(const QString &str) { return cmd(str.toUtf8().constData()); }
+    /**
+     * @brief send a command to radare2 asynchronously
+     * @param str the command you want to execute
+     * @return a shared pointer to the async command task 
+     * @note connect to the &CommandTask::finished signal to add your own logic once
+     *       the command is finished.
+     *       If you want to seek to an address, you should use CutterCore::seek.
+     */
+    QSharedPointer<CommandTask> asyncCmd(const char *str);
+    QSharedPointer<CommandTask> asyncCmd(const QString &str) { return asyncCmd(str.toUtf8().constData()); }
     QString cmdRaw(const QString &str);
     QJsonDocument cmdj(const char *str);
     QJsonDocument cmdj(const QString &str) { return cmdj(str.toUtf8().constData()); }
@@ -435,6 +453,9 @@ signals:
 
     void projectSaved(bool successfully, const QString &name);
 
+    void disableDebugToolbar();
+    void enableDebugToolbar();
+
     /**
      * emitted when config regarding disassembly display changes
      */
@@ -479,6 +500,8 @@ private:
 
     bool emptyGraph = false;
     BasicBlockHighlighter *bbHighlighter;
+
+    QSharedPointer<CommandTask> commandTask;
 };
 
 class RCoreLocked

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -58,14 +58,14 @@ public:
     /**
      * @brief send a command to radare2 asynchronously
      * @param str the command you want to execute
-     * @return a shared pointer to the async command task 
-     * @note connect to the &CommandTask::finished signal to add your own logic once
+     * @param task a shared pointer that will be returned with the R2 command task
+     * @note connect to the &R2Task::finished signal to add your own logic once
      *       the command is finished. Use task->getResult()/getResultJson() for the 
      *       return value.
      *       If you want to seek to an address, you should use CutterCore::seek.
      */
-    QSharedPointer<R2Task> asyncCmd(const char *str);
-    QSharedPointer<R2Task> asyncCmd(const QString &str) { return asyncCmd(str.toUtf8().constData()); }
+    void asyncCmd(const char *str, QSharedPointer<R2Task> &task);
+    void asyncCmd(const QString &str, QSharedPointer<R2Task> &task) { return asyncCmd(str.toUtf8().constData(), task); }
     QString cmdRaw(const QString &str);
     QJsonDocument cmdj(const char *str);
     QJsonDocument cmdj(const QString &str) { return cmdj(str.toUtf8().constData()); }
@@ -73,10 +73,24 @@ public:
     QStringList cmdList(const QString &str) { return cmdList(str.toUtf8().constData()); }
     QString cmdTask(const QString &str);
     QJsonDocument cmdjTask(const QString &str);
+    /**
+     * @brief send a command to radare2 and check for ESIL errors
+     * @param command the command you want to execute
+     * @note If you want to seek to an address, you should use CutterCore::seek.
+     */
     void cmdEsil(const char *command);
     void cmdEsil(const QString &command) { cmdEsil(command.toUtf8().constData()); }
-    QSharedPointer<R2Task> asyncCmdEsil(const char *command);
-    QSharedPointer<R2Task> asyncCmdEsil(const QString &command) { return asyncCmdEsil(command.toUtf8().constData()); }
+    /**
+     * @brief send a command to radare2 and check for ESIL errors
+     * @param command the command you want to execute
+     * @param task a shared pointer that will be returned with the R2 command task
+     * @note connect to the &R2Task::finished signal to add your own logic once
+     *       the command is finished. Use task->getResult()/getResultJson() for the 
+     *       return value.
+     *       If you want to seek to an address, you should use CutterCore::seek.
+     */
+    void asyncCmdEsil(const char *command, QSharedPointer<R2Task> &task);
+    void asyncCmdEsil(const QString &command, QSharedPointer<R2Task> &task) { return asyncCmdEsil(command.toUtf8().constData(), task); }
     QString getVersionInformation();
 
     QJsonDocument parseJson(const char *res, const char *cmd = nullptr);
@@ -458,6 +472,9 @@ signals:
 
     void projectSaved(bool successfully, const QString &name);
 
+    /**
+     * emitted when debugTask started or finished running
+     */
     void debugTaskStateChanged();
 
     /**
@@ -505,7 +522,7 @@ private:
     bool emptyGraph = false;
     BasicBlockHighlighter *bbHighlighter;
 
-    QSharedPointer<R2Task> commandTask;
+    QSharedPointer<R2Task> debugTask;
 };
 
 class RCoreLocked

--- a/src/img/icons/media-suspend_light.svg
+++ b/src/img/icons/media-suspend_light.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="8" height="8" viewBox="0 0 8 8">
  <g>
-  <rect id="svg_3" height="5.953009" width="1.970973" y="1.138955" x="5.520464" stroke-linecap="null" stroke-linejoin="null" stroke-dasharray="null" stroke-width="null" fill="#aaacaf"/>
-  <rect id="svg_6" height="5.966372" width="1.970973" y="1.122789" x="0.516538" stroke-linecap="null" stroke-linejoin="null" stroke-dasharray="null" stroke-width="null" fill="#aaacaf"/>
+  <rect id="svg_3" height="5.953009" width="1.970973" y="1.138955" x="5.520464" stroke-linecap="null" stroke-linejoin="null" stroke-dasharray="null" stroke-width="null" fill="#b15858"/>
+  <rect id="svg_6" height="5.966372" width="1.970973" y="1.122789" x="0.516538" stroke-linecap="null" stroke-linejoin="null" stroke-dasharray="null" stroke-width="null" fill="#b15858"/>
  </g>
 </svg>

--- a/src/img/icons/media-suspend_light.svg
+++ b/src/img/icons/media-suspend_light.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8" viewBox="0 0 8 8">
+ <g>
+  <rect id="svg_3" height="5.953009" width="1.970973" y="1.138955" x="5.520464" stroke-linecap="null" stroke-linejoin="null" stroke-dasharray="null" stroke-width="null" fill="#aaacaf"/>
+  <rect id="svg_6" height="5.966372" width="1.970973" y="1.122789" x="0.516538" stroke-linecap="null" stroke-linejoin="null" stroke-dasharray="null" stroke-width="null" fill="#aaacaf"/>
+ </g>
+</svg>

--- a/src/resources.qrc
+++ b/src/resources.qrc
@@ -25,6 +25,7 @@
         <file>img/icons/play_light_emul.svg</file>
         <file>img/icons/play_light_attach.svg</file>
         <file>img/icons/media-stop_light.svg</file>
+        <file>img/icons/media-suspend_light.svg</file>
         <file>img/icons/media-skip-forward_light.svg</file>
         <file>img/icons/continue_until_main.svg</file>
         <file>img/icons/continue_until_call.svg</file>

--- a/src/widgets/DebugActions.cpp
+++ b/src/widgets/DebugActions.cpp
@@ -107,14 +107,9 @@ DebugActions::DebugActions(QToolBar *toolBar, MainWindow *main) :
     toggleActions = { actionStep, actionStepOver, actionStepOut, actionContinue,
         actionContinueUntilMain, actionContinueUntilCall, actionContinueUntilSyscall};
 
-    connect(Core(), &CutterCore::disableDebugToolbar, this, [ = ]() {
+    connect(Core(), &CutterCore::debugTaskStateChanged, this, [ = ]() {
         for (QAction *a : toggleActions) {
-            a->setDisabled(true);
-        }
-    });
-    connect(Core(), &CutterCore::enableDebugToolbar, this, [ = ]() {
-        for (QAction *a : toggleActions) {
-            a->setDisabled(false);
+            a->setDisabled(Core()->isDebugTaskInProgress());
         }
     });
 

--- a/src/widgets/DebugActions.cpp
+++ b/src/widgets/DebugActions.cpp
@@ -102,6 +102,22 @@ DebugActions::DebugActions(QToolBar *toolBar, MainWindow *main) :
     // hide allactions
     setAllActionsVisible(false);
 
+    // Toggle all buttons except restart and stop since those are necessary to avoid
+    // staying stuck
+    toggleActions = { actionStep, actionStepOver, actionStepOut, actionContinue,
+        actionContinueUntilMain, actionContinueUntilCall, actionContinueUntilSyscall};
+
+    connect(Core(), &CutterCore::disableDebugToolbar, this, [ = ]() {
+        for (QAction *a : toggleActions) {
+            a->setDisabled(true);
+        }
+    });
+    connect(Core(), &CutterCore::enableDebugToolbar, this, [ = ]() {
+        for (QAction *a : toggleActions) {
+            a->setDisabled(false);
+        }
+    });
+
     connect(actionStop, &QAction::triggered, Core(), &CutterCore::stopDebug);
     connect(actionStop, &QAction::triggered, [ = ]() {
         actionStart->setVisible(true);

--- a/src/widgets/DebugActions.cpp
+++ b/src/widgets/DebugActions.cpp
@@ -112,7 +112,7 @@ DebugActions::DebugActions(QToolBar *toolBar, MainWindow *main) :
         actionContinueUntilMain, actionContinueUntilCall, actionContinueUntilSyscall};
 
     connect(Core(), &CutterCore::debugTaskStateChanged, this, [ = ]() {
-        bool disableToolbar = Core()->isDebugTaskInProgress();
+        bool disableToolbar = Core()->isDebugTaskInProgress() || !Core()->currentlyDebugging;
         for (QAction *a : toggleActions) {
             a->setDisabled(disableToolbar);
         }

--- a/src/widgets/DebugActions.h
+++ b/src/widgets/DebugActions.h
@@ -29,6 +29,10 @@ public:
     QAction *actionAllContinues;
 
 private:
+    /**
+     * @brief buttons that will be disabled/enabled on (disable/enable)DebugToolbar
+     */
+    QList<QAction *> toggleActions;
     MainWindow *main;
     QList<QAction *> allActions;
     QToolButton *continueUntilButton;

--- a/src/widgets/DebugActions.h
+++ b/src/widgets/DebugActions.h
@@ -26,6 +26,7 @@ public:
     QAction *actionStepOver;
     QAction *actionStepOut;
     QAction *actionStop;
+    QAction *actionSuspend;
     QAction *actionAllContinues;
 
 private:

--- a/src/widgets/DebugActions.h
+++ b/src/widgets/DebugActions.h
@@ -2,6 +2,8 @@
 
 #include "core/Cutter.h"
 
+#include <QAction>
+
 class MainWindow;
 class QToolBar;
 class QToolButton;
@@ -26,8 +28,13 @@ public:
     QAction *actionStepOver;
     QAction *actionStepOut;
     QAction *actionStop;
-    QAction *actionSuspend;
     QAction *actionAllContinues;
+    
+    // Continue and suspend interchange during runtime
+    QIcon continueIcon;
+    QIcon suspendIcon;
+    QString suspendLabel;
+    QString continueLabel;
 
 private:
     /**

--- a/src/widgets/ThreadsWidget.cpp
+++ b/src/widgets/ThreadsWidget.cpp
@@ -55,6 +55,7 @@ ThreadsWidget::ThreadsWidget(MainWindow *main, QAction *action) :
     connect(ui->quickFilterView, &QuickFilterView::filterTextChanged, modelFilter,
             &ThreadsFilterModel::setFilterWildcard);
     connect(Core(), &CutterCore::refreshAll, this, &ThreadsWidget::updateContents);
+    //connect(Core(), &CutterCore::debugTaskStateChanged, this, &ThreadsWidget::updateContents);
     connect(Core(), &CutterCore::seekChanged, this, &ThreadsWidget::updateContents);
     connect(Config(), &Configuration::fontsUpdated, this, &ThreadsWidget::fontsUpdatedSlot);
     connect(ui->viewThreads, &QTableView::activated, this, &ThreadsWidget::onActivated);
@@ -67,7 +68,12 @@ void ThreadsWidget::updateContents()
     if (!refreshDeferrer->attemptRefresh(nullptr)) {
         return;
     }
+
     setThreadsGrid();
+
+    if (Core()->isDebugTaskInProgress() || !Core()->currentlyDebugging) {
+        ui->viewThreads->setSelectionMode(QAbstractItemView::NoSelection);
+    }
 }
 
 QString ThreadsWidget::translateStatus(QString status)

--- a/src/widgets/ThreadsWidget.cpp
+++ b/src/widgets/ThreadsWidget.cpp
@@ -55,7 +55,6 @@ ThreadsWidget::ThreadsWidget(MainWindow *main, QAction *action) :
     connect(ui->quickFilterView, &QuickFilterView::filterTextChanged, modelFilter,
             &ThreadsFilterModel::setFilterWildcard);
     connect(Core(), &CutterCore::refreshAll, this, &ThreadsWidget::updateContents);
-    connect(Core(), &CutterCore::debugTaskStateChanged, this, &ThreadsWidget::updateContents);
     connect(Core(), &CutterCore::seekChanged, this, &ThreadsWidget::updateContents);
     connect(Config(), &Configuration::fontsUpdated, this, &ThreadsWidget::fontsUpdatedSlot);
     connect(ui->viewThreads, &QTableView::activated, this, &ThreadsWidget::onActivated);

--- a/src/widgets/ThreadsWidget.cpp
+++ b/src/widgets/ThreadsWidget.cpp
@@ -55,7 +55,7 @@ ThreadsWidget::ThreadsWidget(MainWindow *main, QAction *action) :
     connect(ui->quickFilterView, &QuickFilterView::filterTextChanged, modelFilter,
             &ThreadsFilterModel::setFilterWildcard);
     connect(Core(), &CutterCore::refreshAll, this, &ThreadsWidget::updateContents);
-    //connect(Core(), &CutterCore::debugTaskStateChanged, this, &ThreadsWidget::updateContents);
+    connect(Core(), &CutterCore::debugTaskStateChanged, this, &ThreadsWidget::updateContents);
     connect(Core(), &CutterCore::seekChanged, this, &ThreadsWidget::updateContents);
     connect(Config(), &Configuration::fontsUpdated, this, &ThreadsWidget::fontsUpdatedSlot);
     connect(ui->viewThreads, &QTableView::activated, this, &ThreadsWidget::onActivated);


### PR DESCRIPTION
**Detailed description**

As #1848 describes, the Cutter interface freezes when executing commands. This happens because those r2 commands are called with cmd() directly instead of the AsyncCommand class. R2 expects the user to send a signal using the keyboard for it to exit *_dbg_wait similarly to gdb so it isn't an issue there. 

This PR offers a solution that uses the AsyncCommand class, atm there's only support for regular debugging to get your feedback but I plan on adding this feature to emulation as well, can also be handy with other slow commands.
The commands calling AsyncCmd are responsible of disabling the debug toolbar(and possibly other things as well in the future) and connecting to the finished() event(decided not to go with passing callbacks to AsyncCmd since it's too messy and QSharedPointer take care of setting the asynctask pointer to NULL once all clients are done with their logic).

There also needs to be a some kind of "Suspend" button that will stop the async task using a new r2 command/signal.

**Test plan (required)**

Run "continue until main" twice or just "continue" without breakpoints to see that all toolbar buttons are disabled except for stop/restart. Running any of the step commands will momentarily disable the buttons so it's harder to see that it's working.

**Closing issues**

closes #1848 