### PR TITLE
Small debug fixes

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1455,7 +1455,7 @@ void CutterCore::stopDebug()
                 ptraceFiles += "o-" + QString::number(openFile["fd"].toInt()) + ";";
             }
         }
-        cmd("dk 9; oo; .ar-;" + ptraceFiles);
+        cmd("doc" + ptraceFiles);
     }
 
     syncAndSeekProgramCounter();

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -219,6 +219,7 @@ void MainWindow::initToolBar()
     ui->menuDebug->addAction(debugActions->actionStart);
     ui->menuDebug->addAction(debugActions->actionStartEmul);
     ui->menuDebug->addAction(debugActions->actionAttach);
+    ui->menuDebug->addAction(debugActions->actionStartRemote);
     ui->menuDebug->addSeparator();
     ui->menuDebug->addAction(debugActions->actionStep);
     ui->menuDebug->addAction(debugActions->actionStepOver);

--- a/src/widgets/DebugActions.cpp
+++ b/src/widgets/DebugActions.cpp
@@ -108,7 +108,7 @@ DebugActions::DebugActions(QToolBar *toolBar, MainWindow *main) :
     // necessary to avoid staying stuck
     toggleActions = {actionStepOver, actionStep, actionStepOut, actionContinueUntilMain,
         actionContinueUntilCall, actionContinueUntilSyscall};
-    toggleConnectionActions = {actionAttach, actionStartRemote, actionStartEmul};
+    toggleConnectionActions = {actionAttach, actionStartRemote};
 
     connect(Core(), &CutterCore::debugTaskStateChanged, this, [ = ]() {
         bool disableToolbar = Core()->isDebugTaskInProgress();


### PR DESCRIPTION
**Detailed description**

Fixed incomplete rebasing after 'oo', switched to 'doc' to kill all child processes and streamline the closing process, added startRemote to the debug dropdown menu and un-disabled startemul when emulating to allow the user to restart the session.

**Test plan (required)**

Start/stop debug and see that things closed properly and relocated back to the original position.
Everything else is UX and doesn't really need testing other than seeing the restart icon when emulating and startRemote in the debug dropdown menu.
