### PR TITLE
Improve compatibility with cmake 3.10.

### DIFF
--- a/docs/source/building.rst
+++ b/docs/source/building.rst
@@ -243,7 +243,9 @@ so it contains ``$CUSTOM_BREAKPAD_PREFIX/lib/pkgconfig``. For this simply run
 Troubleshooting
 ---------------
 
-   Cmake: qt development package not found
+* Cmake can't find Qt
+
+    Cmake: qt development package not found
 
 Depending on how Qt installed (Distribution packages or using the Qt
 installer application), CMake may not be able to find it by itself if it
@@ -256,4 +258,16 @@ containing bin/, lib/, include/, etc.) and specify it to CMake using
 
    rm CMakeCache.txt # the cache may be polluted with unwanted libraries found before
    cmake -DCMAKE_PREFIX_PATH=/opt/Qt/5.9.1/gcc_64 ..
+
+* R2 libr_***.so cannot be found when running Cutter
+
+   ./Cutter: error while loading shared libraries: libr_lang.so: cannot open shared object file: No such file or directory
+
+The exact r2 .so file that cannot be found may vary. On some systems linker by default uses RUNPATH instead of RPATH which is incompatible with the way r2 is currently compiled. It results in some of the r2 libraries not being found when running cutter. You can verify if this is the problem by running `ldd ./Cutter`. If all the r2 libraries are missing you have a different problem.
+Workaround is to either add `--disable-new-dtags` linker flag when compiling Cutter or add r2 installation path to LD_LIBRARY_PATH environment variable.
+
+::
+
+   cmake -DCMAKE_EXE_LINKER_FLAGS="-Wl,--disable-new-dtags"  ..
+
 

--- a/src/cmake/FindGraphviz.cmake
+++ b/src/cmake/FindGraphviz.cmake
@@ -1,7 +1,7 @@
 set (_module Graphviz)
 
 find_package(PkgConfig REQUIRED)
-if (NOT (CMAKE_VERSION VERSION_LESS "3.13.0"))
+if (NOT (CMAKE_VERSION VERSION_LESS "3.12.0"))
     pkg_check_modules(GVC IMPORTED_TARGET GLOBAL libgvc)
 elseif (NOT (CMAKE_VERSION VERSION_LESS "3.11.0"))
     pkg_check_modules(GVC IMPORTED_TARGET libgvc)

--- a/src/cmake/FindGraphviz.cmake
+++ b/src/cmake/FindGraphviz.cmake
@@ -1,8 +1,10 @@
 set (_module Graphviz)
 
 find_package(PkgConfig REQUIRED)
-if (NOT (CMAKE_VERSION VERSION_LESS "3.6.0"))
+if (NOT (CMAKE_VERSION VERSION_LESS "3.13.0"))
     pkg_check_modules(GVC IMPORTED_TARGET GLOBAL libgvc)
+elseif (NOT (CMAKE_VERSION VERSION_LESS "3.11.0"))
+    pkg_check_modules(GVC IMPORTED_TARGET libgvc)
 else()
     pkg_check_modules(GVC libgvc)
 endif()
@@ -13,7 +15,7 @@ find_package_handle_standard_args(${_module}
         REQUIRED_VARS GVC_INCLUDE_DIRS)
 
 if (${GVC_FOUND})
-    if (CMAKE_VERSION VERSION_LESS "3.6.0")
+    if (CMAKE_VERSION VERSION_LESS "3.11.0")
         add_library(${_module}::GVC INTERFACE IMPORTED)
         set_target_properties(${_module}::GVC PROPERTIES
                 INTERFACE_INCLUDE_DIRECTORIES "${GVC_INCLUDE_DIRS}")

--- a/src/cmake/FindRadare2.cmake
+++ b/src/cmake/FindRadare2.cmake
@@ -84,8 +84,17 @@ else()
 	mark_as_advanced(Radare2_CMAKE_PREFIX_PATH_TEMP)
 
 	if(TARGET PkgConfig::Radare2)
-		set_target_properties(PkgConfig::Radare2 PROPERTIES IMPORTED_GLOBAL ON)
-		add_library(Radare2::libr ALIAS PkgConfig::Radare2)
+		if (CMAKE_VERSION VERSION_LESS "3.11.0")
+			add_library(Radare2::libr INTERFACE IMPORTED)
+			set_target_properties(Radare2::libr PROPERTIES
+			    INTERFACE_INCLUDE_DIRECTORIES "${Radare2_INCLUDE_DIRS}")
+			set_target_properties(Radare2::libr PROPERTIES
+			    INTERFACE_LINK_LIBRARIES "${Radare2_LIBRARIES}")
+			link_directories("${Radare2_LIBDIR}") # target specific link directory or flags require even newer cmake
+		else()
+			set_target_properties(PkgConfig::Radare2 PROPERTIES IMPORTED_GLOBAL ON)
+			add_library(Radare2::libr ALIAS PkgConfig::Radare2)
+		endif()
 		set(Radare2_TARGET Radare2::libr)
 	else()
 		set(Radare2_TARGET Radare2_TARGET-NOTFOUND)


### PR DESCRIPTION
**Detailed description**

Improve compatibility with cmake 3.10 used by Ubuntu 18.04.

**Test plan (required)**

* On clean Ubuntu 18.04 VM install cutter dependencies, pkg-config, libgraphviz-dev
* compile r2 using `sys/user.sh`
* `cd src`
* `mkdir build`
* `cmake ..`
* `make`
* try analyzing `/bin/ls` - currently requires manually specifying LD_LIBRARY_PATH
* make sure existing builds in travis are not broken

**Closing issues**

<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
