### PR TITLE
Add processes widget for kernel and child debugging

### DIFF
--- a/src/Cutter.pro
+++ b/src/Cutter.pro
@@ -331,6 +331,7 @@ SOURCES += \
     widgets/StackWidget.cpp \
     widgets/RegistersWidget.cpp \
     widgets/ThreadsWidget.cpp \
+    widgets/ProcessesWidget.cpp \
     widgets/BacktraceWidget.cpp \
     dialogs/OpenFileDialog.cpp \
     common/CommandTask.cpp \
@@ -464,6 +465,7 @@ HEADERS  += \
     widgets/StackWidget.h \
     widgets/RegistersWidget.h \
     widgets/ThreadsWidget.h \
+    widgets/ProcessesWidget.h \
     widgets/BacktraceWidget.h \
     dialogs/OpenFileDialog.h \
     common/StringsTask.h \
@@ -561,6 +563,7 @@ FORMS    += \
     widgets/StackWidget.ui \
     widgets/RegistersWidget.ui \
     widgets/ThreadsWidget.ui \
+    widgets/ProcessesWidget.ui \
     widgets/BacktraceWidget.ui \
     dialogs/OpenFileDialog.ui \
     dialogs/preferences/DebugOptionsWidget.ui \

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1191,6 +1191,7 @@ void CutterCore::setCurrentDebugThread(int tid)
             emit refreshCodeViews();
             emit stackChanged();
             syncAndSeekProgramCounter();
+            emit switchedThread();
             emit debugTaskStateChanged();
         });
     }
@@ -1213,6 +1214,7 @@ void CutterCore::setCurrentDebugProcess(int pid)
             emit stackChanged();
             emit flagsChanged();
             syncAndSeekProgramCounter();
+            emit switchedProcess();
             emit debugTaskStateChanged();
         });
     }

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -259,6 +259,10 @@ public:
     RVA getProgramCounterValue();
     void setRegister(QString regName, QString regValue);
     void setCurrentDebugThread(int tid);
+    /**
+     * @brief Attach to a given pid from a debug session
+     */
+    void setCurrentDebugProcess(int pid);
     QJsonDocument getStack(int size = 0x100);
     /**
      * @brief Get a list of a given process's threads
@@ -266,6 +270,12 @@ public:
      * @return JSON object result of dptj
      */
     QJsonDocument getProcessThreads(int pid);
+    /**
+     * @brief Get a list of a given process's child processes
+     * @param pid The pid of the process, -1 for the currently debugged process
+     * @return JSON object result of dptj
+     */
+    QJsonDocument getChildProcesses(int pid);
     QJsonDocument getBacktrace();
     void startDebug();
     void startEmulation();

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -486,6 +486,9 @@ signals:
     void refreshCodeViews();
     void stackChanged();
 
+    void switchedThread();
+    void switchedProcess();
+
     void classNew(const QString &cls);
     void classDeleted(const QString &cls);
     void classRenamed(const QString &oldName, const QString &newName);

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -62,6 +62,7 @@
 #include "widgets/DisassemblyWidget.h"
 #include "widgets/StackWidget.h"
 #include "widgets/ThreadsWidget.h"
+#include "widgets/ProcessesWidget.h"
 #include "widgets/RegistersWidget.h"
 #include "widgets/BacktraceWidget.h"
 #include "widgets/HexdumpWidget.h"
@@ -314,6 +315,7 @@ void MainWindow::initDocks()
     flagsDock = new FlagsWidget(this, ui->actionFlags);
     stackDock = new StackWidget(this, ui->actionStack);
     threadsDock = new ThreadsWidget(this, ui->actionThreads);
+    processesDock = new ProcessesWidget(this, ui->actionProcesses);
     backtraceDock = new BacktraceWidget(this, ui->actionBacktrace);
     registersDock = new RegistersWidget(this, ui->actionRegisters);
     memoryMapDock = new MemoryMapWidget(this, ui->actionMemoryMap);
@@ -837,6 +839,7 @@ void MainWindow::restoreDocks()
     splitDockWidget(stackDock, registersDock, Qt::Vertical);
     tabifyDockWidget(stackDock, backtraceDock);
     tabifyDockWidget(backtraceDock, threadsDock);
