### PR TITLE
fixes patching multiple instructions

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -609,7 +609,7 @@ QString CutterCore::getInstructionOpcode(RVA addr)
 
 void CutterCore::editInstruction(RVA addr, const QString &inst)
 {
-    cmd("wa " + inst + " @ " + RAddressString(addr));
+    cmd("\"wa " + inst + "\" @ " + RAddressString(addr));
     emit instructionChanged(addr);
 }
 


### PR DESCRIPTION
**Detailed description**

- You can patch multiple instructions (with `;` as a delimiter) at once.

**Test plan (required)**

- Open any binary with write permission.
- Right click on address you want to edit > Edit > Instruction.
- Write your instruction(s) with `;` as delimiter.
- Click Ok.

**Closing Issue**

closes #1939 

**Screenshots**

![image](https://user-images.githubusercontent.com/30789322/71645094-e2fd8b00-2cf8-11ea-83e9-df28d261dee3.png)

![image](https://user-images.githubusercontent.com/30789322/71645095-e7c23f00-2cf8-11ea-889d-2773854beb37.png)

![image](https://user-images.githubusercontent.com/30789322/71645097-ebee5c80-2cf8-11ea-8db3-db71528a8991.png)
