### PR TITLE
Fix crash when refreshing after debuging (#1925)

### DIFF
--- a/src/common/Helpers.cpp
+++ b/src/common/Helpers.cpp
@@ -23,16 +23,18 @@ static QAbstractItemView::ScrollMode scrollMode()
 
 namespace qhelpers {
 
-QString formatBytecount(const long bytecount)
+QString formatBytecount(const uint64_t bytecount)
 {
-    if (bytecount == 0)
+    if (bytecount == 0) {
         return "0";
-    const int exp = log(bytecount) / log(1000);
+    }
+
+    const int exp = log(bytecount) / log(1024);
     constexpr char suffixes[] = {' ', 'k', 'M', 'G', 'T', 'P', 'E'};
 
     QString str;
     QTextStream stream(&str);
-    stream << qSetRealNumberPrecision(3) << bytecount / pow(1000, exp)
+    stream << qSetRealNumberPrecision(3) << bytecount / pow(1024, exp)
            << ' ' << suffixes[exp] << 'B';
     return stream.readAll();
 }

--- a/src/common/Helpers.h
+++ b/src/common/Helpers.h
@@ -21,7 +21,7 @@ class QMenu;
 class QPaintDevice;
 
 namespace qhelpers {
-QString formatBytecount(const long bytecount);
+QString formatBytecount(const uint64_t bytecount);
 void adjustColumns(QTreeView *tv, int columnCount, int padding);
 void adjustColumns(QTreeWidget *tw, int padding);
 bool selectFirstItem(QAbstractItemView *itemView);


### PR DESCRIPTION
**Detailed description**

The sizes in formatBytes were wrong which meant that wrong sizes were displayed and it caused a crash when seek was set to UT64_MAX.

**Test plan (required)**

See that Cutter doesn't crash after:

-Start debuging ls
-Click continue until process exits
-Click "View/Refresh contents"

or do step 3 while continue is still in progress

**Closing issues**

closes #1925 