### PR TITLE
add instruction highlighting in disassembly view

### DIFF
--- a/src/widgets/DisassemblyWidget.h
+++ b/src/widgets/DisassemblyWidget.h
@@ -69,10 +69,18 @@ private:
 
     RefreshDeferrer *disasmRefresh;
 
+    QAction actionUnhighlightInstruction;
+
     RVA readCurrentDisassemblyOffset();
     RVA readDisassemblyOffset(QTextCursor tc);
     bool eventFilter(QObject *obj, QEvent *event) override;
     QString getWindowTitle() const override;
+
+    /**
+     * Returns pointer to disassemblyLine which contains address,
+     * and size of that disassemblyLine
+     */
+    std::pair<DisassemblyLine*, RVA> getDisassemblyLine(RVA address);
 
     QList<RVA> breakpoints;
 
@@ -84,6 +92,9 @@ private:
     void connectCursorPositionChanged(bool disconnect);
 
     void moveCursorRelative(bool up, bool page);
+
+    void onActionHighlightInstructionTriggered();
+    void onActionUnhighlightInstructionTriggered();
 };
 
 class DisassemblyScrollArea : public QAbstractScrollArea


### PR DESCRIPTION
**Detailed description**
This PR resolves #444 by implementing instruction highlighting in disassembly view. Behaviour is the same as in graph view(#1879).
![2019-12-11-02-29-11](https://user-images.githubusercontent.com/8948436/70583688-c9b46380-1bbe-11ea-8d66-b915a571630f.gif)

**Test plan (required)**
1. Disassembly Widget correctly calculates size of instructions
2. Highlighted instructions are properly synchronized between multiple widgets.

**Closing issues**
closes #444

// Edit
I don't know why #444 was closed, #1879 implemented highlighting in graph view without disassembly. #444 also requested highlighting in disassembly.