### PR TITLE
Add a signal for widget rebasing and switch to oodf for remote debug rebasing

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1265,9 +1265,10 @@ void CutterCore::startDebug()
             setConfig("asm.flags", false);
             currentlyDebugging = true;
             emit changeDebugView();
-            emit flagsChanged();
             emit refreshCodeViews();
         }
+
+        emit codeRebased();
         emit stackChanged();
         emit debugTaskStateChanged();
     });
@@ -1306,10 +1307,11 @@ void CutterCore::startEmulation()
             currentlyDebugging = true;
             currentlyEmulating = true;
             emit changeDebugView();
-            emit flagsChanged();
         }
+
         emit registersChanged();
         emit stackChanged();
+        emit codeRebased();
         emit refreshCodeViews();
         emit debugTaskStateChanged();
     });
@@ -1361,10 +1363,10 @@ void CutterCore::attachRemote(const QString &uri)
             // prevent register flags from appearing during debug/emul
             setConfig("asm.flags", false);
             currentlyDebugging = true;
-            emit flagsChanged();
             emit changeDebugView();
         }
 
+        emit codeRebased();
         emit attachedRemote(true);
         emit debugTaskStateChanged();
     });
@@ -1401,9 +1403,11 @@ void CutterCore::attachDebug(int pid)
             currentlyDebugging = true;
             currentlyOpenFile = getConfig("file.path");
             currentlyAttachedToPID = pid;
-            emit flagsChanged();
             emit changeDebugView();
         }
+
+        emit codeRebased();
+        emit debugTaskStateChanged();
     });
 
     debugTaskDialog = new R2TaskDialog(debugTask);
@@ -1457,7 +1461,7 @@ void CutterCore::stopDebug()
     syncAndSeekProgramCounter();
     setConfig("asm.flags", true);
     setConfig("io.cache", false);
-    emit flagsChanged();
+    emit codeRebased();
     emit changeDefinedView();
     offsetPriorDebugging = getOffset();
     emit debugTaskStateChanged();

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1332,7 +1332,7 @@ void CutterCore::attachRemote(const QString &uri)
     }
 
     // connect to a debugger with the given plugin
