### PR TITLE
Workaround for new debug widgets being opened in normal mode.

### DIFF
--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -677,7 +677,8 @@ void MainWindow::readSettingsOrDefault()
     // make sure all DockWidgets are part of the MainWindow
     // also show them, so newly installed plugin widgets are shown right away
     for (auto dockWidget : dockWidgets) {
-        if (dockWidgetArea(dockWidget) == Qt::DockWidgetArea::NoDockWidgetArea) {
+        if (dockWidgetArea(dockWidget) == Qt::DockWidgetArea::NoDockWidgetArea &&
+            !isDebugWidget(dockWidget)) {
             addDockWidget(Qt::DockWidgetArea::TopDockWidgetArea, dockWidget);
             dockWidget->show();
         }
@@ -863,6 +864,18 @@ void MainWindow::updateDockActionsChecked()
     for (auto i = dockWidgetsOfAction.constBegin(); i != dockWidgetsOfAction.constEnd(); i++) {
         updateDockActionChecked(i.key());
     }
+}
+
+bool MainWindow::isDebugWidget(QDockWidget *dock) const
+{
+    return dock == stackDock ||
+           dock == registersDock ||
+           dock == backtraceDock ||
+           dock == threadsDock ||
+           dock == memoryMapDock ||
+           dock == breakpointDock ||
+           dock == processesDock ||
+           dock == registerRefsDock;
 }
 
 MemoryWidgetType MainWindow::getMemoryWidgetTypeToRestore()

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -288,6 +288,12 @@ private:
     void updateDockActionsChecked();
     void setOverviewData();
     bool isOverviewActive();
+    /**
+     * @brief Check if a widget is one of debug specific dock widgets.
+     * @param dock
+     * @return true for debug specific widgets, false for all other including common dock widgets.
+     */
+    bool isDebugWidget(QDockWidget *dock) const;
 
     MemoryWidgetType getMemoryWidgetTypeToRestore();
 


### PR DESCRIPTION
 <!-- Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request. -->


**Detailed description**

<!-- Explain the **details** for making this change. What existing problem does the pull request solve? Please provide enough information so that others can review your pull request -->


**Test plan (required)**

1. delete Cutter.in
2. open Cutter 1.9
3. open Cutter with fix
4. observe that threads and process widgets are not opened
5. switch to debug mode
6. make sure its possible to open thread and process widgets
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**

Closes #1941
<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
