### PR TITLE
Fix 1756: Disable seek when selecting text on Decompiler Widget

### DIFF
--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -204,6 +204,12 @@ void DecompilerWidget::connectCursorPositionChanged(bool disconnect)
 
 void DecompilerWidget::cursorPositionChanged()
 {
+    // Do not perform seeks along with the cursor while selecting multiple lines
+    if (!ui->textEdit->textCursor().selectedText().isEmpty())
+    {
+        return;
+    }
+
     size_t pos = ui->textEdit->textCursor().position();
     RVA offset = code.OffsetForPosition(pos);
     if (offset != RVA_INVALID && offset != Core()->getOffset()) {


### PR DESCRIPTION

**Detailed description**

This PR disable the extra seek operations when selecting multiple lines in the Decompiler. 
The previous behavior is demonstrated in the relevant issue.
![noSeekForSelection](https://user-images.githubusercontent.com/20182642/70813101-9990de80-1dd1-11ea-92c3-4048dd535901.gif)


**Test plan (required)**

1) Select text in the decompiler widget and see that seek only happens when the mouse button is down and not continues to more seeks when selecting more lines.
2) Seek regularly by pressing (and not selecting) different locations and see that no regression is introduced.



**Closing issues**

fix #1756 
