### PR TITLE
Improve seek backward and outside of function in Decompiler widget

### DIFF
--- a/src/common/CutterSeekable.cpp
+++ b/src/common/CutterSeekable.cpp
@@ -62,3 +62,28 @@ bool CutterSeekable::isSynchronized()
 {
     return synchronized;
 }
+
+void CutterSeekable::seekToReference(RVA offset)
+{
+    if (offset == RVA_INVALID)
+    {
+        return;
+    }
+    RVA jump = Core()->getOffsetJump(offset);
+    
+    if (jump == RVA_INVALID) {
+        QList<XrefDescription> refs = Core()->getXRefs(offset, false, false);
+        
+        if (refs.length()) {
+            jump = refs.at(0).to;
+        }
+
+        if (refs.length() > 1) {
+            qWarning() << "Too many references here. Weird behaviour expected.";
+        }
+    }
+
+    if (jump != RVA_INVALID) {
+        seek(jump);
+    }
+}

--- a/src/common/CutterSeekable.cpp
+++ b/src/common/CutterSeekable.cpp
@@ -69,21 +69,18 @@ void CutterSeekable::seekToReference(RVA offset)
     {
         return;
     }
-    RVA jump = Core()->getOffsetJump(offset);
     
-    if (jump == RVA_INVALID) {
-        QList<XrefDescription> refs = Core()->getXRefs(offset, false, false);
-        
-        if (refs.length()) {
-            jump = refs.at(0).to;
-        }
-
+    RVA target;
+    QList<XrefDescription> refs = Core()->getXRefs(offset, false, false);
+    
+    if (refs.length()) {
         if (refs.length() > 1) {
             qWarning() << "Too many references here. Weird behaviour expected.";
         }
-    }
-
-    if (jump != RVA_INVALID) {
-        seek(jump);
+        
+        target = refs.at(0).to;
+        if (target != RVA_INVALID) {
+            seek(target);
+        }
     }
 }

--- a/src/common/CutterSeekable.h
+++ b/src/common/CutterSeekable.h
@@ -45,7 +45,7 @@ public:
     bool isSynchronized();
 
     /**
-     * @brief seekToReference will seek to the function or the object which is referenced in a give offset
+     * @brief seekToReference will seek to the function or the object which is referenced in a given offset
      * @param offset - an address that contains a reference to jump to
      */
     void seekToReference(RVA offset);

--- a/src/common/CutterSeekable.h
+++ b/src/common/CutterSeekable.h
@@ -44,6 +44,12 @@ public:
      */
     bool isSynchronized();
 
