### PR TITLE
Add menus to seek backward and forward buttons.

### DIFF
--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -1031,11 +1031,11 @@ void MainWindow::updateHistoryMenu(QMenu *menu, bool redo)
         if (current) {
             history = false;
         }
-        if (history != redo || current) { // Includ current in both directions
+        if (history != redo || current) { // Include current in both directions
             QString addressString = RAddressString(offset);
             QString label = QString("%1 (%2)").arg(name, addressString);
             if (current) {
-                label += " current";
+                label = QString("current position (%1)").arg(addressString);
             }
             QAction *action = new QAction(label, menu);
             actions.push_back(action);

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -1020,6 +1020,8 @@ void MainWindow::initBackForwardMenu()
 
 void MainWindow::updateHistoryMenu(QMenu *menu, bool redo)
 {
+    static const int MAX_MENU_ENTRIES = 32;
+
     auto hist = Core()->cmdj("sj");
     bool history = true;
     QList<QAction *> actions;
@@ -1047,6 +1049,11 @@ void MainWindow::updateHistoryMenu(QMenu *menu, bool redo)
     }
     if (!redo) {
         std::reverse(actions.begin(), actions.end());
+    }
+    while (actions.length() > MAX_MENU_ENTRIES) {
+        auto action = actions.back();
+        actions.pop_back();
+        action->deleteLater();
     }
     menu->clear();
     menu->addActions(actions);

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -1007,6 +1007,8 @@ void MainWindow::initBackForwardMenu()
         QFontMetrics metrics(fontMetrics());
         // Roughly 10-16 lines depending on padding size, no need to calculate more precisely
         menu->setMaximumHeight(metrics.lineSpacing() * 20);
+
+        menu->setToolTipsVisible(true);
         return menu;
     };
 
@@ -1026,6 +1028,10 @@ void MainWindow::initBackForwardMenu()
 
 void MainWindow::updateHistoryMenu(QMenu *menu, bool redo)
 {
+    // Not too long so that whole screen doesn't get covered,
+    // not too short so that reasonable length c++ names can be seen most of the time
+    const int MAX_NAME_LENGTH = 64;
+
     auto hist = Core()->cmdj("sj");
     bool history = true;
     QList<QAction *> actions;
@@ -1039,13 +1045,17 @@ void MainWindow::updateHistoryMenu(QMenu *menu, bool redo)
         }
         if (history != redo || current) { // Include current in both directions
             QString addressString = RAddressString(offset);
+
+            QString toolTip = QString("%1 %2").arg(addressString, name); // show non truncated name in tooltip
+
+            name.truncate(MAX_NAME_LENGTH); // TODO:#1904 use common name shortening function
             QString label = QString("%1 (%2)").arg(name, addressString);
             if (current) {
                 label = QString("current position (%1)").arg(addressString);
             }
             QAction *action = new QAction(label, menu);
+            action->setToolTip(toolTip);
             actions.push_back(action);
-            action->setToolTip(addressString);
             if (current) {
                 QFont font;
                 font.setBold(true);

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -1003,15 +1003,21 @@ void MainWindow::initBackForwardMenu()
                 [menu, button] (const QPoint &pos) {
             menu->exec(button->mapToGlobal(pos));
         });
+
+        QFontMetrics metrics(fontMetrics());
+        // Roughly 10-16 lines depending on padding size, no need to calculate more precisely
+        menu->setMaximumHeight(metrics.lineSpacing() * 20);
         return menu;
     };
 
     if (auto menu = prepareButtonMenu(ui->actionBackward)) {
+        menu->setObjectName("historyMenu");
         connect(menu, &QMenu::aboutToShow, menu, [this, menu]() {
             updateHistoryMenu(menu, false);
         });
     }
     if (auto menu = prepareButtonMenu(ui->actionForward)) {
+        menu->setObjectName("forwardHistoryMenu");
         connect(menu, &QMenu::aboutToShow, menu, [this, menu]() {
             updateHistoryMenu(menu, true);
         });
@@ -1020,8 +1026,6 @@ void MainWindow::initBackForwardMenu()
 
 void MainWindow::updateHistoryMenu(QMenu *menu, bool redo)
 {
-    static const int MAX_MENU_ENTRIES = 32;
-
     auto hist = Core()->cmdj("sj");
     bool history = true;
     QList<QAction *> actions;
@@ -1043,17 +1047,14 @@ void MainWindow::updateHistoryMenu(QMenu *menu, bool redo)
             actions.push_back(action);
             action->setToolTip(addressString);
             if (current) {
-                action->setEnabled(false);
+                QFont font;
+                font.setBold(true);
+                action->setFont(font);
             }
         }
     }
     if (!redo) {
         std::reverse(actions.begin(), actions.end());
-    }
-    while (actions.length() > MAX_MENU_ENTRIES) {
-        auto action = actions.back();
-        actions.pop_back();
-        action->deleteLater();
     }
     menu->clear();
     menu->addActions(actions);

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -261,6 +261,7 @@ private:
     void initDocks();
     void initLayout();
     void initCorners();
+    void initBackForwardMenu();
     void displayInitialOptionsDialog(const InitialOptions &options = InitialOptions(), bool skipOptionsDialog = false);
 
     void resetToDefaultLayout();
@@ -274,6 +275,12 @@ private:
     void showZenDocks();
     void showDebugDocks();
     void enableDebugWidgetsMenu(bool enable);
+    /**
+     * @brief Fill menu with seek history entries.
+     * @param menu
+     * @param redo set to false for undo history, true for redo.
+     */
+    void updateHistoryMenu(QMenu *menu, bool redo = false);
 
     void toggleDockWidget(QDockWidget *dock_widget, bool show);
 

--- a/src/themes/lightstyle/light.qss
+++ b/src/themes/lightstyle/light.qss
@@ -755,3 +755,6 @@ QLineEdit, QLineEdit[text=""] {
   color: #00304d;
 }
 
+QMenu#historyMenu, QMenu#forwardHistoryMenu {
+    menu-scrollable: true;
+}