+    tabifyDockWidget(threadsDock, processesDock);
 
     updateDockActionsChecked();
 }

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -250,6 +250,7 @@ private:
     QDockWidget        *calcDock = nullptr;
     QDockWidget        *stackDock = nullptr;
     QDockWidget        *threadsDock = nullptr;
+    QDockWidget        *processesDock = nullptr;
     QDockWidget        *registersDock = nullptr;
     QDockWidget        *backtraceDock = nullptr;
     QDockWidget        *memoryMapDock = nullptr;

--- a/src/core/MainWindow.ui
+++ b/src/core/MainWindow.ui
@@ -153,6 +153,7 @@
      <addaction name="actionBacktrace"/>
      <addaction name="actionBreakpoint"/>
      <addaction name="actionThreads"/>
+     <addaction name="actionProcesses"/>
      <addaction name="actionMemoryMap"/>
      <addaction name="actionRegisters"/>
      <addaction name="actionRegisterRefs"/>
@@ -939,6 +940,14 @@
    </property>
    <property name="text">
     <string>Threads</string>
+   </property>
+  </action>
+  <action name="actionProcesses">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Processes</string>
    </property>
   </action>
   <action name="actionMemoryMap">

--- a/src/widgets/ProcessesWidget.cpp
+++ b/src/widgets/ProcessesWidget.cpp
@@ -58,6 +58,8 @@ ProcessesWidget::ProcessesWidget(MainWindow *main, QAction *action) :
             &ProcessesFilterModel::setFilterWildcard);
     connect(Core(), &CutterCore::refreshAll, this, &ProcessesWidget::updateContents);
     connect(Core(), &CutterCore::seekChanged, this, &ProcessesWidget::updateContents);
+    // Seek doesn't necessarily change when switching processes
+    connect(Core(), &CutterCore::switchedProcess, this, &ProcessesWidget::updateContents);
     connect(Config(), &Configuration::fontsUpdated, this, &ProcessesWidget::fontsUpdatedSlot);
     connect(ui->viewProcesses, &QTableView::activated, this, &ProcessesWidget::onActivated);
 }
@@ -93,7 +95,6 @@ QString ProcessesWidget::translateStatus(QString status)
     case R_DBG_PROC_RAISED:
         return "Raised event";
     default:
-        printf("Status: %s\n", status.toStdString().c_str());
         return "Unknown status";
     }
 }

--- a/src/widgets/ProcessesWidget.cpp
+++ b/src/widgets/ProcessesWidget.cpp
@@ -58,6 +58,7 @@ ProcessesWidget::ProcessesWidget(MainWindow *main, QAction *action) :
             &ProcessesFilterModel::setFilterWildcard);
     connect(Core(), &CutterCore::refreshAll, this, &ProcessesWidget::updateContents);
     connect(Core(), &CutterCore::seekChanged, this, &ProcessesWidget::updateContents);
+    connect(Core(), &CutterCore::debugTaskStateChanged, this, &ProcessesWidget::updateContents);
     // Seek doesn't necessarily change when switching processes
     connect(Core(), &CutterCore::switchedProcess, this, &ProcessesWidget::updateContents);
     connect(Config(), &Configuration::fontsUpdated, this, &ProcessesWidget::fontsUpdatedSlot);
@@ -72,10 +73,17 @@ void ProcessesWidget::updateContents()
         return;
     }
 
-    setProcessesGrid();
+    if (Core()->currentlyDebugging) {
+        setProcessesGrid();
+    } else {
+        // Remove rows from the previous debugging session
+        modelProcesses->removeRows(0, modelProcesses->rowCount());
+    }
 
     if (Core()->isDebugTaskInProgress() || !Core()->currentlyDebugging) {
-        ui->viewProcesses->setSelectionMode(QAbstractItemView::NoSelection);
+        ui->viewProcesses->setDisabled(true);
+    } else {
+        ui->viewProcesses->setDisabled(false);
     }
 }
 

