### PR TITLE
Fix debug not working with paths that have a space in them

### DIFF
--- a/src/widgets/DebugActions.cpp
+++ b/src/widgets/DebugActions.cpp
@@ -303,7 +303,7 @@ void DebugActions::attachProcess(int pid)
 void DebugActions::startDebug()
 {
     // check if file is executable before starting debug
-    QString filename = Core()->getConfig("file.path").section(QLatin1Char(' '), 0, 0);
+    QString filename = Core()->getConfig("file.path");
 
     QFileInfo info(filename);
     if (!Core()->currentlyDebugging && !info.isExecutable()) {


### PR DESCRIPTION
**Detailed description**

Opening paths with spaces didn't work because of a now fixed issue in r2 [#15697](https://github.com/radareorg/radare2/pull/15697) and a workaround in Cutter.

**Test plan (required)**

Start debug on a file with spaces in it's path.

**Closing issues**

closes #1961