--- a/src/themes/lightstyle/light.qss
+++ b/src/themes/lightstyle/light.qss
@@ -397,7 +397,7 @@ QToolButton::menu-button {
 QToolButton::menu-indicator
 {
   image:url(:/qss_icons/rc/down_arrow.png);
-  top:-7px;
+  top:-2px;
   left:-2px;
 }
 

--- a/src/themes/native/native.qss
+++ b/src/themes/native/native.qss
@@ -24,3 +24,7 @@ CutterTreeView::item
    padding-top: 1px;
    padding-bottom: 1px;
 }
+
+QMenu#historyMenu, QMenu#forwardHistoryMenu {
+    menu-scrollable: true;
+}

--- a/src/themes/qdarkstyle/style.qss
+++ b/src/themes/qdarkstyle/style.qss
@@ -1010,7 +1010,7 @@ QToolButton::menu-button:pressed {
 
 QToolButton::menu-indicator {
     image: url(:/qss_icons/rc/down_arrow.png);
-    top: -7px;
+    top: -2px;
     left: -2px;
     /* shift it a bit */
 }

--- a/src/themes/qdarkstyle/style.qss
+++ b/src/themes/qdarkstyle/style.qss
@@ -1223,3 +1223,7 @@ QDateEdit::down-arrow:hover,
 QDateEdit::down-arrow:focus {
     image: url(:/qss_icons/rc/down_arrow.png);
 }
+
+QMenu#historyMenu, QMenu#forwardHistoryMenu {
+    menu-scrollable: true;
+}


### PR DESCRIPTION
 <!-- Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request. -->


**Detailed description**

<!-- Explain the **details** for making this change. What existing problem does the pull request solve? Please provide enough information so that others can review your pull request -->


**Test plan (required)**

* Test what happens with large amount of history items
* Make sure that long press and right click opens menu
* Test that jumping > 1 step works
* Test jump target in forward and backward direction matches label
![native](https://user-images.githubusercontent.com/7101031/69677428-9eecea00-10ab-11ea-953c-63b92064db90.png)



<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
![light](https://user-images.githubusercontent.com/7101031/69677440-a3b19e00-10ab-11ea-9c7b-5cfbfb2c022a.png)
![dark](https://user-images.githubusercontent.com/7101031/69677448-a6ac8e80-10ab-11ea-885d-c123a3898050.png)

<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**

Closes #1617
<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
