### PR TITLE
Add instruction highlight in graph view

### DIFF
--- a/src/Cutter.pro
+++ b/src/Cutter.pro
@@ -359,6 +359,7 @@ SOURCES += \
     common/PythonManager.cpp \
     plugins/PluginManager.cpp \
     common/BasicBlockHighlighter.cpp \
+    common/BasicInstructionHighlighter.cpp \
     dialogs/LinkTypeDialog.cpp \
     widgets/ColorPicker.cpp \
     common/ColorThemeWorker.cpp \
@@ -494,6 +495,7 @@ HEADERS  += \
     common/PythonManager.h \
     plugins/PluginManager.h \
     common/BasicBlockHighlighter.h \
+    common/BasicInstructionHighlighter.h \
     common/UpdateWorker.h \
     widgets/ColorPicker.h \
     common/ColorThemeWorker.h \

--- a/src/common/BasicInstructionHighlighter.cpp
+++ b/src/common/BasicInstructionHighlighter.cpp
@@ -1,0 +1,90 @@
+#include "BasicInstructionHighlighter.h"
+
+BasicInstructionHighlighter::~BasicInstructionHighlighter() {
+    for (BasicInstructionIt it = biMap.begin(); it != biMap.end(); ++it) {
+        delete it->second;
+    }
+}
+
+/**
+ * @brief Clear the basic instruction highlighting
+ */
+void BasicInstructionHighlighter::clear(RVA address, RVA size) {
+    BasicInstructionIt it = biMap.lower_bound(address);
+    if (it != biMap.begin()) {
+        --it;
+    }
+
+    std::vector<RVA> addrs;
+    while (it != biMap.end() && it->first < address + size) {
+        addrs.push_back(it->first);
+        ++it;
+    }
+
+    // first and last entries may intersect, but not necessarily
+    // be contained in [address, address + size), so we need to
+    // check it and perhaps adjust their addresses.
+    std::vector<BasicInstruction*> newInstructions;
+    if (!addrs.empty()) {
+        BasicInstruction *prev = biMap[addrs.front()];
+        if (prev->address < address && prev->address + prev->size > address) {
+            BasicInstruction *newInstr = new BasicInstruction;
+            newInstr->address = prev->address;
+            newInstr->size = address - prev->address;
+            newInstr->color = prev->color;
+            newInstructions.push_back(newInstr);
+        }
+
+        BasicInstruction *next = biMap[addrs.back()];
+        if (next->address < address + size && next->address + next->size > address + size) {
+            const RVA offset = address + size - next->address;
+            BasicInstruction *newInstr = new BasicInstruction;
+            newInstr->address = next->address + offset;
+            newInstr->size = next->size - offset;
+            newInstr->color = next->color;
+            newInstructions.push_back(newInstr);
+        }
+    }
+
+    for (RVA addr : addrs) {
+        BasicInstruction *bi = biMap[addr];
+        if (std::max(bi->address, address) < std::min(bi->address + bi->size, address + size)) {
+            biMap.erase(addr);
+            delete bi;
+        }
+    }
+
+    for (BasicInstruction *newInstr : newInstructions) {
+        biMap[newInstr->address] = newInstr;
+    }
+}
+
+/**
+ * @brief Highlight the basic instruction at address
+ */
+void BasicInstructionHighlighter::highlight(RVA address, RVA size, QColor color) {
+    clear(address, size);
+    BasicInstruction *bi = new BasicInstruction;
+    bi->address = address;
+    bi->size = size;
+    bi->color = color;
+    biMap[address] = bi;
+}
+
+/**
+ * @brief Return a highlighted basic instruction
+ *
+ * If there is nothing to highlight at specified address, returns nullptr
+ */
+BasicInstruction* BasicInstructionHighlighter::getBasicInstruction(RVA address) {
+    BasicInstructionIt it = biMap.upper_bound(address);
+    if (it == biMap.begin()) {
+        return nullptr;
+    }
+
+    BasicInstruction *bi = (--it)->second;
+    if (bi->address <= address && address < bi->address + bi->size) {
+        return bi;
+    }
+    return nullptr;
+}

