### PR TITLE
Highlight in red changes in the Hexdump Widget

### DIFF
--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -207,9 +207,18 @@ void HexWidget::setItemGroupSize(int size)
     viewport()->update();
 }
 
-bool HexWidget::isDataDifferentAt(uint64_t offset) {
-    if (offset >= old_data->minIndex() && offset < old_data->maxIndex()) {
-        uint64_t itemOffset = offset - startAddress;
+/**
+ * @brief Checks if Item at the address changed compared to the last read data.
+ * @param address Address of Item to be compared.
+ * @return True if Item is different, False if Item is equal or last read didn't contain the address.
+ * @see HexWidget#readItem
+ *
+ * Checks if current Item at the address changed compared to the last read data.
+ * It is assumed that the current read data buffer contains the address.
+ */
+bool HexWidget::isItemDifferentAt(uint64_t address) {
+    if (address >= old_data->minIndex() && address < old_data->maxIndex()) {
+        uint64_t itemOffset = address - startAddress;
         QVariant curItem = readItem(itemOffset);
         data.swap(old_data);
         QVariant oldItem = readItem(itemOffset);
@@ -348,6 +357,7 @@ void HexWidget::updateColors()
     printableColor = Config()->getColor("ai.write");
     defColor = Config()->getColor("btext");
     addrColor = Config()->getColor("func_var_addr");
+    diffColor = Config()->getColor("graph.diff.unmatch");
 
     updateCursorMeta();
     viewport()->update();
@@ -769,8 +779,8 @@ void HexWidget::drawItemArea(QPainter &painter)
                 if (selection.contains(itemAddr)  && !cursorOnAscii) {
                     itemColor = palette().highlightedText().color();
                 }
-                if (isDataDifferentAt(itemAddr)) {
-                    itemColor.setRgb(qRgb(255, 25, 25));
+                if (isItemDifferentAt(itemAddr)) {
+                    itemColor.setRgb(diffColor.rgb());
                 }
                 painter.setPen(itemColor);
                 painter.drawText(itemRect, Qt::AlignVCenter, itemString);
@@ -808,8 +818,8 @@ void HexWidget::drawAsciiArea(QPainter &painter)
             if (selection.contains(address) && cursorOnAscii) {
                 color = palette().highlightedText().color();
             }
-            if (isDataDifferentAt(address)) {
-                color.setRgb(qRgb(255, 25, 25));
+            if (isItemDifferentAt(address)) {
+                color.setRgb(diffColor.rgb());
             }
             painter.setPen(color);
             /* Dots look ugly. Use fillRect() instead of drawText(). */

--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -124,7 +124,7 @@ HexWidget::HexWidget(QWidget *parent) :
     startAddress = 0ULL;
     cursor.address = 0ULL;
     data.reset(new MemoryData());
-    old_data.reset(new MemoryData());
+    oldData.reset(new MemoryData());
 
     fetchData();
     updateCursorMeta();
@@ -217,12 +217,12 @@ void HexWidget::setItemGroupSize(int size)
  * It is assumed that the current read data buffer contains the address.
  */
 bool HexWidget::isItemDifferentAt(uint64_t address) {
-    if (address >= old_data->minIndex() && address < old_data->maxIndex()) {
+    if (address >= oldData->minIndex() && address < oldData->maxIndex()) {
         uint64_t itemOffset = address - startAddress;
         QVariant curItem = readItem(itemOffset);
-        data.swap(old_data);
+        data.swap(oldData);
         QVariant oldItem = readItem(itemOffset);
-        data.swap(old_data);
+        data.swap(oldData);
         return (oldItem != curItem);
     }
     return false;
@@ -1222,7 +1222,7 @@ QChar HexWidget::renderAscii(int offset, QColor *color)
 
 void HexWidget::fetchData()
 {
-    data.swap(old_data);
+    data.swap(oldData);
     data->fetch(startAddress, bytesPerScreen());
 }
 

--- a/src/widgets/HexWidget.h
+++ b/src/widgets/HexWidget.h
@@ -122,10 +122,10 @@ public:
     void fetch(uint64_t address, int length) override
     {
         // FIXME: reuse data if possible
-        const uint64_t block_sz = 0x1000ULL;
-        uint64_t alignedAddr = address & ~(block_sz - 1);
+        const uint64_t blockSize = 0x1000ULL;
+        uint64_t alignedAddr = address & ~(blockSize - 1);
         int offset = address - alignedAddr;
-        int len = (offset + length + (block_sz - 1)) & ~(block_sz - 1);
+        int len = (offset + length + (blockSize - 1)) & ~(blockSize - 1);
         m_firstBlockAddr = alignedAddr;
         m_lastValidAddr = length ? alignedAddr + len - 1 : 0;
         if (m_lastValidAddr < m_firstBlockAddr) {
@@ -134,8 +134,8 @@ public:
         }
         m_blocks.clear();
         uint64_t addr = alignedAddr;
-        for (int i = 0; i < len / block_sz; ++i, addr += block_sz) {
-            m_blocks.append(Core()->ioRead(addr, block_sz));
+        for (int i = 0; i < len / blockSize; ++i, addr += blockSize) {
+            m_blocks.append(Core()->ioRead(addr, blockSize));
         }
     }
 
@@ -484,7 +484,7 @@ private:
     QAction *actionCopyAddress;
     QAction *actionSelectRange;
 
-    std::unique_ptr<AbstractData> old_data;
+    std::unique_ptr<AbstractData> oldData;
     std::unique_ptr<AbstractData> data;
 };
 

--- a/src/widgets/HexWidget.h
+++ b/src/widgets/HexWidget.h
@@ -311,7 +311,7 @@ private:
     void setCursorAddr(BasicCursor addr, bool select = false);
     void updateCursorMeta();
     void setCursorOnAscii(bool ascii);
-    bool isDataDifferentAt(uint64_t offset);
+    bool isItemDifferentAt(uint64_t address);
     const QColor itemColor(uint8_t byte);
     QVariant readItem(int offset, QColor *color = nullptr);
     QString renderItem(int offset, QColor *color = nullptr);
@@ -460,6 +460,7 @@ private:
     QColor backgroundColor;
     QColor defColor;
     QColor addrColor;
+    QColor diffColor;
     QColor b0x00Color;
     QColor b0x7fColor;
     QColor b0xffColor;

--- a/src/widgets/HexdumpWidget.cpp
+++ b/src/widgets/HexdumpWidget.cpp
@@ -80,6 +80,9 @@ HexdumpWidget::HexdumpWidget(MainWindow *main, QAction *action) :
 
     connect(Config(), SIGNAL(fontsUpdated()), this, SLOT(fontsUpdated()));
     connect(Core(), &CutterCore::refreshAll, this, [this]() { refresh(); });
+    connect(Core(), &CutterCore::instructionChanged, this, [this]() { refresh(); });
+    connect(Core(), &CutterCore::stackChanged, this, [this]() { refresh(); });
+    connect(Core(), &CutterCore::registersChanged, this, [this]() { refresh(); });
 
     connect(seekable, &CutterSeekable::seekableSeekChanged, this, &HexdumpWidget::onSeekChanged);
     connect(ui->hexTextView, &HexWidget::positionChanged, this, [this](RVA addr) {


### PR DESCRIPTION
 <!-- Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request. -->


**Detailed description**

<!-- Explain the **details** for making this change. What existing problem does the pull request solve? Please provide enough information so that others can review your pull request -->
This is so that it's easier to identify on the hexdump which bytes/values changed after a write if they are in view, especially useful when debugging.

I had to make some changes so that I could check if the old buffer contains the offset to be compared, so some issues may arise because of that, but in my testing I couldn't find any.

**Test plan (required)**
 - Making sure Hexdump still behaves ok:
    - Scroll between block read aligned boundaries (0x1000)
    - Scroll to the start/end of file, make sure it doesn't crash or wrap around

 - Test highlighting when changes occur:
    - Write to area that hexdump is showing, notice the highlighting
    - Scroll once, the highlight disappears
    - Write to area that hexdump is showing again, only the changed bytes get highlighted
    - Write to area that hexdump is not showing, nothing changes
    - Enter emulation mode (with a binary)
    - Seek to the stack in the hexdump (and unsync it)
    - Step and notice the highlighting when something is written to the stack that is different from the previous value, highlight disappears when scrolled/stepped again
    - Make sure it also works in all formats (float, int, hex, octal)

