### PR TITLE
Debug improvements and fixes

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -3115,9 +3115,7 @@ void CutterCore::handleREvent(int type, void *data)
     }
     case R_EVENT_DEBUG_PROCESS_FINISHED: {
         auto ev = reinterpret_cast<REventDebugProcessFinished*>(data);
-        QMessageBox msgBox;
-        msgBox.setText(tr("Debugged process exited (") + QString::number(ev->pid) + ")");
-        msgBox.exec();
+        emit debugProcessFinished(ev->pid);
         break;
     }
     default:

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -3113,6 +3113,13 @@ void CutterCore::handleREvent(int type, void *data)
         emit classAttrsChanged(QString::fromUtf8(ev->attr.class_name));
         break;
     }
+    case R_EVENT_DEBUG_PROCESS_FINISHED: {
+        auto ev = reinterpret_cast<REventDebugProcessFinished*>(data);
+        QMessageBox msgBox;
+        msgBox.setText(tr("Debugged process exited (") + QString::number(ev->pid) + ")");
+        msgBox.exec();
+        break;
+    }
     default:
         break;
     }

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -530,6 +530,11 @@ signals:
     void classRenamed(const QString &oldName, const QString &newName);
     void classAttrsChanged(const QString &cls);
 
+    /**
+     * @brief end of current debug event received
+     */
+    void debugProcessFinished(int pid);
+
     void attachedRemote(bool successfully);
 
     void projectSaved(bool successfully, const QString &name);

--- a/src/widgets/BacktraceWidget.cpp
+++ b/src/widgets/BacktraceWidget.cpp
@@ -30,7 +30,7 @@ BacktraceWidget::BacktraceWidget(MainWindow *main, QAction *action) :
     });
 
     connect(Core(), &CutterCore::refreshAll, this, &BacktraceWidget::updateContents);
-    connect(Core(), &CutterCore::seekChanged, this, &BacktraceWidget::updateContents);
+    connect(Core(), &CutterCore::registersChanged, this, &BacktraceWidget::updateContents);
     connect(Config(), &Configuration::fontsUpdated, this, &BacktraceWidget::fontsUpdatedSlot);
 }
 

--- a/src/widgets/BacktraceWidget.cpp
+++ b/src/widgets/BacktraceWidget.cpp
@@ -38,9 +38,10 @@ BacktraceWidget::~BacktraceWidget() {}
 
 void BacktraceWidget::updateContents()
 {
-    if (!refreshDeferrer->attemptRefresh(nullptr)) {
+    if (!refreshDeferrer->attemptRefresh(nullptr) || Core()->isDebugTaskInProgress()) {
         return;
     }
+
     setBacktraceGrid();
 }
 

--- a/src/widgets/DebugActions.cpp
+++ b/src/widgets/DebugActions.cpp
@@ -231,6 +231,7 @@ void DebugActions::onAttachedRemoteDebugger(bool successfully)
         attachRemoteDialog();
     } else {
         delete remoteDialog;
+        remoteDialog = nullptr;
         attachRemoteDebugger();
     }
 }

--- a/src/widgets/DebugActions.cpp
+++ b/src/widgets/DebugActions.cpp
@@ -110,6 +110,12 @@ DebugActions::DebugActions(QToolBar *toolBar, MainWindow *main) :
         actionContinueUntilCall, actionContinueUntilSyscall};
     toggleConnectionActions = {actionAttach, actionStartRemote};
 
