### PR TITLE
Added a ';' delimiter in instruction preview

### DIFF
--- a/src/dialogs/EditInstructionDialog.cpp
+++ b/src/dialogs/EditInstructionDialog.cpp
@@ -8,6 +8,8 @@ EditInstructionDialog::EditInstructionDialog(InstructionEditMode editMode, QWidg
     editMode(editMode)
 {
     ui->setupUi(this);
+    ui->lineEdit->setMinimumWidth(400);
+    ui->instructionLabel->setWordWrap(true);
     setWindowFlags(windowFlags() & (~Qt::WindowContextHelpButtonHint));
 
     connect(ui->lineEdit, SIGNAL(textEdited(const QString &)), this,
@@ -46,7 +48,7 @@ void EditInstructionDialog::updatePreview(const QString &input)
         return;
     } else if (editMode == EDIT_BYTES) {
         QByteArray data = CutterCore::hexStringToBytes(input);
-        result = Core()->disassemble(data).simplified();
+        result = Core()->disassemble(data).replace('\n', "; ");
     } else if (editMode == EDIT_TEXT) {
         QByteArray data = Core()->assemble(input);
         result = CutterCore::bytesToHexString(data).trimmed();

--- a/src/dialogs/EditInstructionDialog.ui
+++ b/src/dialogs/EditInstructionDialog.ui
@@ -20,6 +20,9 @@
    <property name="spacing">
     <number>2</number>
    </property>
+   <property name="sizeConstraint">
+    <enum>QLayout::SetFixedSize</enum>
+   </property>
    <property name="leftMargin">
     <number>2</number>
    </property>


### PR DESCRIPTION
**Detailed description**

(Continued from #1982)

Instructions are now separated by `; `. Also the dialog box is responsive so there is no overflow.

**Test plan (required)**

- Right Click > Edit > Bytes
- Type your opcodes

![image](https://user-images.githubusercontent.com/30789322/71644419-02db8180-2cee-11ea-85b8-612edc4cb5a9.png)

![image](https://user-images.githubusercontent.com/30789322/71644424-14248e00-2cee-11ea-8911-10f3d79fb2f7.png)
