### PR TITLE
Initial GitHub actions

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -14,6 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, ubuntu-16.04, macos-latest]
+        python-version: [3.7.5]
       # Prevent one job from pausing the rest
       fail-fast: false
     steps:
@@ -28,16 +29,6 @@ jobs:
       run: cd scripts; brew bundle
     - name: Pipenv for Github Actions
       uses: VaultVulp/action-pipenv@v1.0.0
-    # TODO: Only for linux and if isn't applied for some reason, use platform python for now - 
-    # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/software-installed-on-github-hosted-runners
-    #- name: Setup Python environment
-    #  if: contains(matrix.os, 'ubuntu')
-    #  uses: actions/setup-python@v1.1.1
-    #  with:
-    #    # Version range or exact version of a Python version to use, using semvers version range syntax.
-    #    python-version: 3.7.5
-    #    # The target architecture (x86, x64) of the Python interpreter.
-    #    architecture: x64
     - name: py dependencies
       run: |
         pip install meson

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -1,4 +1,4 @@
-name: Radare2 CI
+name: Cutter CI
 
 on:
   push:
@@ -13,16 +13,23 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-18.04, ubuntu-16.04]
     
     steps:
     - uses: actions/checkout@v1
     - name: apt dependencies
       run: sudo apt-get install ninja-build libgraphviz-dev qt5-default libqt5svg5-dev cmake
+    - name: Pipenv for Github Actions
+      uses: VaultVulp/action-pipenv@v1.0.0
+    - name: Setup Python environment
+      uses: actions/setup-python@v1.1.1
+      with:
+        # Version range or exact version of a Python version to use, using semvers version range syntax.
+        python-version: 3.5.2
+        # The target architecture (x86, x64) of the Python interpreter.
+        architecture: x64
     - name: py dependencies
       run: |
-        pyenv install 3.5.2
-        pyenv global 3.5.2
         pip install meson
     - name: cutter dependencies
       run: |

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-16.04]
+        os: [ubuntu-18.04, ubuntu-16.04, macos-latest, windows-latest]
     
     steps:
     - uses: actions/checkout@v1
@@ -33,15 +33,14 @@ jobs:
     - name: py dependencies
       run: |
         pip install meson
-    - name: cmake ${{ matrix.os }}
-      env:
-        run: |
-          scripts/fetch_deps.sh
-          source cutter-deps/env.sh
-          export LD_LIBRARY_PATH="`llvm-config --libdir`:$LD_LIBRARY_PATH"
-          source scripts/prepare_breakpad_linux.sh
-          export PKG_CONFIG_PATH="$CUSTOM_BREAKPAD_PREFIX/lib/pkgconfig:$CUSTOM_PYTHON_PREFIX/lib/pkgconfig:$PKG_CONFIG_PATH"
+    - name: cmake ubuntu
+      if: contains(matrix.os, "ubuntu")
       run: |
+        scripts/fetch_deps.sh
+        source cutter-deps/env.sh
+        export LD_LIBRARY_PATH="`llvm-config --libdir`:$LD_LIBRARY_PATH"
+        source scripts/prepare_breakpad_linux.sh
+        export PKG_CONFIG_PATH="$CUSTOM_BREAKPAD_PREFIX/lib/pkgconfig:$CUSTOM_PYTHON_PREFIX/lib/pkgconfig:$PKG_CONFIG_PATH"
         mkdir build
         cd build
         cmake \
@@ -54,4 +53,27 @@ jobs:
                 -DCUTTER_ENABLE_CRASH_REPORTS=ON \
                 -DCUTTER_USE_BUNDLED_RADARE2=ON \
                 ../src && \
-        make -j4
+            make -j4
+    - name: cmake macos
+      if: contains(matrix.os, "macos")
+      run: |
+        scripts/fetch_deps.sh
+        source cutter-deps/env.sh
+        export PATH=/usr/local/opt/llvm/bin:$PATH
+        source scripts/prepare_breakpad_macos.sh
+        sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target /
+        export PKG_CONFIG_PATH="$CUSTOM_BREAKPAD_PREFIX/lib/pkgconfig:$CUSTOM_PYTHON_PREFIX/lib/pkgconfig:$PKG_CONFIG_PATH"
+        mkdir build
+        cd build
+        cmake \
+                -DCMAKE_BUILD_TYPE=Release \
+                -DPYTHON_LIBRARY="$CUTTER_DEPS_PYTHON_PREFIX/lib/libpython3.6m.dylib" \
+                -DPYTHON_INCLUDE_DIR="$CUTTER_DEPS_PYTHON_PREFIX/include/python3.6m" \
+                -DPYTHON_EXECUTABLE="$CUTTER_DEPS_PYTHON_PREFIX/bin/python3" \
+                -DCUTTER_ENABLE_PYTHON=ON \
+                -DCUTTER_ENABLE_PYTHON_BINDINGS=ON \
+                -DCUTTER_ENABLE_CRASH_REPORTS=ON \
+                -DCUTTER_USE_BUNDLED_RADARE2=ON \
+                -DBREAKPAD_FRAMEWORK_DIR="$BREAKPAD_FRAMEWORK_DIR" \
+                ../src && \
+              make -j4;

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -30,8 +30,6 @@ jobs:
     - name: homebrew dependencies
       if: contains(matrix.os, 'macos')
       run: cd scripts; brew bundle
