### PR TITLE
solves multiple instructions preview

### DIFF
--- a/src/dialogs/EditInstructionDialog.cpp
+++ b/src/dialogs/EditInstructionDialog.cpp
@@ -46,13 +46,13 @@ void EditInstructionDialog::updatePreview(const QString &input)
         return;
     } else if (editMode == EDIT_BYTES) {
         QByteArray data = CutterCore::hexStringToBytes(input);
-        result = Core()->disassemble(data).trimmed();
+        result = Core()->disassemble(data).simplified();
     } else if (editMode == EDIT_TEXT) {
         QByteArray data = Core()->assemble(input);
         result = CutterCore::bytesToHexString(data).trimmed();
     }
 
-    if (result.isEmpty() || result.contains(QLatin1Char('\n'))) {
+    if (result.isEmpty() || result.contains(QLatin1Char('\n')) || result.contains("invalid")) {
         ui->instructionLabel->setText("Unknown Instruction");
     } else {
         ui->instructionLabel->setText(result);

--- a/src/dialogs/EditInstructionDialog.cpp
+++ b/src/dialogs/EditInstructionDialog.cpp
@@ -52,7 +52,7 @@ void EditInstructionDialog::updatePreview(const QString &input)
         result = CutterCore::bytesToHexString(data).trimmed();
     }
 
-    if (result.isEmpty() || result.contains(QLatin1Char('\n')) || result.contains("invalid")) {
+    if (result.isEmpty() || result.contains("invalid")) {
         ui->instructionLabel->setText("Unknown Instruction");
     } else {
         ui->instructionLabel->setText(result);


### PR DESCRIPTION
Description:

- Multiple instructions doesn't throw any error now
- before `90909090` yields a `Unknown Instruction` preview. now it yields `nop nop nop nop`

closes #1940 