-    asyncCmd("o-*; e cfg.debug = true; oodf " + uri, debugTask);
+    asyncCmd("e cfg.debug = true; oodf " + uri, debugTask);
     emit debugTaskStateChanged();
 
     connect(debugTask.data(), &R2Task::finished, this, [this, uri] () {
@@ -1387,7 +1387,7 @@ void CutterCore::attachDebug(int pid)
     }
 
     // attach to process with dbg plugin
-    asyncCmd("o-*; e cfg.debug = true; o+ dbg://" + QString::number(pid), debugTask);
+    asyncCmd("e cfg.debug = true; oodf dbg://" + QString::number(pid), debugTask);
     emit debugTaskStateChanged();
 
     connect(debugTask.data(), &R2Task::finished, this, [this, pid] () {

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1330,7 +1330,7 @@ void CutterCore::attachRemote(const QString &uri)
     }
 
     // connect to a debugger with the given plugin
-    asyncCmd("o-*; e cfg.debug = true; o+ " + uri, debugTask);
+    asyncCmd("o-*; e cfg.debug = true; oodf " + uri, debugTask);
     emit debugTaskStateChanged();
 
     connect(debugTask.data(), &R2Task::finished, this, [this, uri] () {

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -491,6 +491,10 @@ signals:
     void breakpointsChanged();
     void refreshCodeViews();
     void stackChanged();
+    /**
+     * @brief update all the widgets that are affected by rebasing in debug mode
+     */
+    void codeRebased();
 
     void switchedThread();
     void switchedProcess();

--- a/src/widgets/BreakpointWidget.cpp
+++ b/src/widgets/BreakpointWidget.cpp
@@ -142,6 +142,7 @@ BreakpointWidget::BreakpointWidget(MainWindow *main, QAction *action) :
 
     connect(Core(), &CutterCore::refreshAll, this, &BreakpointWidget::refreshBreakpoint);
     connect(Core(), &CutterCore::breakpointsChanged, this, &BreakpointWidget::refreshBreakpoint);
+    connect(Core(), &CutterCore::codeRebased, this, &BreakpointWidget::refreshBreakpoint);
     connect(Core(), &CutterCore::refreshCodeViews, this, &BreakpointWidget::refreshBreakpoint);
     connect(ui->addBreakpoint, &QAbstractButton::clicked, this, &BreakpointWidget::addBreakpointDialog);
     connect(ui->delBreakpoint, &QAbstractButton::clicked, this, &BreakpointWidget::delBreakpoint);

--- a/src/widgets/ClassesWidget.cpp
+++ b/src/widgets/ClassesWidget.cpp
@@ -219,6 +219,7 @@ AnalClassesModel::AnalClassesModel(CutterDockWidget *parent)
     });
 
     connect(Core(), &CutterCore::refreshAll, this, &AnalClassesModel::refreshAll);
+    connect(Core(), &CutterCore::codeRebased, this, &AnalClassesModel::refreshAll);
     connect(Core(), &CutterCore::classNew, this, &AnalClassesModel::classNew);
     connect(Core(), &CutterCore::classDeleted, this, &AnalClassesModel::classDeleted);
     connect(Core(), &CutterCore::classRenamed, this, &AnalClassesModel::classRenamed);

--- a/src/widgets/CommentsWidget.cpp
+++ b/src/widgets/CommentsWidget.cpp
@@ -259,8 +259,9 @@ CommentsWidget::CommentsWidget(MainWindow *main, QAction *action) :
     connect(this, &QWidget::customContextMenuRequested,
             this, &CommentsWidget::showTitleContextMenu);
 
-    connect(Core(), SIGNAL(commentsChanged()), this, SLOT(refreshTree()));
-    connect(Core(), SIGNAL(refreshAll()), this, SLOT(refreshTree()));
+    connect(Core(), &CutterCore::codeRebased, this, &CommentsWidget::refreshTree);
+    connect(Core(), &CutterCore::commentsChanged, this, &CommentsWidget::refreshTree);
+    connect(Core(), &CutterCore::refreshAll, this, &CommentsWidget::refreshTree);
 }
 
 CommentsWidget::~CommentsWidget() {}

--- a/src/widgets/EntrypointWidget.cpp
+++ b/src/widgets/EntrypointWidget.cpp
@@ -20,7 +20,8 @@ EntrypointWidget::EntrypointWidget(MainWindow *main, QAction *action) :
 
     setScrollMode();
 
-    connect(Core(), SIGNAL(refreshAll()), this, SLOT(fillEntrypoint()));
+    connect(Core(), &CutterCore::codeRebased, this, &EntrypointWidget::fillEntrypoint);
+    connect(Core(), &CutterCore::refreshAll, this, &EntrypointWidget::fillEntrypoint);
 }
 
 EntrypointWidget::~EntrypointWidget() {}

--- a/src/widgets/ExportsWidget.cpp
+++ b/src/widgets/ExportsWidget.cpp
@@ -142,7 +142,8 @@ ExportsWidget::ExportsWidget(MainWindow *main, QAction *action) :
             main->updateDockActionChecked(action);
             } );
 
-    connect(Core(), SIGNAL(refreshAll()), this, SLOT(refreshExports()));
+    connect(Core(), &CutterCore::codeRebased, this, &ExportsWidget::refreshExports);
+    connect(Core(), &CutterCore::refreshAll, this, &ExportsWidget::refreshExports);
 }
 
 ExportsWidget::~ExportsWidget() {}

--- a/src/widgets/FlagsWidget.cpp
+++ b/src/widgets/FlagsWidget.cpp
@@ -160,8 +160,9 @@ FlagsWidget::FlagsWidget(MainWindow *main, QAction *action) :
 
     setScrollMode();
 