+    /**
+     * @brief seekToReference will seek to the function or the object which is referenced in a give offset
+     * @param offset - an address that contains a reference to jump to
+     */
+    void seekToReference(RVA offset);
+
 public slots:
     /**
      * @brief seekPrev seeks to last location.

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -7,6 +7,7 @@
 #include "common/TempConfig.h"
 #include "common/SelectionHighlight.h"
 #include "common/Decompiler.h"
+#include "common/CutterSeekable.h"
 
 #include <QTextEdit>
 #include <QPlainTextEdit>
@@ -22,6 +23,9 @@ DecompilerWidget::DecompilerWidget(MainWindow *main, QAction *action) :
     ui->setupUi(this);
 
     syntaxHighlighter = Config()->createSyntaxHighlighter(ui->textEdit->document());
+
+    // Event filter to intercept double clicks in the textbox
+    ui->textEdit->viewport()->installEventFilter(this);
 
     setupFonts();
     colorsUpdatedSlot();
@@ -88,6 +92,13 @@ DecompilerWidget::DecompilerWidget(MainWindow *main, QAction *action) :
     connect(Core(), &CutterCore::commentsChanged, this, &DecompilerWidget::doAutoRefresh);
     connect(Core(), &CutterCore::instructionChanged, this, &DecompilerWidget::doAutoRefresh);
     connect(Core(), &CutterCore::refreshCodeViews, this, &DecompilerWidget::doAutoRefresh);
+
+    // Esc to seek backward
+    QAction *seekPrevAction = new QAction(this);
+    seekPrevAction->setShortcut(Qt::Key_Escape);
+    seekPrevAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+    addAction(seekPrevAction);
+    connect(seekPrevAction, &QAction::triggered, seekable, &CutterSeekable::seekPrev);
 }
 
 DecompilerWidget::~DecompilerWidget() = default;
@@ -288,4 +299,26 @@ void DecompilerWidget::showDisasContextMenu(const QPoint &pt)
 {
     mCtxMenu->exec(ui->textEdit->mapToGlobal(pt));
     doRefresh();
+}
+
+void DecompilerWidget::seekToReference()
+{
+    size_t pos = ui->textEdit->textCursor().position();
+    RVA offset = code.OffsetForPosition(pos);
+    seekable->seekToReference(offset);
+}
+
+bool DecompilerWidget::eventFilter(QObject *obj, QEvent *event)
+{
+
+    if (event->type() == QEvent::MouseButtonDblClick
+        && (obj == ui->textEdit || obj == ui->textEdit->viewport())) {
+        QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
+
+        const QTextCursor& cursor = ui->textEdit->cursorForPosition(QPoint(mouseEvent->x(), mouseEvent->y()));
+        seekToReference();
+        return true;
+    }
+
+    return MemoryDockWidget::eventFilter(obj, event);
 }

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -310,7 +310,6 @@ void DecompilerWidget::seekToReference()
 
 bool DecompilerWidget::eventFilter(QObject *obj, QEvent *event)
 {
-
     if (event->type() == QEvent::MouseButtonDblClick
         && (obj == ui->textEdit || obj == ui->textEdit->viewport())) {
         QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);

--- a/src/widgets/DecompilerWidget.h
+++ b/src/widgets/DecompilerWidget.h
@@ -70,6 +70,13 @@ private:
     void updateCursorPosition();
 
     QString getWindowTitle() const override;
+    bool eventFilter(QObject *obj, QEvent *event) override;
+
+    /**
+     * @brief a wrapper around CutterSeekable::seekToReference to seek to an object which is
+     * referenced from the address under cursor
+     */
+    void seekToReference();
 };
 
 #endif // DECOMPILERWIDGET_H

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -996,18 +996,7 @@ void DisassemblerGraphView::blockDoubleClicked(GraphView::GraphBlock &block, QMo
                                                QPoint pos)
 {
     Q_UNUSED(event);
-
-    RVA instr = getAddrForMouseEvent(block, &pos);
-    if (instr == RVA_INVALID) {
-        return;
-    }
-    QList<XrefDescription> refs = Core()->getXRefs(instr, false, false);
-    if (refs.length()) {
-        seekable->seek(refs.at(0).to);
-    }
-    if (refs.length() > 1) {
-        qWarning() << "Too many references here. Weird behaviour expected.";
-    }
+    seekable->seekToReference(getAddrForMouseEvent(block, &pos));
 }
 
 void DisassemblerGraphView::blockHelpEvent(GraphView::GraphBlock &block, QHelpEvent *event,

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -617,20 +617,7 @@ void DisassemblyWidget::moveCursorRelative(bool up, bool page)
 void DisassemblyWidget::jumpToOffsetUnderCursor(const QTextCursor &cursor)
 {
     RVA offset = readDisassemblyOffset(cursor);
-    RVA jump = Core()->getOffsetJump(offset);
-
-    if (jump == RVA_INVALID) {
-        bool ok;
-        RVA xref = Core()->cmdj("axfj@" + QString::number(
-                                              offset)).array().first().toObject().value("to").toVariant().toULongLong(&ok);
-        if (ok) {
-            jump = xref;
-        }
-    }
-
-    if (jump != RVA_INVALID) {
-        seekable->seek(jump);
-    }
+    seekable->seekToReference(offset);
 }
 
 bool DisassemblyWidget::eventFilter(QObject *obj, QEvent *event)


### PR DESCRIPTION
 <!-- Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request. -->


**Detailed description**

This PR improve or implements the following things:

1) Double click on a function\object in decompiler widget will seek to this address
2) Implement seek backward by pressing <kbd>Escape</kbd>
3) Improve usage of seeking to a reference and seeking back using the underused CutterSeekable class

![cutterSeek](https://user-images.githubusercontent.com/20182642/70811722-d9a29200-1dce-11ea-90fc-9caf103881cc.gif)


**Test plan (required)**
Double click:
0) Make sure to have a decompiler installed in Cutter
1) Open a binary in Cutter and open the decompiler widget
2) Choose a function with calls to other functions
3) Double click other function names and see how Cutter is seeking to these addresses


Seeking back:
1) Open a binary in cutter and performs some seeks
2) Now test that pressing <kbd>Escape</kbd> in graph, disas, hex, and decompiler works properly

<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**

<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
