### PR TITLE
Add highlight to hexdump parsing

### DIFF
--- a/src/widgets/HexdumpWidget.cpp
+++ b/src/widgets/HexdumpWidget.cpp
@@ -4,6 +4,7 @@
 #include "common/Helpers.h"
 #include "common/Configuration.h"
 #include "common/TempConfig.h"
+#include "common/SyntaxHighlighter.h"
 #include "core/MainWindow.h"
 
 #include <QJsonObject>
@@ -36,7 +37,9 @@ HexdumpWidget::HexdumpWidget(MainWindow *main, QAction *action) :
     QIcon closeIcon = QIcon(":/img/icons/delete.svg");
     closeButton->setIcon(closeIcon);
     closeButton->setAutoRaise(true);
+
     ui->hexSideTab_2->setCornerWidget(closeButton);
+    syntaxHighLighter = Config()->createSyntaxHighlighter(ui->hexDisasTextEdit->document());
 
     ui->openSideViewB->hide();  // hide button at startup since side view is visible
 
@@ -215,6 +218,8 @@ void HexdumpWidget::updateParseWindow(RVA start_address, int size)
         // Get selected combos
         QString arch = ui->parseArchComboBox->currentText();
         QString bits = ui->parseBitsComboBox->currentText();
+        QString selectedCommand = "";
+        QString commandResult = "";
         bool bigEndian = ui->parseEndianComboBox->currentIndex() == 1;
 
         TempConfig tempConfig;
@@ -225,41 +230,40 @@ void HexdumpWidget::updateParseWindow(RVA start_address, int size)
 
         switch (ui->parseTypeComboBox->currentIndex()) {
         case 0: // Disassembly
-            ui->hexDisasTextEdit->setPlainText(Core()->cmd("pda " + argument));
+            selectedCommand = "pda";
             break;
         case 1: // String
-            ui->hexDisasTextEdit->setPlainText(Core()->cmd("pcs " + argument));
+            selectedCommand = "pcs";
             break;
         case 2: // Assembler
-            ui->hexDisasTextEdit->setPlainText(Core()->cmd("pca " + argument));
+            selectedCommand = "pca";
             break;
         case 3: // C byte array
-            ui->hexDisasTextEdit->setPlainText(Core()->cmd("pc " + argument));
+            selectedCommand = "pc";
             break;
         case 4: // C half-word
-            ui->hexDisasTextEdit->setPlainText(Core()->cmd("pch " + argument));
+            selectedCommand = "pch";
             break;
         case 5: // C word
-            ui->hexDisasTextEdit->setPlainText(Core()->cmd("pcw " + argument));
+            selectedCommand = "pcw";
             break;
         case 6: // C dword
-            ui->hexDisasTextEdit->setPlainText(Core()->cmd("pcd " + argument));
+            selectedCommand = "pcd";
             break;
         case 7: // Python
-            ui->hexDisasTextEdit->setPlainText(Core()->cmd("pcp " + argument));
+            selectedCommand = "pcp";
             break;
         case 8: // JSON
-            ui->hexDisasTextEdit->setPlainText(Core()->cmd("pcj " + argument));
+            selectedCommand = "pcj";
             break;
         case 9: // JavaScript
-            ui->hexDisasTextEdit->setPlainText(Core()->cmd("pcJ " + argument));
+            selectedCommand = "pcJ";
             break;
         case 10: // Yara
-            ui->hexDisasTextEdit->setPlainText(Core()->cmd("pcy " + argument));
+            selectedCommand = "pcy";
             break;
-        default:
-            ui->hexDisasTextEdit->setPlainText("");
         }
+        ui->hexDisasTextEdit->setPlainText(selectedCommand != "" ? Core()->cmd(selectedCommand + " " + argument) : "");
     } else {
         // Fill the information tab hashes and entropy
         ui->bytesMD5->setText(Core()->cmd("ph md5 " + argument).trimmed());

--- a/src/widgets/HexdumpWidget.h
+++ b/src/widgets/HexdumpWidget.h
@@ -25,6 +25,7 @@ class HexdumpWidget;
 }
 
 class RefreshDeferrer;
+class QSyntaxHighlighter;
 
 class HexdumpWidget : public MemoryDockWidget
 {
@@ -48,6 +49,7 @@ private:
     bool sent_seek = false;
 
     RefreshDeferrer *refreshDeferrer;
+    QSyntaxHighlighter *syntaxHighLighter;
 
     void refresh();
     void refresh(RVA addr);


### PR DESCRIPTION
 <!-- Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request. -->


**Detailed description**

This pull reuqest implements syntax highlighting inside Hexdump parsing feature.
While it is not perfect for all cases of output, it does look better than the plain white

**Test plan (required)**

Got to hex widget
Open the side bar, select the parsing feature
Select bytes and see them shown with highlight

**Screenshots**
C

![image](https://user-images.githubusercontent.com/20182642/67577360-9e75d200-f740-11e9-8858-2f16985820e9.png)

Python

![image](https://user-images.githubusercontent.com/20182642/67577434-be0cfa80-f740-11e9-9917-91e81cf997f7.png)

Javascript

![image](https://user-images.githubusercontent.com/20182642/67577456-c7966280-f740-11e9-94ae-f06149fee2a1.png)