+    connect(Core(), &CutterCore::debugProcessFinished, this, [ = ](int pid) {
+        QMessageBox msgBox;
+        msgBox.setText(tr("Debugged process exited (") + QString::number(pid) + ")");
+        msgBox.exec();
+    });
+
     connect(Core(), &CutterCore::debugTaskStateChanged, this, [ = ]() {
         bool disableToolbar = Core()->isDebugTaskInProgress();
         if (Core()->currentlyDebugging) {

--- a/src/widgets/ProcessesWidget.cpp
+++ b/src/widgets/ProcessesWidget.cpp
@@ -56,7 +56,7 @@ ProcessesWidget::ProcessesWidget(MainWindow *main, QAction *action) :
     connect(ui->quickFilterView, &QuickFilterView::filterTextChanged, modelFilter,
             &ProcessesFilterModel::setFilterWildcard);
     connect(Core(), &CutterCore::refreshAll, this, &ProcessesWidget::updateContents);
-    connect(Core(), &CutterCore::seekChanged, this, &ProcessesWidget::updateContents);
+    connect(Core(), &CutterCore::registersChanged, this, &ProcessesWidget::updateContents);
     connect(Core(), &CutterCore::debugTaskStateChanged, this, &ProcessesWidget::updateContents);
     // Seek doesn't necessarily change when switching processes
     connect(Core(), &CutterCore::switchedProcess, this, &ProcessesWidget::updateContents);

--- a/src/widgets/ProcessesWidget.cpp
+++ b/src/widgets/ProcessesWidget.cpp
@@ -72,16 +72,16 @@ void ProcessesWidget::updateContents()
         return;
     }
 
-    if (Core()->currentlyDebugging) {
-        setProcessesGrid();
-    } else {
+    if (!Core()->currentlyDebugging) {
         // Remove rows from the previous debugging session
         modelProcesses->removeRows(0, modelProcesses->rowCount());
+        return;
     }
 
-    if (Core()->isDebugTaskInProgress() || !Core()->currentlyDebugging) {
+    if (Core()->isDebugTaskInProgress()) {
         ui->viewProcesses->setDisabled(true);
     } else {
+        setProcessesGrid();
         ui->viewProcesses->setDisabled(false);
     }
 }

--- a/src/widgets/SectionsWidget.cpp
+++ b/src/widgets/SectionsWidget.cpp
@@ -237,7 +237,7 @@ void SectionsWidget::initConnects()
 
 void SectionsWidget::refreshSections()
 {
-    if (!sectionsRefreshDeferrer->attemptRefresh(nullptr)) {
+    if (!sectionsRefreshDeferrer->attemptRefresh(nullptr) || Core()->isDebugTaskInProgress()) {
         return;
     }
     sectionsModel->beginResetModel();

--- a/src/widgets/StackWidget.cpp
+++ b/src/widgets/StackWidget.cpp
@@ -58,7 +58,7 @@ StackWidget::~StackWidget() = default;
 
 void StackWidget::updateContents()
 {
-    if (!refreshDeferrer->attemptRefresh(nullptr)) {
+    if (!refreshDeferrer->attemptRefresh(nullptr) || Core()->isDebugTaskInProgress()) {
         return;
     }
 

--- a/src/widgets/StackWidget.cpp
+++ b/src/widgets/StackWidget.cpp
@@ -37,7 +37,7 @@ StackWidget::StackWidget(MainWindow *main, QAction *action) :
     });
 
     connect(Core(), &CutterCore::refreshAll, this, &StackWidget::updateContents);
-    connect(Core(), &CutterCore::seekChanged, this, &StackWidget::updateContents);
+    connect(Core(), &CutterCore::registersChanged, this, &StackWidget::updateContents);
     connect(Core(), &CutterCore::stackChanged, this, &StackWidget::updateContents);
     connect(Config(), &Configuration::fontsUpdated, this, &StackWidget::fontsUpdatedSlot);
     connect(viewStack, SIGNAL(doubleClicked(const QModelIndex &)), this,

--- a/src/widgets/ThreadsWidget.cpp
+++ b/src/widgets/ThreadsWidget.cpp
@@ -71,16 +71,16 @@ void ThreadsWidget::updateContents()
         return;
     }
 
-    if (Core()->currentlyDebugging) {
-        setThreadsGrid();
-    } else {
+    if (!Core()->currentlyDebugging) {
         // Remove rows from the previous debugging session
         modelThreads->removeRows(0, modelThreads->rowCount());
+        return;
     }
 
-    if (Core()->isDebugTaskInProgress() || !Core()->currentlyDebugging) {
+    if (Core()->isDebugTaskInProgress()) {
         ui->viewThreads->setDisabled(true);
     } else {
+        setThreadsGrid();
         ui->viewThreads->setDisabled(false);
     }
 }

--- a/src/widgets/ThreadsWidget.cpp
+++ b/src/widgets/ThreadsWidget.cpp
@@ -54,7 +54,7 @@ ThreadsWidget::ThreadsWidget(MainWindow *main, QAction *action) :
     connect(ui->quickFilterView, &QuickFilterView::filterTextChanged, modelFilter,
             &ThreadsFilterModel::setFilterWildcard);
     connect(Core(), &CutterCore::refreshAll, this, &ThreadsWidget::updateContents);
-    connect(Core(), &CutterCore::seekChanged, this, &ThreadsWidget::updateContents);
+    connect(Core(), &CutterCore::registersChanged, this, &ThreadsWidget::updateContents);
     connect(Core(), &CutterCore::debugTaskStateChanged, this, &ThreadsWidget::updateContents);
     // Seek doesn't necessarily change when switching threads/processes
     connect(Core(), &CutterCore::switchedThread, this, &ThreadsWidget::updateContents);

--- a/src/widgets/VisualNavbar.cpp
+++ b/src/widgets/VisualNavbar.cpp
@@ -291,6 +291,12 @@ QList<QString> VisualNavbar::sectionsForAddress(RVA address)
 QString VisualNavbar::toolTipForAddress(RVA address)
 {
     QString ret = "Address: " + RAddressString(address);
+
+    // Don't append sections when a debug task is in progress to avoid freezing the interface
+    if (Core()->isDebugTaskInProgress()) {
+        return ret;
+    }
+
     auto sections = sectionsForAddress(address);
     if (sections.count()) {
         ret += "\nSections: \n";


### PR DESCRIPTION
**Detailed description**

- Prevented the refresh of some widgets that are available during debug to avoid freezing on a request that requires lock acquisition(for example, gdb and windbg can only execute one command at the same time and you will have to wait until the first one is over) - This should be replaced with async functionality in the future
- Made the interface quicker by avoiding widget updates every time seek changed (which also prevents the previously mentioned freezes caused by seek)
- Added a msgbox to notify the user when the debugged process exited based on revent.
- Fixed a crash in the remote debug dialog that we missed because of an already fixed r2 gdb reopen crash.

**Test plan (required)**

- See that a message pops up when the process exits (continue once to get to the exit and then step/continue again to exit)
- Verify that stack widget doesn't freeze the interface every time you move up or down in the disassembly view
- Attempt to re-open remote debug multiple times
- Attempt to move around in the disassembly view and switch between Stack, Threads, Processes, Backtrace, Visual Navbar and Sections Widget widgets while in remote debug with a task in progress (step over `sleep(20)`) and see that the interface doesn't freeze


