### PR TITLE
Add more breakpoint editing options

### DIFF
--- a/src/Cutter.pro
+++ b/src/Cutter.pro
@@ -385,7 +385,8 @@ SOURCES += \
     menus/AddressableItemContextMenu.cpp \
     common/AddressableItemModel.cpp \
     widgets/ListDockWidget.cpp \
-    dialogs/MultitypeFileSaveDialog.cpp
+    dialogs/MultitypeFileSaveDialog.cpp \
+    widgets/BoolToggleDelegate.cpp
 
 GRAPHVIZ_SOURCES = \
     widgets/GraphvizLayout.cpp
@@ -528,7 +529,8 @@ HEADERS  += \
     common/AddressableItemModel.h \
     widgets/ListDockWidget.h \
     widgets/AddressableItemList.h \
-    dialogs/MultitypeFileSaveDialog.h
+    dialogs/MultitypeFileSaveDialog.h \
+    widgets/BoolToggleDelegate.cpp
 
 GRAPHVIZ_HEADERS = widgets/GraphGridLayout.h
 

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1776,6 +1776,15 @@ void CutterCore::disableBreakpoint(RVA addr)
     emit breakpointsChanged();
 }
 
+void CutterCore::setBreakpointTrace(int index, bool enabled)
+{
+    if (enabled) {
+        cmd(QString("dbite %1").arg(index));
+    } else {
+        cmd(QString("dbitd %1").arg(index));
+    }
+}
+
 QList<BreakpointDescription> CutterCore::getBreakpoints()
 {
     QList<BreakpointDescription> ret;

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -326,6 +326,13 @@ public:
     void delAllBreakpoints();
     void enableBreakpoint(RVA addr);
     void disableBreakpoint(RVA addr);
+    /**
+     * @brief Enable or disable breakpoint tracing.
+     * @param index - breakpoint index to modify
+     * @param enabled - true if tracing should be enabled
+     */
+    void setBreakpointTrace(int index, bool enabled);
+
     bool isBreakpoint(const QList<RVA> &breakpoints, RVA addr);
     QList<RVA> getBreakpointsAddresses();
     

--- a/src/widgets/BoolToggleDelegate.cpp
+++ b/src/widgets/BoolToggleDelegate.cpp
@@ -1,0 +1,32 @@
+#include "BoolToggleDelegate.h"
+#include <QEvent>
+
+BoolTogggleDelegate::BoolTogggleDelegate(QObject *parent)
+    : QStyledItemDelegate(parent)
+{
+}
+
+QWidget *BoolTogggleDelegate::createEditor(QWidget *parent,
+                                           const QStyleOptionViewItem &option,
+                                           const QModelIndex &index) const
+{
+    if (index.data().canConvert<bool>()) {
+        return nullptr;
+    }
+    return QStyledItemDelegate::createEditor(parent, option, index);
+}
+
+bool BoolTogggleDelegate::editorEvent(QEvent *event, QAbstractItemModel *model,
+                                      const QStyleOptionViewItem &option, const QModelIndex &index)
+{
+    if (model->flags(index).testFlag(Qt::ItemFlag::ItemIsEditable)) {
+        if (event->type() == QEvent::MouseButtonDblClick) {
+            auto data = index.data();
+            if (data.canConvert<bool>()) {
+                model->setData(index, !data.toBool());
+                return true;
+            }
+        }
+    }
+    return QStyledItemDelegate::editorEvent(event, model, option, index);
+}

--- a/src/widgets/BoolToggleDelegate.cpp
+++ b/src/widgets/BoolToggleDelegate.cpp
@@ -10,7 +10,7 @@ QWidget *BoolTogggleDelegate::createEditor(QWidget *parent,
                                            const QStyleOptionViewItem &option,
                                            const QModelIndex &index) const
 {
-    if (index.data().canConvert<bool>()) {
+    if (index.data(Qt::EditRole).type() == QVariant::Bool) {
         return nullptr;
     }
     return QStyledItemDelegate::createEditor(parent, option, index);
@@ -21,8 +21,8 @@ bool BoolTogggleDelegate::editorEvent(QEvent *event, QAbstractItemModel *model,
 {
     if (model->flags(index).testFlag(Qt::ItemFlag::ItemIsEditable)) {
         if (event->type() == QEvent::MouseButtonDblClick) {
-            auto data = index.data();
-            if (data.canConvert<bool>()) {
+            auto data = index.data(Qt::EditRole);
+            if (data.type() == QVariant::Bool) {
                 model->setData(index, !data.toBool());
                 return true;
             }

--- a/src/widgets/BoolToggleDelegate.h
+++ b/src/widgets/BoolToggleDelegate.h
@@ -1,0 +1,20 @@
+#ifndef BOOLTOGGGLEDELEGATE_H
+#define BOOLTOGGGLEDELEGATE_H
+
+#include <QStyledItemDelegate>
+
+class BoolTogggleDelegate : public QStyledItemDelegate
+{
+public:
+    BoolTogggleDelegate(QObject *parent = nullptr);
+
+    QWidget *createEditor(QWidget *parent,
+                          const QStyleOptionViewItem &option,
+                          const QModelIndex &index) const override;
+
+    bool editorEvent(QEvent *event, QAbstractItemModel *model, const QStyleOptionViewItem &option,
+                     const QModelIndex &index) override;
+};
+
+
+#endif // BOOLTOGGGLEDELEGATE_H

--- a/src/widgets/BreakpointWidget.cpp
+++ b/src/widgets/BreakpointWidget.cpp
@@ -6,7 +6,7 @@
 #include <QMenu>
 
 BreakpointModel::BreakpointModel(QList<BreakpointDescription> *breakpoints, QObject *parent)
-    : QAbstractListModel(parent),
+    : AddressableItemModel<QAbstractListModel>(parent),
       breakpoints(breakpoints)
 {
 }
@@ -74,10 +74,17 @@ QVariant BreakpointModel::headerData(int section, Qt::Orientation, int role) con
     }
 }
 
-BreakpointProxyModel::BreakpointProxyModel(BreakpointModel *sourceModel, QObject *parent)
-    : QSortFilterProxyModel(parent)
+RVA BreakpointModel::address(const QModelIndex &index) const
 {
-    setSourceModel(sourceModel);
+    if (index.row() < breakpoints->count()) {
+        return breakpoints->at(index.row()).addr;
+    }
+    return RVA_INVALID;
+}
+
+BreakpointProxyModel::BreakpointProxyModel(BreakpointModel *sourceModel, QObject *parent)
+    : AddressableFilterProxyModel(sourceModel, parent)
+{
 }
 
 bool BreakpointProxyModel::filterAcceptsRow(int row, const QModelIndex &parent) const
@@ -178,7 +185,7 @@ void BreakpointWidget::on_breakpointTreeView_doubleClicked(const QModelIndex &in
 {
     BreakpointDescription item = index.data(
                                      BreakpointModel::BreakpointDescriptionRole).value<BreakpointDescription>();
-    Core()->seekAndShow(item.addr);
+    //Core()->seekAndShow(item.addr);
 }
 
 void BreakpointWidget::showBreakpointContextMenu(const QPoint &pt)

--- a/src/widgets/BreakpointWidget.h
+++ b/src/widgets/BreakpointWidget.h
@@ -28,19 +28,25 @@ class BreakpointModel: public AddressableItemModel<QAbstractListModel>
     friend BreakpointWidget;
 
 private:
-    QList<BreakpointDescription> *breakpoints;
+    QList<BreakpointDescription> breakpoints;
 
 public:
     enum Column { AddrColumn = 0, PermColumn, HwColumn, TraceColumn, EnabledColumn, ColumnCount };
     enum Role { BreakpointDescriptionRole = Qt::UserRole };
 
-    BreakpointModel(QList<BreakpointDescription> *breakpoints, QObject *parent = nullptr);
+    BreakpointModel(QObject *parent = nullptr);
+
+    void refresh();
 
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     int columnCount(const QModelIndex &parent = QModelIndex()) const override;
 
     QVariant data(const QModelIndex &index, int role) const override;
-    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+    QVariant headerData(int section, Qt::Orientation orientation,
+                        int role = Qt::DisplayRole) const override;
+    bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
+    Qt::ItemFlags flags(const QModelIndex &index) const override;
+
 
     RVA address(const QModelIndex &index) const override;
 };
@@ -70,8 +76,6 @@ public:
     ~BreakpointWidget();
 
 private slots:
-    void on_breakpointTreeView_doubleClicked(const QModelIndex &index);
-    void showBreakpointContextMenu(const QPoint &pt);
     void delBreakpoint();
     void toggleBreakpoint();
     void addBreakpointDialog();

--- a/src/widgets/BreakpointWidget.h
+++ b/src/widgets/BreakpointWidget.h
@@ -4,6 +4,7 @@
 
 #include "core/Cutter.h"
 #include "CutterDockWidget.h"
+#include "AddressableItemModel.h"
 
 #include <QAbstractListModel>
 #include <QSortFilterProxyModel>
@@ -20,7 +21,7 @@ class MainWindow;
 class QTreeWidgetItem;
 class BreakpointWidget;
 
-class BreakpointModel: public QAbstractListModel
+class BreakpointModel: public AddressableItemModel<QAbstractListModel>
 {
     Q_OBJECT
 
@@ -35,16 +36,18 @@ public:
 
     BreakpointModel(QList<BreakpointDescription> *breakpoints, QObject *parent = nullptr);
 
-    int rowCount(const QModelIndex &parent = QModelIndex()) const;
-    int columnCount(const QModelIndex &parent = QModelIndex()) const;
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    int columnCount(const QModelIndex &parent = QModelIndex()) const override;
 
-    QVariant data(const QModelIndex &index, int role) const;
-    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
+    QVariant data(const QModelIndex &index, int role) const override;
+    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+
+    RVA address(const QModelIndex &index) const override;
 };
 
 
 
-class BreakpointProxyModel : public QSortFilterProxyModel
+class BreakpointProxyModel : public AddressableFilterProxyModel
 {
     Q_OBJECT
 

--- a/src/widgets/BreakpointWidget.h
+++ b/src/widgets/BreakpointWidget.h
@@ -91,6 +91,8 @@ private:
     QAction *actionToggleBreakpoint = nullptr;
 
     void setScrollMode();
+    QVector<RVA> getSelectedAddresses() const;
 
     RefreshDeferrer *refreshDeferrer;
+    bool editing = false;
 };

--- a/src/widgets/BreakpointWidget.ui
+++ b/src/widgets/BreakpointWidget.ui
@@ -28,7 +28,7 @@
      <number>0</number>
     </property>
     <item>
-     <widget class="CutterTreeView" name="breakpointTreeView">
+     <widget class="AddressableItemList&lt;&gt;" name="breakpointTreeView">
       <property name="styleSheet">
        <string notr="true">CutterTreeView::item
 {
@@ -80,9 +80,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>CutterTreeView</class>
+   <class>AddressableItemList&lt;&gt;</class>
    <extends>QTreeView</extends>
-   <header>widgets/CutterTreeView.h</header>
+   <header>widgets/AddressableItemList.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/widgets/FlagsWidget.ui
+++ b/src/widgets/FlagsWidget.ui
@@ -101,6 +101,9 @@
    <property name="shortcut">
     <string>N</string>
    </property>
+   <property name="shortcutContext">
+    <enum>Qt::WidgetWithChildrenShortcut</enum>
+   </property>
   </action>
   <action name="actionDelete">
    <property name="text">
@@ -108,6 +111,9 @@
    </property>
    <property name="shortcut">
     <string>Del</string>
+   </property>
+   <property name="shortcutContext">
+    <enum>Qt::WidgetWithChildrenShortcut</enum>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
 <!-- Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request. -->


**Detailed description**
* Convert breakpoint widget to AddressableItemWidget
* When selecting multiple breakpoints and pressing delete key delete all of them
* Allow toggling breakpoint trace and active properties by doublicking them in table

**Test plan (required)**

* start debuging
* Create a few breakpoints
* doubleclick a breakpoint in breakpoint widget, make sure seek works
* rightclick an item in breakpoint widget,  it should contain actions from AddResableItem widget, and toggle, delete actions.
   * test at least one AddressableItemWidget action using menu and keyboard shortcut
   * test that toggle using space and menu works
* test that deleting single breakpoint works (using menu, button, keyboard)
* test that deleting multiple selected breakpoints work

Part2
* start debuging
* create 3 breakpoints
* disable first one by double clicking "active" column
* enable trace mode for second breakpoint by double click in trace column
* verify that breakpoint state reported by `dbj` matches previous actions
* resume executable by pressing continue
* make sure debugger stops on third breakpoint and printed trace message for second one

<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Observed issues**
Changing trace property for first breakpoint doesn't work. Due to r2 sharing logic for handling address and index argument in db command. Need to create an issue for that.

When breakpoint is disabled it is still triggered and printed in console, but automatically continued. Not sure if this is intended behavior or not. I expected disabled breakpoint not to be triggered at all. What happens when it has command asigned?

**Closing issues**

<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
