### PR TITLE
Set the Style tab to the default view of Assembly Options dialog

### DIFF
--- a/src/dialogs/preferences/AsmOptionsWidget.ui
+++ b/src/dialogs/preferences/AsmOptionsWidget.ui
@@ -28,7 +28,7 @@
         </sizepolicy>
        </property>
        <property name="currentIndex">
-        <number>1</number>
+        <number>0</number>
        </property>
        <widget class="QWidget" name="asmStyleTab">
         <attribute name="title">


### PR DESCRIPTION


**Detailed description**

The following PR sets the Style tab to be the default view of Assembly Options dialog. Before this PR, the default tab was the Meta tab.


**Test plan (required)**
1. Open Preferences widget
2. Choose Assembly Options
3. See that the default tab is the Style tab