-    - name: Pipenv for Github Actions
-      uses: VaultVulp/action-pipenv@v1.0.0
     - name: py dependencies
       run: |
         pip install meson

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -25,7 +25,7 @@ jobs:
       uses: actions/setup-python@v1.1.1
       with:
         # Version range or exact version of a Python version to use, using semvers version range syntax.
-        python-version: 3.5.2
+        python-version: 3.5.7
         # The target architecture (x86, x64) of the Python interpreter.
         architecture: x64
     - name: py dependencies

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -20,7 +20,11 @@ jobs:
       with:
         submodules: true # 'recursive' 'true' or 'false'
     - name: apt dependencies
+      if: contains(matrix.os, 'ubuntu')
       run: sudo apt-get install ninja-build libgraphviz-dev
+    - name: homebrew dependencies
+      if: contains(matrix.os, 'macos')
+      run: brew bundle scripts/Brewfile
     - name: Pipenv for Github Actions
       uses: VaultVulp/action-pipenv@v1.0.0
     - name: Setup Python environment

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -1,0 +1,48 @@
+name: Radare2 CI
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    
+    steps:
+    - uses: actions/checkout@v1
+    - name: apt dependencies
+      run: sudo apt-get install ninja-build libgraphviz-dev qt5-default libqt5svg5-dev cmake
+    - name: py dependencies
+      run: |
+        pyenv install 3.5.2
+        pyenv global 3.5.2
+        pip install meson
+    - name: cutter dependencies
+      run: |
+        scripts/fetch_deps.sh
+        source cutter-deps/env.sh
+        export LD_LIBRARY_PATH="`llvm-config --libdir`:$LD_LIBRARY_PATH"
+        source scripts/prepare_breakpad_linux.sh
+    - name: cmake
+      run: |
+        mkdir build
+        cd build
+        export PKG_CONFIG_PATH="$CUSTOM_BREAKPAD_PREFIX/lib/pkgconfig:$CUSTOM_PYTHON_PREFIX/lib/pkgconfig:$PKG_CONFIG_PATH"
+        cmake
+                -DCMAKE_BUILD_TYPE=Release
+                -DPYTHON_LIBRARY="$CUTTER_DEPS_PYTHON_PREFIX/lib/libpython3.6m.so.1.0"
+                -DPYTHON_INCLUDE_DIR="$CUTTER_DEPS_PYTHON_PREFIX/include/python3.6m"
+                -DPYTHON_EXECUTABLE="$CUTTER_DEPS_PYTHON_PREFIX/bin/python3"
+                -DCUTTER_ENABLE_PYTHON=ON
+                -DCUTTER_ENABLE_PYTHON_BINDINGS=ON
+                -DCUTTER_ENABLE_CRASH_REPORTS=ON
+                -DCUTTER_USE_BUNDLED_RADARE2=ON
+                ../src &&
+        make -j4

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -27,7 +27,9 @@ jobs:
       run: brew bundle scripts/Brewfile
     - name: Pipenv for Github Actions
       uses: VaultVulp/action-pipenv@v1.0.0
+    # Use system provided python on other platforms
     - name: Setup Python environment
+      if: contains(matrix.os, 'ubuntu')
       uses: actions/setup-python@v1.1.1
       with:
         # Version range or exact version of a Python version to use, using semvers version range syntax.

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -14,7 +14,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, ubuntu-16.04, macos-latest, windows-latest]
-    
+      # Prevent one job from pausing the rest
+      fail-fast: false
     steps:
     - uses: actions/checkout@v1
       with:

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -25,7 +25,7 @@ jobs:
       uses: actions/setup-python@v1.1.1
       with:
         # Version range or exact version of a Python version to use, using semvers version range syntax.