-    connect(Core(), SIGNAL(flagsChanged()), this, SLOT(flagsChanged()));
-    connect(Core(), SIGNAL(refreshAll()), this, SLOT(refreshFlagspaces()));
+    connect(Core(), &CutterCore::flagsChanged, this, &FlagsWidget::flagsChanged);
+    connect(Core(), &CutterCore::codeRebased, this, &FlagsWidget::flagsChanged);
+    connect(Core(), &CutterCore::refreshAll, this, &FlagsWidget::refreshFlagspaces);
 
     auto menu = ui->flagsTreeView->getItemContextMenu();
     menu->addSeparator();

--- a/src/widgets/FunctionsWidget.cpp
+++ b/src/widgets/FunctionsWidget.cpp
@@ -480,8 +480,9 @@ FunctionsWidget::FunctionsWidget(MainWindow *main, QAction *action) :
     connect(this, SIGNAL(customContextMenuRequested(const QPoint &)),
             this, SLOT(showTitleContextMenu(const QPoint &)));
 
-    connect(Core(), SIGNAL(functionsChanged()), this, SLOT(refreshTree()));
-    connect(Core(), SIGNAL(refreshAll()), this, SLOT(refreshTree()));
+    connect(Core(), &CutterCore::functionsChanged, this, &FunctionsWidget::refreshTree);
+    connect(Core(), &CutterCore::codeRebased, this, &FunctionsWidget::refreshTree);
+    connect(Core(), &CutterCore::refreshAll, this, &FunctionsWidget::refreshTree);
 }
 
 FunctionsWidget::~FunctionsWidget() {}

--- a/src/widgets/HeadersWidget.cpp
+++ b/src/widgets/HeadersWidget.cpp
@@ -123,6 +123,7 @@ HeadersWidget::HeadersWidget(MainWindow *main, QAction *action) :
     ui->quickFilterView->closeFilter();
     showCount(false);
 
+    connect(Core(), &CutterCore::codeRebased, this, &HeadersWidget::refreshHeaders);
     connect(Core(), &CutterCore::refreshAll, this, &HeadersWidget::refreshHeaders);
 }
 

--- a/src/widgets/ImportsWidget.cpp
+++ b/src/widgets/ImportsWidget.cpp
@@ -155,7 +155,8 @@ ImportsWidget::ImportsWidget(MainWindow *main, QAction *action) :
             main->updateDockActionChecked(action);
             } );
 
-    connect(Core(), SIGNAL(refreshAll()), this, SLOT(refreshImports()));
+    connect(Core(), &CutterCore::codeRebased, this, &ImportsWidget::refreshImports);
+    connect(Core(), &CutterCore::refreshAll, this, &ImportsWidget::refreshImports);
 }
 
 ImportsWidget::~ImportsWidget() {}

--- a/src/widgets/RelocsWidget.cpp
+++ b/src/widgets/RelocsWidget.cpp
@@ -124,6 +124,7 @@ RelocsWidget::RelocsWidget(MainWindow *main, QAction *action) :
     setModels(relocsProxyModel);
     ui->treeView->sortByColumn(RelocsModel::NameColumn, Qt::AscendingOrder);
 
+    connect(Core(), &CutterCore::codeRebased, this, &RelocsWidget::refreshRelocs);
     connect(Core(), &CutterCore::refreshAll, this, &RelocsWidget::refreshRelocs);
 }
 