--- a/src/common/BasicInstructionHighlighter.h
+++ b/src/common/BasicInstructionHighlighter.h
@@ -1,0 +1,29 @@
+#ifndef BASICINSTRUCTIONHIGHLIGHTER_H
+#define BASICINSTRUCTIONHIGHLIGHTER_H
+
+class BasicInstructionHighlighter;
+
+#include "Cutter.h"
+#include <map> 
+
+struct BasicInstruction {
+    RVA address;
+    RVA size;
+    QColor color;
+};
+
+typedef std::map<RVA, BasicInstruction*>::iterator BasicInstructionIt;
+
+class BasicInstructionHighlighter
+{
+public:
+    ~BasicInstructionHighlighter();
+    void clear(RVA address, RVA size);
+    void highlight(RVA address, RVA size, QColor color);
+    BasicInstruction* getBasicInstruction(RVA address);
+
+private:
+    std::map<RVA, BasicInstruction*> biMap;
+};
+
+#endif // BASICINSTRUCTIONHIGHLIGHTER_H

--- a/src/common/BasicInstructionHighlighter.h
+++ b/src/common/BasicInstructionHighlighter.h
@@ -1,10 +1,9 @@
 #ifndef BASICINSTRUCTIONHIGHLIGHTER_H
 #define BASICINSTRUCTIONHIGHLIGHTER_H
 
-class BasicInstructionHighlighter;
-
-#include "Cutter.h"
-#include <map> 
+#include "CutterCommon.h"
+#include <map>
+#include <QColor>
 
 struct BasicInstruction {
     RVA address;
@@ -12,18 +11,17 @@ struct BasicInstruction {
     QColor color;
 };
 
-typedef std::map<RVA, BasicInstruction*>::iterator BasicInstructionIt;
+typedef std::map<RVA, BasicInstruction>::iterator BasicInstructionIt;
 
 class BasicInstructionHighlighter
 {
 public:
-    ~BasicInstructionHighlighter();
     void clear(RVA address, RVA size);
     void highlight(RVA address, RVA size, QColor color);
-    BasicInstruction* getBasicInstruction(RVA address);
+    BasicInstruction *getBasicInstruction(RVA address);
 
 private:
-    std::map<RVA, BasicInstruction*> biMap;
+    std::map<RVA, BasicInstruction> biMap;
 };
 
 #endif // BASICINSTRUCTIONHIGHLIGHTER_H

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -198,9 +198,6 @@ void CutterCore::initialize()
     // Initialize graph node highlighter
     bbHighlighter = new BasicBlockHighlighter();
 
-    // Initialize (currently only graph view) instruction highlighter
-    biHighlighter = new BasicInstructionHighlighter();
-
     // Initialize Async tasks manager
     asyncTaskManager = new AsyncTaskManager(this);
 }