-        python-version: 3.5.7
+        python-version: 3.6.9
         # The target architecture (x86, x64) of the Python interpreter.
         architecture: x64
     - name: py dependencies
@@ -42,14 +42,14 @@ jobs:
         mkdir build
         cd build
         export PKG_CONFIG_PATH="$CUSTOM_BREAKPAD_PREFIX/lib/pkgconfig:$CUSTOM_PYTHON_PREFIX/lib/pkgconfig:$PKG_CONFIG_PATH"
-        cmake
-                -DCMAKE_BUILD_TYPE=Release
-                -DPYTHON_LIBRARY="$CUTTER_DEPS_PYTHON_PREFIX/lib/libpython3.6m.so.1.0"
-                -DPYTHON_INCLUDE_DIR="$CUTTER_DEPS_PYTHON_PREFIX/include/python3.6m"
-                -DPYTHON_EXECUTABLE="$CUTTER_DEPS_PYTHON_PREFIX/bin/python3"
-                -DCUTTER_ENABLE_PYTHON=ON
-                -DCUTTER_ENABLE_PYTHON_BINDINGS=ON
-                -DCUTTER_ENABLE_CRASH_REPORTS=ON
-                -DCUTTER_USE_BUNDLED_RADARE2=ON
-                ../src &&
+        cmake \
+                -DCMAKE_BUILD_TYPE=Release \
+                -DPYTHON_LIBRARY="$CUTTER_DEPS_PYTHON_PREFIX/lib/libpython3.6m.so.1.0" \
+                -DPYTHON_INCLUDE_DIR="$CUTTER_DEPS_PYTHON_PREFIX/include/python3.6m" \
+                -DPYTHON_EXECUTABLE="$CUTTER_DEPS_PYTHON_PREFIX/bin/python3" \
+                -DCUTTER_ENABLE_PYTHON=ON \
+                -DCUTTER_ENABLE_PYTHON_BINDINGS=ON \
+                -DCUTTER_ENABLE_CRASH_REPORTS=ON \
+                -DCUTTER_USE_BUNDLED_RADARE2=ON \
+                ../src && \
         make -j4

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -54,7 +54,7 @@ jobs:
                 -DPYTHON_INCLUDE_DIR="$CUTTER_DEPS_PYTHON_PREFIX/include/python3.6m" \
                 -DPYTHON_EXECUTABLE="$CUTTER_DEPS_PYTHON_PREFIX/bin/python3" \
                 -DCUTTER_ENABLE_PYTHON=ON \
-                -DCUTTER_ENABLE_PYTHON_BINDINGS=ON \
+                -DCUTTER_ENABLE_PYTHON_BINDINGS=OFF \
                 -DCUTTER_ENABLE_CRASH_REPORTS=ON \
                 -DCUTTER_USE_BUNDLED_RADARE2=ON \
                 ../src && \
@@ -76,7 +76,7 @@ jobs:
                 -DPYTHON_INCLUDE_DIR="$CUTTER_DEPS_PYTHON_PREFIX/include/python3.6m" \
                 -DPYTHON_EXECUTABLE="$CUTTER_DEPS_PYTHON_PREFIX/bin/python3" \
                 -DCUTTER_ENABLE_PYTHON=ON \
-                -DCUTTER_ENABLE_PYTHON_BINDINGS=OFF \
+                -DCUTTER_ENABLE_PYTHON_BINDINGS=ON \
                 -DCUTTER_ENABLE_CRASH_REPORTS=ON \
                 -DCUTTER_USE_BUNDLED_RADARE2=ON \
                 -DBREAKPAD_FRAMEWORK_DIR="$BREAKPAD_FRAMEWORK_DIR" \

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -34,6 +34,7 @@ jobs:
         brew bundle
         brew tap iveney/mocha
         brew install realpath
+        brew install pkg-config
     - name: py dependencies
       run: |
         pip install meson

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -33,16 +33,17 @@ jobs:
     - name: py dependencies
       run: |
         pip install meson
-    - env: |
-        scripts/fetch_deps.sh
-        source cutter-deps/env.sh
-        export LD_LIBRARY_PATH="`llvm-config --libdir`:$LD_LIBRARY_PATH"
-        source scripts/prepare_breakpad_linux.sh
-    - name: cmake
+    - name: cmake ${{ matrix.os }}
+      env:
+        run: |
+          scripts/fetch_deps.sh
+          source cutter-deps/env.sh
+          export LD_LIBRARY_PATH="`llvm-config --libdir`:$LD_LIBRARY_PATH"
+          source scripts/prepare_breakpad_linux.sh
+          export PKG_CONFIG_PATH="$CUSTOM_BREAKPAD_PREFIX/lib/pkgconfig:$CUSTOM_PYTHON_PREFIX/lib/pkgconfig:$PKG_CONFIG_PATH"
       run: |
         mkdir build
         cd build