--- a/src/widgets/ProcessesWidget.cpp
+++ b/src/widgets/ProcessesWidget.cpp
@@ -151,7 +151,7 @@ void ProcessesWidget::onActivated(const QModelIndex &index)
     for (QJsonValue value : processesValues) {
         QString status = value.toObject()["status"].toString();
         if (pid == value.toObject()["pid"].toInt()) {
-            if (R_DBG_PROC_ZOMBIE == status || R_DBG_PROC_DEAD == status) {
+            if ((char)R_DBG_PROC_ZOMBIE == status || (char)R_DBG_PROC_DEAD == status) {
                 QMessageBox msgBox;
                 msgBox.setText(tr("Unable to switch to the requested process."));
                 msgBox.exec();

--- a/src/widgets/ProcessesWidget.cpp
+++ b/src/widgets/ProcessesWidget.cpp
@@ -160,7 +160,7 @@ void ProcessesWidget::onActivated(const QModelIndex &index)
     for (QJsonValue value : processesValues) {
         QString status = value.toObject()["status"].toString();
         if (pid == value.toObject()["pid"].toInt()) {
-            if ((char)R_DBG_PROC_ZOMBIE == status || (char)R_DBG_PROC_DEAD == status) {
+            if (QString(R_DBG_PROC_ZOMBIE) == status || QString(R_DBG_PROC_DEAD) == status) {
                 QMessageBox msgBox;
                 msgBox.setText(tr("Unable to switch to the requested process."));
                 msgBox.exec();

--- a/src/widgets/ProcessesWidget.cpp
+++ b/src/widgets/ProcessesWidget.cpp
@@ -1,0 +1,186 @@
+#include <QShortcut>
+#include "ProcessesWidget.h"
+#include "ui_ProcessesWidget.h"
+#include "common/JsonModel.h"
+#include "QuickFilterView.h"
+#include <r_debug.h>
+
+#include "core/MainWindow.h"
+
+#define DEBUGGED_PID (-1)
+
+enum ColumnIndex {
+    COLUMN_CURRENT = 0,
+    COLUMN_PID,
+    COLUMN_UID,
+    COLUMN_STATUS,
+    COLUMN_PATH,
+};
+
+ProcessesWidget::ProcessesWidget(MainWindow *main, QAction *action) :
+    CutterDockWidget(main, action),
+    ui(new Ui::ProcessesWidget)
+{
+    ui->setupUi(this);
+
+    // Setup processes model
+    modelProcesses = new QStandardItemModel(1, 5, this);
+    modelProcesses->setHorizontalHeaderItem(COLUMN_CURRENT, new QStandardItem(tr("Current")));
+    modelProcesses->setHorizontalHeaderItem(COLUMN_UID, new QStandardItem(tr("UID")));
+    modelProcesses->setHorizontalHeaderItem(COLUMN_PID, new QStandardItem(tr("PID")));
+    modelProcesses->setHorizontalHeaderItem(COLUMN_STATUS, new QStandardItem(tr("Status")));
+    modelProcesses->setHorizontalHeaderItem(COLUMN_PATH, new QStandardItem(tr("Path")));
+    ui->viewProcesses->horizontalHeader()->setDefaultAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+    ui->viewProcesses->setFont(Config()->getFont());
+
+    modelFilter = new ProcessesFilterModel(this);
+    modelFilter->setSourceModel(modelProcesses);
+    ui->viewProcesses->setModel(modelFilter);
+
+    // CTRL+F switches to the filter view and opens it in case it's hidden
+    QShortcut *searchShortcut = new QShortcut(QKeySequence::Find, this);
+    connect(searchShortcut, &QShortcut::activated, ui->quickFilterView, &QuickFilterView::showFilter);
+    searchShortcut->setContext(Qt::WidgetWithChildrenShortcut);
+
+    // ESC switches back to the processes table and clears the buffer
+    QShortcut *clearShortcut = new QShortcut(QKeySequence(Qt::Key_Escape), this);
+    connect(clearShortcut, &QShortcut::activated, this, [this]() {
+        ui->quickFilterView->clearFilter();
+        ui->viewProcesses->setFocus();
+    });
+    clearShortcut->setContext(Qt::WidgetWithChildrenShortcut);
+
+    refreshDeferrer = createRefreshDeferrer([this]() {
+        updateContents();
+    });
+
+    connect(ui->quickFilterView, &QuickFilterView::filterTextChanged, modelFilter,
+            &ProcessesFilterModel::setFilterWildcard);
+    connect(Core(), &CutterCore::refreshAll, this, &ProcessesWidget::updateContents);
+    connect(Core(), &CutterCore::seekChanged, this, &ProcessesWidget::updateContents);
+    connect(Config(), &Configuration::fontsUpdated, this, &ProcessesWidget::fontsUpdatedSlot);
+    connect(ui->viewProcesses, &QTableView::activated, this, &ProcessesWidget::onActivated);
+}
+
+ProcessesWidget::~ProcessesWidget() {}
+
+void ProcessesWidget::updateContents()
+{
+    if (!refreshDeferrer->attemptRefresh(nullptr)) {
+        return;
+    }
+
+    setProcessesGrid();
+
+    if (Core()->isDebugTaskInProgress() || !Core()->currentlyDebugging) {
+        ui->viewProcesses->setSelectionMode(QAbstractItemView::NoSelection);
+    }
+}
+
+QString ProcessesWidget::translateStatus(QString status)
+{
+    switch (status.toStdString().c_str()[0]) {
+    case R_DBG_PROC_STOP:
+        return "Stopped";
+    case R_DBG_PROC_RUN:
+        return "Running";
+    case R_DBG_PROC_SLEEP:
+        return "Sleeping";
+    case R_DBG_PROC_ZOMBIE:
+        return "Zombie";
+    case R_DBG_PROC_DEAD:
+        return "Dead";
+    case R_DBG_PROC_RAISED:
+        return "Raised event";
+    default:
+        printf("Status: %s\n", status.toStdString().c_str());
+        return "Unknown status";
+    }
+}
+
+void ProcessesWidget::setProcessesGrid()
+{
+    QJsonArray processesValues = Core()->getChildProcesses(DEBUGGED_PID).array();
+    int i = 0;
+    for (const QJsonValue &value : processesValues) {
+        QJsonObject processesItem = value.toObject();
+        int pid = processesItem["pid"].toVariant().toInt();
+        int uid = processesItem["uid"].toVariant().toInt();
+        QString status = translateStatus(processesItem["status"].toString());
+        QString path = processesItem["path"].toString();
+        bool current = processesItem["current"].toBool();
+
+        QStandardItem *rowCurrent = new QStandardItem(QString(current ? "True" : "False"));
+        QStandardItem *rowPid = new QStandardItem(QString::number(pid));
+        QStandardItem *rowUid = new QStandardItem(QString::number(uid));
+        QStandardItem *rowStatus = new QStandardItem(status);
+        QStandardItem *rowPath = new QStandardItem(path);
+
+        modelProcesses->setItem(i, COLUMN_CURRENT, rowCurrent);
+        modelProcesses->setItem(i, COLUMN_PID, rowPid);
+        modelProcesses->setItem(i, COLUMN_UID, rowUid);
+        modelProcesses->setItem(i, COLUMN_STATUS, rowStatus);
+        modelProcesses->setItem(i, COLUMN_PATH, rowPath);
+        i++;
+    }
+
+    // Remove irrelevant old rows
+    if (modelProcesses->rowCount() > i) {
+        modelProcesses->removeRows(i, modelProcesses->rowCount() - i);
+    }
+
+    modelFilter->setSourceModel(modelProcesses);
+    ui->viewProcesses->resizeColumnsToContents();;
+}
+
+void ProcessesWidget::fontsUpdatedSlot()
+{
+    ui->viewProcesses->setFont(Config()->getFont());
+}
+
+void ProcessesWidget::onActivated(const QModelIndex &index)
+{
+    if (!index.isValid())
+        return;
+
+    int pid = modelFilter->data(index.sibling(index.row(), COLUMN_PID)).toInt();
+
+    // Verify that the selected pid is still in the processes list since dp= will
+    // attach to any given id. If it isn't found simply update the UI.
+    QJsonArray processesValues = Core()->getChildProcesses(DEBUGGED_PID).array();
+    for (QJsonValue value : processesValues) {
+        QString status = value.toObject()["status"].toString();
+        if (pid == value.toObject()["pid"].toInt()) {
+            if (R_DBG_PROC_ZOMBIE == status || R_DBG_PROC_DEAD == status) {
+                QMessageBox msgBox;
+                msgBox.setText(tr("Unable to switch to the requested process."));
+                msgBox.exec();
+            } else {
+                Core()->setCurrentDebugProcess(pid);
+            }
+            break;
+        }
+    }
+
+    updateContents();
+}
+
+ProcessesFilterModel::ProcessesFilterModel(QObject *parent)
+    : QSortFilterProxyModel(parent)
+{
+    setFilterCaseSensitivity(Qt::CaseInsensitive);
+    setSortCaseSensitivity(Qt::CaseInsensitive);
+}
+
+bool ProcessesFilterModel::filterAcceptsRow(int row, const QModelIndex &parent) const
+{
+    // All columns are checked for a match
+    for (int i = COLUMN_CURRENT; i <= COLUMN_PATH; ++i) {
+        QModelIndex index = sourceModel()->index(row, i, parent);
+        if (sourceModel()->data(index).toString().contains(filterRegExp())) {
+            return true;
+        }
+    }
+
+    return false;
+}

--- a/src/widgets/ProcessesWidget.h
+++ b/src/widgets/ProcessesWidget.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <QJsonObject>
+#include <memory>
+#include <QStandardItem>
+#include <QTableView>
+#include <QSortFilterProxyModel>
+
+#include "core/Cutter.h"
+#include "CutterDockWidget.h"
+
+class MainWindow;
+
+namespace Ui {
+class ProcessesWidget;
+}
+
+class ProcessesFilterModel : public QSortFilterProxyModel
+{
+    Q_OBJECT
+
+public:
+    ProcessesFilterModel(QObject *parent = nullptr);
+
+protected:
+    bool filterAcceptsRow(int row, const QModelIndex &parent) const override;
+};
+
+class ProcessesWidget : public CutterDockWidget
+{
+    Q_OBJECT
+
+public:
+    explicit ProcessesWidget(MainWindow *main, QAction *action = nullptr);
+    ~ProcessesWidget();
+
+private slots:
+    void updateContents();
+    void setProcessesGrid();
+    void fontsUpdatedSlot();
+    void onActivated(const QModelIndex &index);
+
+private:
+    QString translateStatus(QString status);
+    std::unique_ptr<Ui::ProcessesWidget> ui;
+    QStandardItemModel *modelProcesses;
+    ProcessesFilterModel *modelFilter;
+    RefreshDeferrer *refreshDeferrer;
+};

--- a/src/widgets/ProcessesWidget.ui
+++ b/src/widgets/ProcessesWidget.ui
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ProcessesWidget</class>
+ <widget class="QDockWidget" name="ProcessesWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>463</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string notr="true">Processes</string>
+  </property>
+  <widget class="QWidget" name="dockWidgetContents">
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <property name="spacing">
+       <number>10</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QTableView" name="viewProcesses">
+        <property name="sortingEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="cornerButtonEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="selectionMode">
+         <enum>QAbstractItemView::SingleSelection</enum>
+        </property>
+        <property name="editTriggers">
+         <enum>QAbstractItemView::NoEditTriggers</enum>
+        </property>
+        <property name="horizontalScrollMode">
+         <enum>QAbstractItemView::ScrollPerPixel</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QuickFilterView" name="quickFilterView" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+     </layout>
+  </widget>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QuickFilterView</class>
+   <extends>QWidget</extends>
+   <header>widgets/QuickFilterView.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/widgets/ThreadsWidget.cpp
+++ b/src/widgets/ThreadsWidget.cpp
@@ -56,6 +56,7 @@ ThreadsWidget::ThreadsWidget(MainWindow *main, QAction *action) :
             &ThreadsFilterModel::setFilterWildcard);
     connect(Core(), &CutterCore::refreshAll, this, &ThreadsWidget::updateContents);
     connect(Core(), &CutterCore::seekChanged, this, &ThreadsWidget::updateContents);
+    connect(Core(), &CutterCore::debugTaskStateChanged, this, &ThreadsWidget::updateContents);
     // Seek doesn't necessarily change when switching threads/processes
     connect(Core(), &CutterCore::switchedThread, this, &ThreadsWidget::updateContents);
     connect(Core(), &CutterCore::switchedProcess, this, &ThreadsWidget::updateContents);
@@ -71,10 +72,17 @@ void ThreadsWidget::updateContents()
         return;
     }
 
-    setThreadsGrid();
+    if (Core()->currentlyDebugging) {
+        setThreadsGrid();
+    } else {
+        // Remove rows from the previous debugging session
+        modelThreads->removeRows(0, modelThreads->rowCount());
+    }
 
     if (Core()->isDebugTaskInProgress() || !Core()->currentlyDebugging) {
-        ui->viewThreads->setSelectionMode(QAbstractItemView::NoSelection);
+        ui->viewThreads->setDisabled(true);
+    } else {
+        ui->viewThreads->setDisabled(false);
     }
 }
 

--- a/src/widgets/ThreadsWidget.cpp
+++ b/src/widgets/ThreadsWidget.cpp
@@ -56,6 +56,9 @@ ThreadsWidget::ThreadsWidget(MainWindow *main, QAction *action) :
             &ThreadsFilterModel::setFilterWildcard);
     connect(Core(), &CutterCore::refreshAll, this, &ThreadsWidget::updateContents);
     connect(Core(), &CutterCore::seekChanged, this, &ThreadsWidget::updateContents);
+    // Seek doesn't necessarily change when switching threads/processes
+    connect(Core(), &CutterCore::switchedThread, this, &ThreadsWidget::updateContents);
+    connect(Core(), &CutterCore::switchedProcess, this, &ThreadsWidget::updateContents);
     connect(Config(), &Configuration::fontsUpdated, this, &ThreadsWidget::fontsUpdatedSlot);
     connect(ui->viewThreads, &QTableView::activated, this, &ThreadsWidget::onActivated);
 }


### PR DESCRIPTION
**Detailed description**

A fairly simple widget based on ThreadsWidget that shows all child processes with `dp` and switches between them with `dp=` when debugging. This is primarily useful for kernel debugging and following forks. Since it's not really required in most debug sessions, the widget doesn't popup with default settings, you have to toggle it in the debug window menu.

**Test plan (required)**

- Attach to WinDbg and switch between processes that are running in the kernel.
- Attach to one of the processes on your system and switch to a child, example program:

##### Linux:

```
void child_func() {
    while(true) {
        sleep(1);
    }
}

int main(int argc, char *argv[])
{
    sleep(10); // time to attach
    switch (fork())
    {
        case -1:
            perror("fork");
            exit(1);
        case 0:
            child_func();
            break;
        default:
            break;
    }
    int status;
    wait(&status);
}
```

##### Windows:
```
#include <Windows.h>
int main(int argc, char *argv[]) {
	wchar_t* wString = new wchar_t[4096];
	MultiByteToWideChar(CP_ACP, 0, "C:\\Windows\\system32\\notepad.exe", -1, wString, 4096); // or the path to your program

	PROCESS_INFORMATION ProcessInfo;
	STARTUPINFO StartupInfo;
	ZeroMemory(&StartupInfo, sizeof(StartupInfo));
	StartupInfo.cb = sizeof StartupInfo;
	if (CreateProcess(wString, NULL,
		NULL, NULL, FALSE, 0, NULL,
		NULL, &StartupInfo, &ProcessInfo))
	{
		WaitForSingleObject(ProcessInfo.hProcess, INFINITE);
		CloseHandle(ProcessInfo.hThread);
		CloseHandle(ProcessInfo.hProcess);
	}
	else
	{
		printf("process creation failed\n");
	}
        return 0;
}
```

**Notes**

~Requires further debugging for these issues, linux only(wip):~
~- Forks don't work with local debug, you'll have to attach to a running process.~ Fixed
~- When working with an attached process the children that you will attach to will also instantly die.~ Fixed
- Windows dp= works but will switch you back to your process after stepping. Working on fixing it but it shouldn't matter on cutter's side.

Other issues:
- WinDbg disassembly isn't properly loaded without having the kernel binary but you can see the processes and switch between them(See #1886).

![Untitled](https://user-images.githubusercontent.com/5659696/69903721-33e63080-1395-11ea-94d2-45a124ec8fc7.png)