### PR TITLE
Change focus order in SetToDataDialog.

### DIFF
--- a/src/dialogs/SetToDataDialog.ui
+++ b/src/dialogs/SetToDataDialog.ui
@@ -56,16 +56,6 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="0" colspan="2">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
    <item row="3" column="1">
     <widget class="QLineEdit" name="repeatEdit">
      <property name="text">
@@ -80,8 +70,22 @@
      </property>
     </widget>
    </item>
+   <item row="4" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>sizeEdit</tabstop>
+  <tabstop>repeatEdit</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>


### PR DESCRIPTION
 <!-- Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request. -->


**Detailed description**

Change tab order from top to bottom and focus on first one (Item size) when opening the dialog.

It is now possible to do `*,enter size,tab,enter count,enter`.
Previously you had to do `*,tab,tab,enter count,tab,enter size, enter`.

**Test plan (required)**

* open disassembly
* press `*` or context menu for `set as/data/...`
* observe that focus is in top most input field
* press tab, observe that focus changes to next input field
* press enter, observe that dialog can be confirmed using enter key without using tab to focus button bar


<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**

<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