-        export PKG_CONFIG_PATH="$CUSTOM_BREAKPAD_PREFIX/lib/pkgconfig:$CUSTOM_PYTHON_PREFIX/lib/pkgconfig:$PKG_CONFIG_PATH"
         cmake \
                 -DCMAKE_BUILD_TYPE=Release \
                 -DPYTHON_LIBRARY="$CUTTER_DEPS_PYTHON_PREFIX/lib/libpython3.6m.so.1.0" \

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -25,7 +25,7 @@ jobs:
       run: sudo apt-get install ninja-build libgraphviz-dev
     - name: homebrew dependencies
       if: contains(matrix.os, 'macos')
-      run: brew bundle --brewfile=scripts/Brewfile
+      run: brew bundle --brewfile=./scripts/Brewfile
     - name: Pipenv for Github Actions
       uses: VaultVulp/action-pipenv@v1.0.0
     # Use system provided python on other platforms

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -26,7 +26,7 @@ jobs:
         submodules: true # 'recursive' 'true' or 'false'
     - name: apt dependencies
       if: contains(matrix.os, 'ubuntu')
-      run: sudo apt-get install ninja-build libgraphviz-dev
+      run: sudo apt-get install ninja-build libgraphviz-dev libclang-7-dev
     - name: homebrew dependencies
       if: contains(matrix.os, 'macos')
       run: cd scripts; brew bundle
@@ -55,6 +55,7 @@ jobs:
                 ../src && \
             make -j4
     - name: cmake macos
+      shell: bash
       if: contains(matrix.os, 'macos')
       run: |
         scripts/fetch_deps.sh

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-16.04, macos-latest, windows-latest]
+        os: [ubuntu-18.04, ubuntu-16.04, macos-latest]
       # Prevent one job from pausing the rest
       fail-fast: false
     steps:
@@ -28,15 +28,16 @@ jobs:
       run: cd scripts; brew bundle
     - name: Pipenv for Github Actions
       uses: VaultVulp/action-pipenv@v1.0.0
-    # Use system provided python on other platforms
-    - name: Setup Python environment
-      if: contains(matrix.os, 'ubuntu')
-      uses: actions/setup-python@v1.1.1
-      with:
-        # Version range or exact version of a Python version to use, using semvers version range syntax.
-        python-version: 3.7.5
-        # The target architecture (x86, x64) of the Python interpreter.
-        architecture: x64
+    # TODO: Only for linux and if isn't applied for some reason, use platform python for now - 
+    # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/software-installed-on-github-hosted-runners
+    #- name: Setup Python environment
+    #  if: contains(matrix.os, 'ubuntu')
+    #  uses: actions/setup-python@v1.1.1
+    #  with:
+    #    # Version range or exact version of a Python version to use, using semvers version range syntax.
+    #    python-version: 3.7.5
+    #    # The target architecture (x86, x64) of the Python interpreter.
+    #    architecture: x64
     - name: py dependencies
       run: |
         pip install meson

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -29,7 +29,10 @@ jobs:
       run: sudo apt-get install ninja-build libgraphviz-dev llvm-7 llvm-7-dev libclang-7-dev
     - name: homebrew dependencies
       if: contains(matrix.os, 'macos')
-      run: cd scripts; brew bundle
+      run: |
+        cd scripts
+        brew bundle
+        brew install realpath
     - name: py dependencies
       run: |
         pip install meson

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -26,7 +26,7 @@ jobs:
         submodules: true # 'recursive' 'true' or 'false'
     - name: apt dependencies
       if: contains(matrix.os, 'ubuntu')
-      run: sudo apt-get install ninja-build libgraphviz-dev libclang-7-dev
+      run: sudo apt-get install ninja-build libgraphviz-dev llvm-7 llvm-7-dev libclang-7-dev
     - name: homebrew dependencies
       if: contains(matrix.os, 'macos')
       run: cd scripts; brew bundle

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -25,7 +25,7 @@ jobs:
       run: sudo apt-get install ninja-build libgraphviz-dev
     - name: homebrew dependencies
       if: contains(matrix.os, 'macos')
