### PR TITLE
Solve search widget issues in debug mode

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1264,7 +1264,7 @@ void CutterCore::startDebug()
         if (!currentlyDebugging) {
             setConfig("asm.flags", false);
             currentlyDebugging = true;
-            emit changeDebugView();
+            emit toggleDebugView();
             emit refreshCodeViews();
         }
 
@@ -1306,7 +1306,7 @@ void CutterCore::startEmulation()
             setConfig("io.cache", true);
             currentlyDebugging = true;
             currentlyEmulating = true;
-            emit changeDebugView();
+            emit toggleDebugView();
         }
 
         emit registersChanged();
@@ -1363,7 +1363,7 @@ void CutterCore::attachRemote(const QString &uri)
             // prevent register flags from appearing during debug/emul
             setConfig("asm.flags", false);
             currentlyDebugging = true;
-            emit changeDebugView();
+            emit toggleDebugView();
         }
 
         emit codeRebased();
@@ -1403,7 +1403,7 @@ void CutterCore::attachDebug(int pid)
             currentlyDebugging = true;
             currentlyOpenFile = getConfig("file.path");
             currentlyAttachedToPID = pid;
-            emit changeDebugView();
+            emit toggleDebugView();
         }
 
         emit codeRebased();
@@ -1462,7 +1462,7 @@ void CutterCore::stopDebug()
     setConfig("asm.flags", true);
     setConfig("io.cache", false);
     emit codeRebased();
-    emit changeDefinedView();
+    emit toggleDebugView();
     offsetPriorDebugging = getOffset();
     emit debugTaskStateChanged();
 }

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -529,8 +529,7 @@ signals:
      */
     void seekChanged(RVA offset);
 
-    void changeDefinedView();
-    void changeDebugView();
+    void toggleDebugView();
 
     void newMessage(const QString &msg);
     void newDebugMessage(const QString &msg);

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -171,8 +171,7 @@ void MainWindow::initUI()
     connect(core, SIGNAL(projectSaved(bool, const QString &)), this, SLOT(projectSaved(bool,
                                                                                        const QString &)));
 
-    connect(core, &CutterCore::changeDebugView, this, &MainWindow::changeDebugView);
-    connect(core, &CutterCore::changeDefinedView, this, &MainWindow::changeDefinedView);
+    connect(core, &CutterCore::toggleDebugView, this, &MainWindow::toggleDebugView);
 
     connect(core, SIGNAL(newMessage(const QString &)),
             this->consoleDock, SLOT(addOutput(const QString &)));
@@ -1437,22 +1436,21 @@ void MainWindow::projectSaved(bool successfully, const QString &name)
         core->message(tr("Failed to save project: %1").arg(name));
 }
 
-void MainWindow::changeDebugView()
+void MainWindow::toggleDebugView()
 {
-    saveSettings();
-    restoreDebugLayout();
-    enableDebugWidgetsMenu(true);
-}
-
-void MainWindow::changeDefinedView()
-{
-    saveDebugSettings();
-    MemoryWidgetType memType = getMemoryWidgetTypeToRestore();
-    hideAllDocks();
-    restoreDocks();
-    readSettingsOrDefault();
-    enableDebugWidgetsMenu(false);
-    showMemoryWidget(memType);
+    if (Core()->currentlyDebugging) {
+        saveSettings();
+        restoreDebugLayout();
+        enableDebugWidgetsMenu(true);
+    } else {
+        saveDebugSettings();
+        MemoryWidgetType memType = getMemoryWidgetTypeToRestore();
+        hideAllDocks();
+        restoreDocks();
+        readSettingsOrDefault();
+        enableDebugWidgetsMenu(false);
+        showMemoryWidget(memType);
+    }
 }
 
 void MainWindow::mousePressEvent(QMouseEvent *event)

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -193,8 +193,7 @@ private slots:
 
     void mousePressEvent(QMouseEvent *event) override;
     bool eventFilter(QObject *object, QEvent *event) override;
-    void changeDebugView();
-    void changeDefinedView();
+    void toggleDebugView();
     void chooseThemeIcons();
 
     void onZoomIn();

--- a/src/widgets/SearchWidget.h
+++ b/src/widgets/SearchWidget.h
@@ -70,6 +70,7 @@ public:
 private slots:
     void on_searchInCombo_currentIndexChanged(int index);
     void searchChanged();
+    void updateSearchBoundaries();
     void refreshSearchspaces();
 
 private:


### PR DESCRIPTION
**Detailed description**

Previously, you could search in boundaries that weren't properly configured in debug mode and freeze Cutter. That also meant previously typed searches(most types) would freeze Cutter when debug started.

**Test plan (required)**

Search in all available categories when in and out of debug mode.
