### PR TITLE
Highlight Breakpoints and PC in decompiler

### DIFF
--- a/src/common/SelectionHighlight.cpp
+++ b/src/common/SelectionHighlight.cpp
@@ -35,13 +35,32 @@ QList<QTextEdit::ExtraSelection> createSameWordsSelections(QPlainTextEdit *textE
     return selections;
 }
 
-QTextEdit::ExtraSelection createLineHighlightSelection(const QTextCursor &cursor)
+
+QTextEdit::ExtraSelection createLineHighlight(const QTextCursor &cursor, QColor highlightColor)
 {
-    QColor highlightColor = ConfigColor("lineHighlight");
     QTextEdit::ExtraSelection highlightSelection;
     highlightSelection.cursor = cursor;
     highlightSelection.format.setBackground(highlightColor);
     highlightSelection.format.setProperty(QTextFormat::FullWidthSelection, true);
     highlightSelection.cursor.clearSelection();
     return highlightSelection;
+}
+
+QTextEdit::ExtraSelection createLineHighlightSelection(const QTextCursor &cursor)
+{
+    QColor highlightColor = ConfigColor("lineHighlight");
+    return createLineHighlight(cursor, highlightColor);
+}
+
+
+QTextEdit::ExtraSelection createLineHighlightPC(const QTextCursor &cursor)
+{
+    QColor highlightColor = ConfigColor("highlightPC");
+    return createLineHighlight(cursor, highlightColor);
+}
+
+QTextEdit::ExtraSelection createLineHighlightBP(const QTextCursor &cursor)
+{
+    QColor highlightColor = ConfigColor("gui.breakpoint_background");
+    return createLineHighlight(cursor, highlightColor);
 }

--- a/src/common/SelectionHighlight.h
+++ b/src/common/SelectionHighlight.h
@@ -6,7 +6,41 @@
 class QPlainTextEdit;
 class QString;
 
+/**
+ * @brief createSameWordsSelections se
+ * @param textEdit
+ * @param word
+ * @return
+ */
 QList<QTextEdit::ExtraSelection> createSameWordsSelections(QPlainTextEdit *textEdit, const QString &word);
+
+/**
+ * @brief createLineHighlight
+ * @param cursor - a Cursor object represents the line to be highlighted
+ * @param highlightColor - the color to be used for highlighting. The color is decided by the callee for different usages (BP, PC, Current line, ...)
+ * @return ExtraSelection with highlighted line
+ */
+QTextEdit::ExtraSelection createLineHighlight(const QTextCursor &cursor, QColor highlightColor);
+
+/**
+ * @brief This function responsible to highlight the currently selected line 
+ * @param cursor - a Cursor object represents the line to be highlighted
+ * @return ExtraSelection with highlighted line
+ */
 QTextEdit::ExtraSelection createLineHighlightSelection(const QTextCursor &cursor);
+
+/**
+ * @brief This function responsible to highlight the program counter line 
+ * @param cursor - a Cursor object represents the line to be highlighted
+ * @return ExtraSelection with highlighted line
+ */
+QTextEdit::ExtraSelection createLineHighlightPC(const QTextCursor &cursor);
+
+/**
+ * @brief This function responsible to highlight a line with breakpoint
+ * @param cursor - a Cursor object represents the line to be highlighted
+ * @return ExtraSelection with highlighted line
+ */
+QTextEdit::ExtraSelection createLineHighlightBP(const QTextCursor &cursor);
 
 #endif //CUTTER_SELECTIONHIGHLIGHT_H

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1802,6 +1802,19 @@ QList<RVA> CutterCore::getBreakpointsAddresses()
     return bpAddresses;
 }
 
+QList<RVA> CutterCore::getBreakpointsInFunction(RVA funcAddr)
+{
+    QList<RVA> allBreakpoints = getBreakpointsAddresses();
+    QList<RVA> functionBreakpoints;
+
+    // Use std manipulations to take only the breakpoints that belong to this function
+    std::copy_if(allBreakpoints.begin(),
+             allBreakpoints.end(),
+             std::back_inserter(functionBreakpoints),
+             [this, funcAddr](RVA BPadd) { return getFunctionStart(BPadd) == funcAddr; });
+    return functionBreakpoints;
+}
+
 bool CutterCore::isBreakpoint(const QList<RVA> &breakpoints, RVA addr)
 {
     return breakpoints.contains(addr);

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -327,6 +327,11 @@ public:
     void disableBreakpoint(RVA addr);
     bool isBreakpoint(const QList<RVA> &breakpoints, RVA addr);
     QList<RVA> getBreakpointsAddresses();
+    
+    /**
+     * @brief Get all breakpoinst that are belong to a functions at this address
+     */
+    QList<RVA> getBreakpointsInFunction(RVA funcAddr);
     QString getActiveDebugPlugin();
     QStringList getDebugPlugins();
     void setDebugPlugin(QString plugin);

--- a/src/widgets/DecompilerWidget.h
+++ b/src/widgets/DecompilerWidget.h
@@ -1,6 +1,7 @@
 #ifndef DECOMPILERWIDGET_H
 #define DECOMPILERWIDGET_H
 
+#include <QTextEdit>
 #include <memory>
 
 #include "core/Cutter.h"
@@ -29,6 +30,7 @@ public:
 public slots:
     void showDisasContextMenu(const QPoint &pt);
 
+    void highlightPC();
 private slots:
     void fontsUpdatedSlot();
     void colorsUpdatedSlot();
@@ -77,6 +79,26 @@ private:
      * referenced from the address under cursor
      */
     void seekToReference();
+
+    /**
+     * @brief Retrieve the Cursor for a location as close as possible to the given address
+     * @param addr - an address in the decompiled function
+     * @return a Cursor object for the given address
+     */
+    QTextCursor getCursorForAddress(RVA addr);
+
+    /**
+     * @brief Append a highlighted line to the TextEdit
+     * @param extraSelection - an ExtraSelection object colored with the appropriate color
+     * @return True on success, otherwise False
+     */
+    bool colorLine(QTextEdit::ExtraSelection extraSelection);
+
+    /**
+     * @brief This function responsible to highlight all the breakpoints in the decompiler view.
+     * It will also run when a breakpoint is added, removed or modified.
+     */
+    void highlightBreakpoints();
 };
 
 #endif // DECOMPILERWIDGET_H


### PR DESCRIPTION

**Detailed description**

This pull request implements the feature of showing breakpoints and PC highlighted in the decompiler widget.

![ezgif-6-c8e570e8e5b4](https://user-images.githubusercontent.com/20182642/71174524-127ab500-226e-11ea-8f62-7d983c5fc614.gif)




**Test plan (required)**

1) Add breakpoints, remove breakpoints
2) Step in a function and see the PC changes
3) Change functions and see that everything works fine

**Closing issues**