-      run: brew bundle --brewfile=./scripts/Brewfile
+      run: cd scripts; brew bundle
     - name: Pipenv for Github Actions
       uses: VaultVulp/action-pipenv@v1.0.0
     # Use system provided python on other platforms

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -24,7 +24,7 @@ jobs:
       run: sudo apt-get install ninja-build libgraphviz-dev
     - name: homebrew dependencies
       if: contains(matrix.os, 'macos')
-      run: brew bundle scripts/Brewfile
+      run: brew bundle --brewfile=scripts/Brewfile
     - name: Pipenv for Github Actions
       uses: VaultVulp/action-pipenv@v1.0.0
     # Use system provided python on other platforms

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -34,7 +34,7 @@ jobs:
       run: |
         pip install meson
     - name: cmake ubuntu
-      if: contains(matrix.os, "ubuntu")
+      if: contains(matrix.os, 'ubuntu')
       run: |
         scripts/fetch_deps.sh
         source cutter-deps/env.sh
@@ -55,7 +55,7 @@ jobs:
                 ../src && \
             make -j4
     - name: cmake macos
-      if: contains(matrix.os, "macos")
+      if: contains(matrix.os, 'macos')
       run: |
         scripts/fetch_deps.sh
         source cutter-deps/env.sh

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -17,6 +17,8 @@ jobs:
     
     steps:
     - uses: actions/checkout@v1
+      with:
+        submodules: true # 'recursive' 'true' or 'false'
     - name: apt dependencies
       run: sudo apt-get install ninja-build libgraphviz-dev qt5-default libqt5svg5-dev cmake
     - name: Pipenv for Github Actions
@@ -48,7 +50,7 @@ jobs:
                 -DPYTHON_INCLUDE_DIR="$CUTTER_DEPS_PYTHON_PREFIX/include/python3.6m" \
                 -DPYTHON_EXECUTABLE="$CUTTER_DEPS_PYTHON_PREFIX/bin/python3" \
                 -DCUTTER_ENABLE_PYTHON=ON \
-                -DCUTTER_ENABLE_PYTHON_BINDINGS=ON \
+                -DCUTTER_ENABLE_PYTHON_BINDINGS=OFF \
                 -DCUTTER_ENABLE_CRASH_REPORTS=ON \
                 -DCUTTER_USE_BUNDLED_RADARE2=ON \
                 ../src && \

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -32,6 +32,7 @@ jobs:
       run: |
         cd scripts
         brew bundle
+        brew tap iveney/mocha
         brew install realpath
     - name: py dependencies
       run: |

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -33,18 +33,13 @@ jobs:
     - name: py dependencies
       run: |
         pip install meson
-    #- name: cutter dependencies
-    #  run: |
-#       scripts/fetch_deps.sh
-#       source cutter-deps/env.sh
-#       export LD_LIBRARY_PATH="`llvm-config --libdir`:$LD_LIBRARY_PATH"
-#       source scripts/prepare_breakpad_linux.sh
-    - name: cmake
-      run: |
+    - env: |
         scripts/fetch_deps.sh
         source cutter-deps/env.sh
         export LD_LIBRARY_PATH="`llvm-config --libdir`:$LD_LIBRARY_PATH"
         source scripts/prepare_breakpad_linux.sh
+    - name: cmake
+      run: |
         mkdir build
         cd build
         export PKG_CONFIG_PATH="$CUSTOM_BREAKPAD_PREFIX/lib/pkgconfig:$CUSTOM_PYTHON_PREFIX/lib/pkgconfig:$PKG_CONFIG_PATH"
@@ -54,7 +49,7 @@ jobs:
                 -DPYTHON_INCLUDE_DIR="$CUTTER_DEPS_PYTHON_PREFIX/include/python3.6m" \
                 -DPYTHON_EXECUTABLE="$CUTTER_DEPS_PYTHON_PREFIX/bin/python3" \
                 -DCUTTER_ENABLE_PYTHON=ON \
-                -DCUTTER_ENABLE_PYTHON_BINDINGS=OFF \
+                -DCUTTER_ENABLE_PYTHON_BINDINGS=ON \
                 -DCUTTER_ENABLE_CRASH_REPORTS=ON \
                 -DCUTTER_USE_BUNDLED_RADARE2=ON \
                 ../src && \

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -66,7 +66,6 @@ jobs:
         source cutter-deps/env.sh
         export PATH=/usr/local/opt/llvm/bin:$PATH
         source scripts/prepare_breakpad_macos.sh
