### PR TITLE
Fix automatic function naming

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1020,7 +1020,7 @@ QString CutterCore::createFunctionAt(RVA addr, QString name)
 {
     static const QRegularExpression regExp("[^a-zA-Z0-9_]");
     name.remove(regExp);
-    QString command = "af " + name + " " + RAddressString(addr);
+    QString command = "af " + name + " @ " + RAddressString(addr);
     QString ret = cmd(command);
     emit functionsChanged();
     return ret;


### PR DESCRIPTION
"Define function here" would name a function "0x1337" if it starts at 0x1337 instead of the expected "fcn.0x1337" if no name is given.

**Test plan (required)**

* right click any address
* click "Define function here"
* Enter no name and apply
* Check the function's name