### PR TITLE
When using add breakpoint button add it not toggle.

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1736,7 +1736,15 @@ void CutterCore::toggleBreakpoint(RVA addr)
 
 void CutterCore::toggleBreakpoint(QString addr)
 {
-    cmd("dbs " + addr);
+    cmdRaw("dbs " + addr);
+    emit instructionChanged(addr.toULongLong());
+    emit breakpointsChanged();
+}
+
+
+void CutterCore::addBreakpoint(QString addr)
+{
+    cmdRaw("db " + addr);
     emit instructionChanged(addr.toULongLong());
     emit breakpointsChanged();
 }

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -319,6 +319,7 @@ public:
     void stepDebug();
     void stepOverDebug();
     void stepOutDebug();
+    void addBreakpoint(QString addr);
     void toggleBreakpoint(RVA addr);
     void toggleBreakpoint(QString addr);
     void delBreakpoint(RVA addr);

--- a/src/widgets/BreakpointWidget.cpp
+++ b/src/widgets/BreakpointWidget.cpp
@@ -203,7 +203,7 @@ void BreakpointWidget::addBreakpointDialog()
         if (!bps.isEmpty()) {
             QStringList bpList = bps.split(QLatin1Char(' '), QString::SkipEmptyParts);
             for (const QString &bp : bpList) {
-                Core()->toggleBreakpoint(bp);
+                Core()->addBreakpoint(bp);
             }
         }
     }


### PR DESCRIPTION
 <!-- Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request. -->


**Detailed description**

Clicking a button "Add breakpoint" shouldn't remove a breakpoint. In case of conflict it should either fail or worst case replace old breakpoint with new one.

**Test plan (required)**

* Start debugging
* Add a breakpoint
* Trying adding breakpoint in the address of existing one using breakpoint widget add button. Make sure old breakpoint isn't removed and there is a message in console widget.
* Test that toggling breakpoint  isn't broken. Using F2 in disassebmly widget try adding and removing it.

<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**
Closes #1952
<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