-        sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target /
         export PKG_CONFIG_PATH="$CUSTOM_BREAKPAD_PREFIX/lib/pkgconfig:$CUSTOM_PYTHON_PREFIX/lib/pkgconfig:$PKG_CONFIG_PATH"
         mkdir build
         cd build

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -26,7 +26,7 @@ jobs:
         submodules: true # 'recursive' 'true' or 'false'
     - name: apt dependencies
       if: contains(matrix.os, 'ubuntu')
-      run: sudo apt-get install ninja-build libgraphviz-dev llvm-7 llvm-7-dev libclang-7-dev
+      run: sudo apt-get install ninja-build libgraphviz-dev
     - name: homebrew dependencies
       if: contains(matrix.os, 'macos')
       run: |
@@ -76,7 +76,7 @@ jobs:
                 -DPYTHON_INCLUDE_DIR="$CUTTER_DEPS_PYTHON_PREFIX/include/python3.6m" \
                 -DPYTHON_EXECUTABLE="$CUTTER_DEPS_PYTHON_PREFIX/bin/python3" \
                 -DCUTTER_ENABLE_PYTHON=ON \
-                -DCUTTER_ENABLE_PYTHON_BINDINGS=ON \
+                -DCUTTER_ENABLE_PYTHON_BINDINGS=OFF \
                 -DCUTTER_ENABLE_CRASH_REPORTS=ON \
                 -DCUTTER_USE_BUNDLED_RADARE2=ON \
                 -DBREAKPAD_FRAMEWORK_DIR="$BREAKPAD_FRAMEWORK_DIR" \

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -20,27 +20,31 @@ jobs:
       with:
         submodules: true # 'recursive' 'true' or 'false'
     - name: apt dependencies
-      run: sudo apt-get install ninja-build libgraphviz-dev qt5-default libqt5svg5-dev cmake
+      run: sudo apt-get install ninja-build libgraphviz-dev
     - name: Pipenv for Github Actions
       uses: VaultVulp/action-pipenv@v1.0.0
     - name: Setup Python environment
       uses: actions/setup-python@v1.1.1
       with:
         # Version range or exact version of a Python version to use, using semvers version range syntax.
-        python-version: 3.6.9
+        python-version: 3.7.5
         # The target architecture (x86, x64) of the Python interpreter.
         architecture: x64
     - name: py dependencies
       run: |
         pip install meson
-    - name: cutter dependencies
+    #- name: cutter dependencies
+    #  run: |
+#       scripts/fetch_deps.sh
+#       source cutter-deps/env.sh
+#       export LD_LIBRARY_PATH="`llvm-config --libdir`:$LD_LIBRARY_PATH"
+#       source scripts/prepare_breakpad_linux.sh
+    - name: cmake
       run: |
         scripts/fetch_deps.sh
         source cutter-deps/env.sh
         export LD_LIBRARY_PATH="`llvm-config --libdir`:$LD_LIBRARY_PATH"
         source scripts/prepare_breakpad_linux.sh
-    - name: cmake
-      run: |
         mkdir build
         cd build
         export PKG_CONFIG_PATH="$CUSTOM_BREAKPAD_PREFIX/lib/pkgconfig:$CUSTOM_PYTHON_PREFIX/lib/pkgconfig:$PKG_CONFIG_PATH"

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -18,6 +18,9 @@ jobs:
       # Prevent one job from pausing the rest
       fail-fast: false
     steps:
+    - uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
     - uses: actions/checkout@v1
       with:
         submodules: true # 'recursive' 'true' or 'false'


### PR DESCRIPTION
You can see it live in a [PR on my fork](https://github.com/yossizap/cutter/pull/1) or my [actions](https://github.com/yossizap/cutter/actions).

- Ubuntu fails to build with Shiboken (now disabled) - can't find libclang-7 even though it's installed with apt. Ideas? Also, apt llvm-7/clang-7 isn't available in ubuntu 16.04 so we could manually build+install it. [Failed build here](https://github.com/yossizap/cutter/commit/c08568aad3c2566c2a1a408b5da5a613adf3a8e6/checks?check_suite_id=328183690)
- I'll leave windows support to someone else since the appveyor yml isn't straightforward. 

Docs:
https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions
https://help.github.com/en/actions/automating-your-workflow-with-github-actions/contexts-and-expression-syntax-for-github-actions
https://help.github.com/en/actions/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions
https://help.github.com/en/actions/automating-your-workflow-with-github-actions/software-installed-on-github-hosted-runners