--- a/src/widgets/SectionsWidget.cpp
+++ b/src/widgets/SectionsWidget.cpp
@@ -215,6 +215,7 @@ void SectionsWidget::initAddrMapDocks()
 void SectionsWidget::initConnects()
 {
     connect(Core(), &CutterCore::refreshAll, this, &SectionsWidget::refreshSections);
+    connect(Core(), &CutterCore::codeRebased, this, &SectionsWidget::refreshSections);
     connect(this, &QDockWidget::visibilityChanged, this, [ = ](bool visibility) {
         if (visibility) {
             refreshSections();

--- a/src/widgets/SegmentsWidget.cpp
+++ b/src/widgets/SegmentsWidget.cpp
@@ -145,7 +145,8 @@ SegmentsWidget::SegmentsWidget(MainWindow *main, QAction *action) :
     ui->quickFilterView->closeFilter();
     showCount(false);
 
-    connect(Core(), SIGNAL(refreshAll()), this, SLOT(refreshSegments()));
+    connect(Core(), &CutterCore::refreshAll, this, &SegmentsWidget::refreshSegments);
+    connect(Core(), &CutterCore::codeRebased, this, &SegmentsWidget::refreshSegments);
 }
 
 SegmentsWidget::~SegmentsWidget() {}

--- a/src/widgets/StringsWidget.cpp
+++ b/src/widgets/StringsWidget.cpp
@@ -186,7 +186,8 @@ StringsWidget::StringsWidget(MainWindow *main, QAction *action) :
     });
     clearShortcut->setContext(Qt::WidgetWithChildrenShortcut);
 
-    connect(Core(), SIGNAL(refreshAll()), this, SLOT(refreshStrings()));
+    connect(Core(), &CutterCore::refreshAll, this, &StringsWidget::refreshStrings);
+    connect(Core(), &CutterCore::codeRebased, this, &StringsWidget::refreshStrings);
 
     connect(
         ui->quickFilterView->comboBox(), &QComboBox::currentTextChanged, this,

--- a/src/widgets/SymbolsWidget.cpp
+++ b/src/widgets/SymbolsWidget.cpp
@@ -124,6 +124,7 @@ SymbolsWidget::SymbolsWidget(MainWindow *main, QAction *action) :
     setModels(symbolsProxyModel);
     ui->treeView->sortByColumn(SymbolsModel::AddressColumn, Qt::AscendingOrder);
 
+    connect(Core(), &CutterCore::codeRebased, this, &SymbolsWidget::refreshSymbols);
     connect(Core(), &CutterCore::refreshAll, this, &SymbolsWidget::refreshSymbols);
 }
 

--- a/src/widgets/VTablesWidget.cpp
+++ b/src/widgets/VTablesWidget.cpp
@@ -161,7 +161,8 @@ VTablesWidget::VTablesWidget(MainWindow *main, QAction *action) :
         tree->showItemsNumber(proxy->rowCount());
     });
     
-    connect(Core(), SIGNAL(refreshAll()), this, SLOT(refreshVTables()));
+    connect(Core(), &CutterCore::codeRebased, this, &VTablesWidget::refreshVTables);
+    connect(Core(), &CutterCore::refreshAll, this, &VTablesWidget::refreshVTables);
 }
 
 VTablesWidget::~VTablesWidget()


### PR DESCRIPTION
**Detailed description**

Up until now only a part of the widgets were rebased, primarily by accident because they connected to seekUpdated or refreshCodeView. This change covers all relevant widgets(Tell me if I missed something) except for Search which needs fixing on r2's level and would freeze with this change.

**Test plan (required)**

- Start native/remote/attach debug on any PIE binary and check the following for each widget(Functions, Breakpoints, Strings, Flags, Comments, Segments, Sections, Headers, Exports, Imports, VTables, Classes and Relocs):
    - All offsets seem to be correct
    - If the text is selectable see if it sends you to the correct position in the code
    - If you can create it before debug see if it is properly rebased afterwards and between sessions (breakpoints[have to do it manually through the widget if you're not in debug mode but you can check if it works between sessions], comments)
- Try those things across different sessions and see that everything stays the same between/after debug

**Notes**

- SearchWidget can't be updated this way without freezing Cutter, shouldn't be critical for this issue. We'll just add it's rebasing once search works in debug.
- Classes widget only rebases the member functions - r2 issue
- ELF header symbols aren't rebased - r2 issue

If it's some random info window and it isn't rebased just report it and we'll submit issues in r2 to fix it later, it doesn't really matter since people don't jump to ELF header properties while debugging. The important widgets that must work are Functions, Strings, Breakpoints, Flags and Comments.

**Related issues**
Closes #1053 