@@ -208,7 +205,6 @@ void CutterCore::initialize()
 CutterCore::~CutterCore()
 {
     delete bbHighlighter;
-    delete biHighlighter;
     r_cons_sleep_end(coreBed);
     r_core_task_sync_end(core_);
     r_core_free(this->core_);
@@ -2902,7 +2898,7 @@ BasicBlockHighlighter* CutterCore::getBBHighlighter()
 
 BasicInstructionHighlighter* CutterCore::getBIHighlighter()
 {
-    return biHighlighter;
+    return &biHighlighter;
 }
 
 /**

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -197,6 +197,9 @@ void CutterCore::initialize()
     // Initialize graph node highlighter
     bbHighlighter = new BasicBlockHighlighter();
 
+    // Initialize (currently only graph view) instruction highlighter
+    ibbHighlighter = new BasicBlockHighlighter();
+
     // Initialize Async tasks manager
     asyncTaskManager = new AsyncTaskManager(this);
 }
@@ -204,6 +207,7 @@ void CutterCore::initialize()
 CutterCore::~CutterCore()
 {
     delete bbHighlighter;
+    delete ibbHighlighter;
     r_cons_sleep_end(coreBed);
     r_core_task_sync_end(core_);
     r_core_free(this->core_);
@@ -2895,6 +2899,10 @@ BasicBlockHighlighter* CutterCore::getBBHighlighter()
     return bbHighlighter;
 }
 
+BasicBlockHighlighter* CutterCore::getIBBHighlighter()
+{
+    return ibbHighlighter;
+}
 
 /**
  * @brief get a compact disassembly preview for tooltips

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -8,6 +8,7 @@
 #include <memory>
 
 #include "common/TempConfig.h"
+#include "common/BasicInstructionHighlighter.h"
 #include "common/Configuration.h"
 #include "common/AsyncTask.h"
 #include "common/R2Task.h"
@@ -198,7 +199,7 @@ void CutterCore::initialize()
     bbHighlighter = new BasicBlockHighlighter();
 
     // Initialize (currently only graph view) instruction highlighter
-    ibbHighlighter = new BasicBlockHighlighter();
+    biHighlighter = new BasicInstructionHighlighter();
 
     // Initialize Async tasks manager
     asyncTaskManager = new AsyncTaskManager(this);
@@ -207,7 +208,7 @@ void CutterCore::initialize()
 CutterCore::~CutterCore()
 {
     delete bbHighlighter;
-    delete ibbHighlighter;
+    delete biHighlighter;
     r_cons_sleep_end(coreBed);
     r_core_task_sync_end(core_);
     r_core_free(this->core_);
@@ -2899,9 +2900,9 @@ BasicBlockHighlighter* CutterCore::getBBHighlighter()
     return bbHighlighter;
 }
 
-BasicBlockHighlighter* CutterCore::getIBBHighlighter()
+BasicInstructionHighlighter* CutterCore::getBIHighlighter()
 {
-    return ibbHighlighter;
+    return biHighlighter;
 }
 
 /**

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -405,6 +405,7 @@ public:
 
     static QString ansiEscapeToHtml(const QString &text);
     BasicBlockHighlighter *getBBHighlighter();
+    BasicBlockHighlighter *getIBBHighlighter();
 
 signals:
     void refreshAll();
@@ -471,6 +472,7 @@ private:
 
     bool emptyGraph = false;
     BasicBlockHighlighter *bbHighlighter;
+    BasicBlockHighlighter *ibbHighlighter;
 };
 
 class RCoreLocked

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -14,6 +14,7 @@
 #include <QMutex>
 
 class AsyncTaskManager;
+class BasicInstructionHighlighter;
 class CutterCore;
 class Decompiler;
 
@@ -405,7 +406,7 @@ public:
 
     static QString ansiEscapeToHtml(const QString &text);
     BasicBlockHighlighter *getBBHighlighter();
-    BasicBlockHighlighter *getIBBHighlighter();
+    BasicInstructionHighlighter *getBIHighlighter();
 
 signals:
     void refreshAll();
@@ -472,7 +473,7 @@ private:
 
     bool emptyGraph = false;
     BasicBlockHighlighter *bbHighlighter;
-    BasicBlockHighlighter *ibbHighlighter;
+    BasicInstructionHighlighter *biHighlighter;
 };
 
 class RCoreLocked

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -3,6 +3,7 @@
 
 #include "core/CutterCommon.h"
 #include "core/CutterDescriptions.h"
+#include "common/BasicInstructionHighlighter.h"
 
 #include <QMap>
 #include <QDebug>
@@ -473,7 +474,7 @@ private:
 
     bool emptyGraph = false;
     BasicBlockHighlighter *bbHighlighter;
-    BasicInstructionHighlighter *biHighlighter;
+    BasicInstructionHighlighter biHighlighter;
 };
 
 class RCoreLocked

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -46,7 +46,7 @@ DisassemblerGraphView::DisassemblerGraphView(QWidget *parent, CutterSeekable *se
       seekable(seekable),
       actionExportGraph(this),
       actionUnhighlight(this),
-      actionUnhighlightLine(this)
+      actionUnhighlightInstruction(this)
 {
     highlight_token = nullptr;
     auto *layout = new QVBoxLayout(this);
@@ -157,7 +157,7 @@ DisassemblerGraphView::DisassemblerGraphView(QWidget *parent, CutterSeekable *se
     });
 
     QAction *highlightLBB = new QAction(this);
-    actionUnhighlightLine.setVisible(false);
+    actionUnhighlightInstruction.setVisible(false);
 
     highlightLBB->setText(tr("Highlight line"));
     connect(highlightLBB, &QAction::triggered, this, [this]() {
@@ -177,8 +177,8 @@ DisassemblerGraphView::DisassemblerGraphView(QWidget *parent, CutterSeekable *se
         Config()->colorsUpdated();
     });
 
-    actionUnhighlightLine.setText(tr("Unhighlight line"));
-    connect(&actionUnhighlightLine, &QAction::triggered, this, [this]() {
+    actionUnhighlightInstruction.setText(tr("Unhighlight line"));
+    connect(&actionUnhighlightInstruction, &QAction::triggered, this, [this]() {
         auto lbbh = Core()->getIBBHighlighter();
         lbbh->clear(this->seekable->getOffset());
         Config()->colorsUpdated();
@@ -187,7 +187,7 @@ DisassemblerGraphView::DisassemblerGraphView(QWidget *parent, CutterSeekable *se
     blockMenu->addAction(highlightBB);
     blockMenu->addAction(&actionUnhighlight);
     blockMenu->addAction(highlightLBB);
-    blockMenu->addAction(&actionUnhighlightLine);
+    blockMenu->addAction(&actionUnhighlightInstruction);
 
 
     // Include all actions from generic context menu in block specific menu
@@ -1018,7 +1018,7 @@ void DisassemblerGraphView::blockContextMenuRequested(GraphView::GraphBlock &blo
 {
     const RVA offset = this->seekable->getOffset();
     actionUnhighlight.setVisible(Core()->getBBHighlighter()->getBasicBlock(block.entry));
-    actionUnhighlightLine.setVisible(Core()->getIBBHighlighter()->getBasicBlock(offset));
+    actionUnhighlightInstruction.setVisible(Core()->getIBBHighlighter()->getBasicBlock(offset));
     event->accept();
     blockMenu->exec(event->globalPos());
 }

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -45,7 +45,8 @@ DisassemblerGraphView::DisassemblerGraphView(QWidget *parent, CutterSeekable *se
       contextMenu(new QMenu(this)),
       seekable(seekable),
       actionExportGraph(this),
-      actionUnhighlight(this)
+      actionUnhighlight(this),
+      actionUnhighlightLine(this)
 {
     highlight_token = nullptr;
     auto *layout = new QVBoxLayout(this);

--- a/src/widgets/DisassemblerGraphView.h
+++ b/src/widgets/DisassemblerGraphView.h
@@ -224,6 +224,7 @@ private:
 
     QAction actionExportGraph;
     QAction actionUnhighlight;
+    QAction actionUnhighlightLine;
 
     QLabel *emptyText = nullptr;
 

--- a/src/widgets/DisassemblerGraphView.h
+++ b/src/widgets/DisassemblerGraphView.h
@@ -193,6 +193,7 @@ private:
      */
     QRectF getInstrRect(GraphView::GraphBlock &block, RVA addr) const;
     void showInstruction(GraphView::GraphBlock &block, RVA addr);
+    const Instr *instrForAddress(RVA addr);
     DisassemblyBlock *blockForAddress(RVA addr);
     void seekLocal(RVA addr, bool update_viewport = true);
     void seekInstruction(bool previous_instr);

--- a/src/widgets/DisassemblerGraphView.h
+++ b/src/widgets/DisassemblerGraphView.h
@@ -157,6 +157,8 @@ protected:
 
 private slots:
     void on_actionExportGraph_triggered();
+    void onActionHighlightBITriggered();
+    void onActionUnhighlightBITriggered();
 
 private:
     bool transition_dont_seek = false;

--- a/src/widgets/DisassemblerGraphView.h
+++ b/src/widgets/DisassemblerGraphView.h
@@ -224,7 +224,7 @@ private:
 
     QAction actionExportGraph;
     QAction actionUnhighlight;
-    QAction actionUnhighlightLine;
+    QAction actionUnhighlightInstruction;
 
     QLabel *emptyText = nullptr;
 


### PR DESCRIPTION
**Detailed description**
As #444 mentions it would be nice to have instruction highlighting in graph view/disassembly. I have implemented instruction highlighting in graph view. To implement this i have used BasicBlock API.
Two new entries were added to graph view context menu 'Highlight Instruction' and 'Unhighlight Instruction' whose work analogously to 'Highlight block' and 'Unhighlight block'.
It's important to note that currently breakpoint color takes priority over manual highlight. I don't know if it's a good choice.
Default color is set to 'linehl' from radare2 color keys.
![gif](https://user-images.githubusercontent.com/8948436/68881988-85908900-070e-11ea-9c5e-051c8caf9dc6.gif)


**Test plan (required)**
1. Set as ... dosen't remove highlight
2. highlight color changes when line is selected
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**
One step closer to closing #444.

