### PR TITLE
Improve graph HighDPI scaling

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -186,6 +186,12 @@ int main(int argc, char *argv[])
     initializeSettings();
 
     QCoreApplication::setAttribute(Qt::AA_ShareOpenGLContexts); // needed for QtWebEngine inside Plugins
+#ifdef Q_OS_WIN
+    QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
+    #endif
+#endif
 
     CutterApplication a(argc, argv);
 


### PR DESCRIPTION
 <!-- Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request. -->


**Detailed description**

<!-- Explain the **details** for making this change. What existing problem does the pull request solve? Please provide enough information so that others can review your pull request -->


**Test plan (required)**

* Make sure graph cache is reenabled

Environments:
* Linux + qt wayland :heavy_check_mark: 
* Linux + xcb backend :heavy_check_mark:  slightly blurry, probably qt+xwayland limitation
* Windows  - :heavy_check_mark: 
* macOS - :heavy_check_mark: 

Things to test:
* Test with two displays one with scaling factor 1 other 2 or 1.5 if supported by OS. Scaling factor set in OS display configuration for each monitor.
* After dragging to other screen try changing global scaling factor (ctrl++, ctrl+- with focus in disassembly widget)
* In graph right click inside and outside block, context menu content should change
* Zoom using mousewheel, zoom should focus to mouse cursor position
* Text size in context menu and top menu bar should match the scaling in properly scaled system software like file browser
* text size relative to button size shouldn't change when switching between screens
* hexwidget drawing isn't broken


<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**
Closes #1825, closes #1959
<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
