### PR TITLE
Pressing Enter in disassembly will jump to the desired location

### DIFF
--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -614,33 +614,48 @@ void DisassemblyWidget::moveCursorRelative(bool up, bool page)
     }
 }
 
+void DisassemblyWidget::jumpToOffsetByCursor(const QTextCursor &cursor)
+{
+    RVA offset = readDisassemblyOffset(cursor);
+    RVA jump = Core()->getOffsetJump(offset);
+
+    if (jump == RVA_INVALID) {
+        bool ok;
+        RVA xref = Core()->cmdj("axfj@" + QString::number(
+                                              offset)).array().first().toObject().value("to").toVariant().toULongLong(&ok);
+        if (ok) {
+            jump = xref;
+        }
+    }
+
+    if (jump != RVA_INVALID) {
+        seekable->seek(jump);
+    }
+}
+
 bool DisassemblyWidget::eventFilter(QObject *obj, QEvent *event)
 {
     if (event->type() == QEvent::MouseButtonDblClick
         && (obj == mDisasTextEdit || obj == mDisasTextEdit->viewport())) {
         QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
 
-        QTextCursor cursor = mDisasTextEdit->cursorForPosition(QPoint(mouseEvent->x(), mouseEvent->y()));
-        RVA offset = readDisassemblyOffset(cursor);
-
-        RVA jump = Core()->getOffsetJump(offset);
-
-        if (jump == RVA_INVALID) {
-            bool ok;
-            RVA xref = Core()->cmdj("axfj@" + QString::number(
-                offset)).array().first().toObject().value("to").toVariant().toULongLong(&ok);
-            if (ok) {
-                jump = xref;
-            }
-        }
-
-        if (jump != RVA_INVALID) {
-            seekable->seek(jump);
-        }
+        const QTextCursor& cursor = mDisasTextEdit->cursorForPosition(QPoint(mouseEvent->x(), mouseEvent->y()));
+        jumpToOffsetByCursor(cursor);
 
         return true;
     }
+
     return MemoryDockWidget::eventFilter(obj, event);
+}
+
+void DisassemblyWidget::keyPressEvent(QKeyEvent *event)
+{
+    if(event->key() == Qt::Key_Return) {
+        const QTextCursor cursor = mDisasTextEdit->textCursor();
+        jumpToOffsetByCursor(cursor);
+    }
+
+    MemoryDockWidget::keyPressEvent(event);
 }
 
 QString DisassemblyWidget::getWindowTitle() const

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -614,7 +614,7 @@ void DisassemblyWidget::moveCursorRelative(bool up, bool page)
     }
 }
 
-void DisassemblyWidget::jumpToOffsetByCursor(const QTextCursor &cursor)
+void DisassemblyWidget::jumpToOffsetUnderCursor(const QTextCursor &cursor)
 {
     RVA offset = readDisassemblyOffset(cursor);
     RVA jump = Core()->getOffsetJump(offset);
@@ -640,7 +640,7 @@ bool DisassemblyWidget::eventFilter(QObject *obj, QEvent *event)
         QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
 
         const QTextCursor& cursor = mDisasTextEdit->cursorForPosition(QPoint(mouseEvent->x(), mouseEvent->y()));
-        jumpToOffsetByCursor(cursor);
+        jumpToOffsetUnderCursor(cursor);
 
         return true;
     }
@@ -652,7 +652,7 @@ void DisassemblyWidget::keyPressEvent(QKeyEvent *event)
 {
     if(event->key() == Qt::Key_Return) {
         const QTextCursor cursor = mDisasTextEdit->textCursor();
-        jumpToOffsetByCursor(cursor);
+        jumpToOffsetUnderCursor(cursor);
     }
 
     MemoryDockWidget::keyPressEvent(event);

--- a/src/widgets/DisassemblyWidget.h
+++ b/src/widgets/DisassemblyWidget.h
@@ -86,7 +86,7 @@ private:
 
     void moveCursorRelative(bool up, bool page);
 
-    void jumpToOffsetByCursor(const QTextCursor&);
+    void jumpToOffsetUnderCursor(const QTextCursor&);
 };
 
 class DisassemblyScrollArea : public QAbstractScrollArea

--- a/src/widgets/DisassemblyWidget.h
+++ b/src/widgets/DisassemblyWidget.h
@@ -72,6 +72,7 @@ private:
     RVA readCurrentDisassemblyOffset();
     RVA readDisassemblyOffset(QTextCursor tc);
     bool eventFilter(QObject *obj, QEvent *event) override;
+    void keyPressEvent(QKeyEvent *event) override;
     QString getWindowTitle() const override;
 
     QList<RVA> breakpoints;
@@ -84,6 +85,8 @@ private:
     void connectCursorPositionChanged(bool disconnect);
 
     void moveCursorRelative(bool up, bool page);
+
+    void jumpToOffsetByCursor(const QTextCursor&);
 };
 
 class DisassemblyScrollArea : public QAbstractScrollArea


### PR DESCRIPTION
 <!-- Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request. -->


**Detailed description**
#1887 
When Enter is pressed while the user's cursor is on a potential location (flag, function, address, ...), Cutter will jump to this location. Similarly to what it does with double click.


**Test plan (required)**

![alt text](https://i.makeagif.com/media/12-10-2019/5TE1La.gif)


<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**
closes #1887 
<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
