### PR TITLE
Removed formatBytecount in favor of Qt function

### DIFF
--- a/src/common/Helpers.cpp
+++ b/src/common/Helpers.cpp
@@ -23,20 +23,6 @@ static QAbstractItemView::ScrollMode scrollMode()
 
 namespace qhelpers {
 
-QString formatBytecount(const long bytecount)
-{
-    if (bytecount == 0)
-        return "0";
-    const int exp = log(bytecount) / log(1000);
-    constexpr char suffixes[] = {' ', 'k', 'M', 'G', 'T', 'P', 'E'};
-
-    QString str;
-    QTextStream stream(&str);
-    stream << qSetRealNumberPrecision(3) << bytecount / pow(1000, exp)
-           << ' ' << suffixes[exp] << 'B';
-    return stream.readAll();
-}
-
 void adjustColumns(QTreeView *tv, int columnCount, int padding)
 {
     for (int i = 0; i != columnCount; ++i) {

--- a/src/common/Helpers.h
+++ b/src/common/Helpers.h
@@ -21,7 +21,6 @@ class QMenu;
 class QPaintDevice;
 
 namespace qhelpers {
-QString formatBytecount(const long bytecount);
 void adjustColumns(QTreeView *tv, int columnCount, int padding);
 void adjustColumns(QTreeWidget *tw, int padding);
 bool selectFirstItem(QAbstractItemView *itemView);

--- a/src/dialogs/NewFileDialog.cpp
+++ b/src/dialogs/NewFileDialog.cpp
@@ -290,7 +290,7 @@ bool NewFileDialog::fillRecentFilesList()
         } else {
             // Format the text and add the item to the file list
             const QString text = QString("%1\n%2\nSize: %3").arg(basename, filenameHome,
-                                                                 qhelpers::formatBytecount(info.size()));
+                                                                 Config()->getCurrLocale().formattedDataSize(info.size()));
             QListWidgetItem *item = new QListWidgetItem(
                 getIconFor(basename, i++),
                 text

--- a/src/widgets/Dashboard.cpp
+++ b/src/widgets/Dashboard.cpp
@@ -42,7 +42,7 @@ void Dashboard::updateContents()
     setPlainText(this->ui->formatEdit, item["format"].toString());
     setPlainText(this->ui->modeEdit, item["mode"].toString());
     setPlainText(this->ui->typeEdit, item["type"].toString());
-    setPlainText(this->ui->sizeEdit, qhelpers::formatBytecount(item["size"].toDouble()));
+    setPlainText(this->ui->sizeEdit, Config()->getCurrLocale().formattedDataSize(item["size"].toVariant().toULongLong()));
     setPlainText(this->ui->fdEdit, QString::number(item["fd"].toDouble()));
 
     setPlainText(this->ui->archEdit, item2["arch"].toString());

--- a/src/widgets/ResourcesWidget.cpp
+++ b/src/widgets/ResourcesWidget.cpp
@@ -35,7 +35,7 @@ QVariant ResourcesModel::data(const QModelIndex &index, int role) const
         case TYPE:
             return res.type;
         case SIZE:
-            return qhelpers::formatBytecount(res.size);
+            return Config()->getCurrLocale().formattedDataSize(res.size);
         case LANG:
             return res.lang;
         default:


### PR DESCRIPTION
The old function was segfaulting when bytecount was too large,
resulting in accessing out of bound array.
Qt 5.10 introduced QLocale::formattedDataSize that will do the
same job.