### PR TITLE
Add a custom telescoping function and improve StackWidget's output

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1180,7 +1180,7 @@ QJsonObject CutterCore::getAddrRefs(RVA addr, int depth) {
 
     // Search for the section the addr is in, avoid duplication for heap/stack with type
     if(!(type & R_ANAL_ADDR_TYPE_HEAP || type & R_ANAL_ADDR_TYPE_STACK)) {
-        // Attempt to find the address withing a map
+        // Attempt to find the address within a map
         RDebugMap *map = r_debug_map_get(core->dbg, addr);
         if (map && map->name && map->name[0]) {
             json["mapname"] = map->name;
@@ -1201,7 +1201,7 @@ QJsonObject CutterCore::getAddrRefs(RVA addr, int depth) {
         }
     }
 
-    // Attempt to find the address withing a function
+    // Attempt to find the address within a function
     RAnalFunction *fcn = r_anal_get_fcn_in(core->anal, addr, 0);
     if (fcn) {
         json["fcn"] = fcn->name;

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1139,9 +1139,148 @@ QJsonDocument CutterCore::getSignatureInfo()
     return cmdj("iCj");
 }
 
-QJsonDocument CutterCore::getStack(int size)
+QList<QJsonObject> CutterCore::getStack(int size, int depth)
 {
-    return cmdj("pxrj " + QString::number(size) + " @ r:SP");
+    QList<QJsonObject> stack;
+    if (!currentlyDebugging) {
+        return stack;
+    }
+
+    CORE_LOCK();
+    bool ret;
+    RVA addr = cmd("dr SP").toULongLong(&ret, 16);
+    if (!ret) {
+        return stack;
+    }
+
+    int base = core->anal->bits;
+    for (int i = 0; i < size; i += base / 8) {
+        if ((base == 32 && addr + i >= UT32_MAX) || (base == 16 && addr + i >= UT16_MAX)) {
+            break;
+        }
+
+        stack.append(getAddrRefs(addr + i, depth));
+    }
+
+    return stack;
+}
+
+QJsonObject CutterCore::getAddrRefs(RVA addr, int depth) {
+    QJsonObject json;
+    if (depth < 1 || addr == UT64_MAX) {
+        return json;
+    }
+
+    CORE_LOCK();
+    int bits = core->assembler->bits;
+    QByteArray buf = QByteArray();
+    ut64 type = r_core_anal_address(core, addr);
+
+    json["addr"] = QString::number(addr);
+
+    // Attempt to find the address withing a map
+    RDebugMap *map = r_debug_map_get(core->dbg, addr);
+    if (map && map->name && map->name[0]) {
+        json["mapname"] = map->name;
+    }
+
+    // Search for the section the addr is in, avoid duplication for heap/stack with mapname
+    if(!(type & R_ANAL_ADDR_TYPE_HEAP || type & R_ANAL_ADDR_TYPE_STACK)) {
+        RBinSection *sect = r_bin_get_section_at(r_bin_cur_object (core->bin), addr, true);
+        // Do not repeat "stack" or "heap" words unnecessarily.
+        if (sect && sect->name[0]) {
+            json["section"] = sect->name;
+        }
+    }
+
+    // Check if the address points to a register
+    RFlagItem *fi = r_flag_get_i(core->flags, addr);
+    if (fi) {
+        RRegItem *r = r_reg_get(core->dbg->reg, fi->name, -1);
+        if (r) {
+            json["reg"] = r->name;
+        }
+    }
+
+    // Attempt to find the address withing a function
+    RAnalFunction *fcn = r_anal_get_fcn_in(core->anal, addr, 0);
+    if (fcn) {
+        json["fcn"] = fcn->name;
+    }
+
+    // Update type and permission information
+    if (type != 0) {
+        if (type & R_ANAL_ADDR_TYPE_HEAP) {
+            json["type"] = "heap";
+        } else if (type & R_ANAL_ADDR_TYPE_STACK) {
+            json["type"] = "stack";
+        } else if (type & R_ANAL_ADDR_TYPE_PROGRAM) {
+            json["type"] = "program";
+        } else if (type & R_ANAL_ADDR_TYPE_LIBRARY) {
+            json["type"] = "library";
+        } else if (type & R_ANAL_ADDR_TYPE_ASCII) {
+            json["type"] = "ascii";
+            json["value"] = QString::number((char)addr);
+        } else if (type & R_ANAL_ADDR_TYPE_SEQUENCE) {
+            json["type"] = "sequence";
+        }
+
+        QString perms = "";
+        if (type & R_ANAL_ADDR_TYPE_READ) {
+            perms += "r";
+        }
+        if (type & R_ANAL_ADDR_TYPE_WRITE) {
+            perms += "w";
+        }
+        if (type & R_ANAL_ADDR_TYPE_EXEC) {
+            RAsmOp op;
+            buf.resize(32);
+            perms += "x";
+            // Instruction disassembly
+            r_io_read_at(core->io, addr, (unsigned char*)buf.data(), buf.size());
+            r_asm_set_pc(core->assembler, addr);
+            r_asm_disassemble(core->assembler, &op, (unsigned char*)buf.data(), buf.size());
+            json["asm"] = r_asm_op_get_asm(&op);
+        }
+
+        if (!perms.isEmpty()) {
+            json["perms"] = perms;
+        }
+    } else {
+        json["value"] = QString::number(addr);
+    }
+
+    // Try to telescope further if depth permits it
+    if ((type & R_ANAL_ADDR_TYPE_READ) && !(type & R_ANAL_ADDR_TYPE_EXEC)) {
+        buf.resize(64);
+        ut32 *n32 = (ut32 *)buf.data();
+        ut64 *n64 = (ut64 *)buf.data();
+        r_io_read_at(core->io, addr, (unsigned char*)buf.data(), buf.size());
+        ut64 n = (bits == 64)? *n64: *n32;
+        // The value of the next address will serve as an indication that there's more to
+        // telescope if we have reached the depth limit
+        json["value"] = QString::number(n);
+        if (depth && n != addr) {
+            // Make sure we aren't telescoping the same address
+            QJsonObject ref = getAddrRefs(n, depth-1);
+            if (!ref.empty()) {
+                // If the dereference of the current pointer is an ascii character we
+                // might have a string in this address
+                if (ref["type"].toString().contains("ascii")) {
+                    buf.resize(128);
+                    r_io_read_at(core->io, addr, (unsigned char*)buf.data(), buf.size());
+                    QString strVal = QString(buf);
+                    // Indicate that the string is longer than the printed value
+                    if (strVal.size() == buf.size()) {
+                        strVal += "...";
+                    }
+                    json["string"] = strVal;
+                }
+                json["ref"] = ref;
+            }
+        }
+    }
+    return json;
 }
 
 QJsonDocument CutterCore::getProcessThreads(int pid)

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -286,7 +286,18 @@ public:
      * @brief Attach to a given pid from a debug session
      */
     void setCurrentDebugProcess(int pid);
-    QJsonDocument getStack(int size = 0x100);
+    /**
+     * @brief Returns a list of stack address and their telescoped references
+     * @param size number of bytes to scan
+     * @param depth telescoping depth 
+     */
+    QList<QJsonObject> getStack(int size = 0x100, int depth = 6);
+    /**
+     * @brief Returns the telescoped values of a given address up to a given depth
+     * @param addr telescoping addr
+     * @param depth telescoping depth 
+     */
+    QJsonObject getAddrRefs(RVA addr, int depth);
     /**
      * @brief Get a list of a given process's threads
      * @param pid The pid of the process, -1 for the currently debugged process

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -293,7 +293,8 @@ public:
      */
     QList<QJsonObject> getStack(int size = 0x100, int depth = 6);
     /**
-     * @brief Returns the telescoped values of a given address up to a given depth
+     * @brief Recursively dereferences pointers starting at the specified address
+     *        up to a given depth
      * @param addr telescoping addr
      * @param depth telescoping depth 
      */

--- a/src/widgets/StackWidget.cpp
+++ b/src/widgets/StackWidget.cpp
@@ -161,7 +161,7 @@ void StackModel::reload()
             QString str = refItem["string"].toVariant().toString();
             if (!str.isEmpty()) {
                 item.description = str;
-                item.descriptionColor = QVariant(QColor(243, 156, 17));
+                    item.descriptionColor = ConfigColor("comment");
             } else {
                 QString type, mapname, section, func, perms, asmb, string, reg, value;
                 do {
@@ -207,13 +207,13 @@ void StackModel::reload()
 
                 // Set the description's color according to the last item type
                 if (type == "ascii") {
-                    item.descriptionColor = QVariant(QColor(243, 156, 17));
+                    item.descriptionColor = ConfigColor("comment");
                 } else if (type == "program") {
-                    item.descriptionColor = QVariant(QColor(Qt::red));
+                    item.descriptionColor = ConfigColor("fname");
                 } else if (type == "library") {
-                    item.descriptionColor = QVariant(QColor(Qt::green));
+                    item.descriptionColor = ConfigColor("floc");
                 } else if (type == "stack") {
-                    item.descriptionColor = QVariant(QColor(Qt::cyan));
+                    item.descriptionColor = ConfigColor("offset");
                 }
             }
         }

--- a/src/widgets/StackWidget.cpp
+++ b/src/widgets/StackWidget.cpp
@@ -144,6 +144,16 @@ StackModel::StackModel(QObject *parent)
 {
 }
 
+// Utility function to check if a telescoped item exists and add it with prefixes to the desc
+static inline const QString append_var(QString &dst, const QString val, const QString prepend_val,
+                                       const QString append_val)
+{
+    if (!val.isEmpty()) {
+        dst += prepend_val + val + append_val;
+    }
+    return val;
+}
+
 void StackModel::reload()
 {
     QList<QJsonObject> stackItems = Core()->getStack();
@@ -161,47 +171,20 @@ void StackModel::reload()
             QString str = refItem["string"].toVariant().toString();
             if (!str.isEmpty()) {
                 item.description = str;
-                    item.descriptionColor = ConfigColor("comment");
+                item.descriptionColor = ConfigColor("comment");
             } else {
-                QString type, mapname, section, func, perms, asmb, string, reg, value;
+                QString type;
                 do {
                     item.description += " ->";
-                    reg = refItem["reg"].toVariant().toString();
-                    if (!reg.isEmpty()) {
-                        item.description += " @" + reg;
-                    }
-                    mapname = refItem["mapname"].toVariant().toString();
-                    if (!mapname.isEmpty()) {
-                        item.description += " (" + mapname + ")";
-                    }
-                    section = refItem["section"].toVariant().toString();
-                    if (!section.isEmpty()) {
-                        item.description += " (" + section + ")";
-                    }
-                    func = refItem["func"].toVariant().toString();
-                    if (!func.isEmpty()) {
-                        item.description += " " + func;
-                    }
-                    type = refItem["type"].toVariant().toString();
-                    if (!type.isEmpty()) {
-                        item.description += " " + type;
-                    }
-                    perms = refItem["perms"].toVariant().toString();
-                    if (!perms.isEmpty()) {
-                        item.description += " " + perms;
-                    }
-                    asmb = refItem["asm"].toVariant().toString();
-                    if (!asmb.isEmpty()) {
-                        item.description += " \"" + asmb + "\"";
-                    }
-                    string = refItem["string"].toVariant().toString();
-                    if (!string.isEmpty()) {
-                        item.description += " " + string;
-                    }
-                    value = RAddressString(stackItem["value"].toVariant().toULongLong());
-                    if (!value.isEmpty()) {
-                        item.description += " " + value;
-                    }
+                    append_var(item.description, refItem["reg"].toVariant().toString(), " @", "");
+                    append_var(item.description, refItem["mapname"].toVariant().toString(), " (", ")");
+                    append_var(item.description, refItem["section"].toVariant().toString(), " (", ")");
+                    append_var(item.description, refItem["func"].toVariant().toString(), " ", "");
+                    type = append_var(item.description, refItem["type"].toVariant().toString(), " ", "");
+                    append_var(item.description, refItem["perms"].toVariant().toString(), " ", "");
+                    append_var(item.description, refItem["asm"].toVariant().toString(), " \"", "\"");
+                    append_var(item.description, refItem["string"].toVariant().toString(), " ", "");
+                    append_var(item.description, RAddressString(stackItem["value"].toVariant().toULongLong()), " ", "");
                     refItem = refItem["ref"].toObject();
                 } while (!refItem.empty());
 

--- a/src/widgets/StackWidget.cpp
+++ b/src/widgets/StackWidget.cpp
@@ -173,7 +173,7 @@ void StackModel::reload()
                 item.description = str;
                 item.descriptionColor = ConfigColor("comment");
             } else {
-                QString type;
+                QString type, string;
                 do {
                     item.description += " ->";
                     append_var(item.description, refItem["reg"].toVariant().toString(), " @", "");
@@ -183,13 +183,19 @@ void StackModel::reload()
                     type = append_var(item.description, refItem["type"].toVariant().toString(), " ", "");
                     append_var(item.description, refItem["perms"].toVariant().toString(), " ", "");
                     append_var(item.description, refItem["asm"].toVariant().toString(), " \"", "\"");
-                    append_var(item.description, refItem["string"].toVariant().toString(), " ", "");
-                    append_var(item.description, RAddressString(stackItem["value"].toVariant().toULongLong()), " ", "");
+                    string = append_var(item.description, refItem["string"].toVariant().toString(), " ", "");
+                    if (!string.isNull()) {
+                        // There is no point in adding ascii and addr info after a string
+                        break;
+                    }
+                    if (!refItem["value"].isNull()) {
+                        append_var(item.description, RAddressString(refItem["value"].toVariant().toULongLong()), " ", "");
+                    }
                     refItem = refItem["ref"].toObject();
                 } while (!refItem.empty());
 
                 // Set the description's color according to the last item type
-                if (type == "ascii") {
+                if (type == "ascii" || !string.isEmpty()) {
                     item.descriptionColor = ConfigColor("comment");
                 } else if (type == "program") {
                     item.descriptionColor = ConfigColor("fname");


### PR DESCRIPTION
**Detailed description**

This PR is aimed at optimizing debug performance issues caused by getStack telescoping and stack widget string de-referencing(Which was necessary since we didn't have access to each deref separately and regex was tricky with r2's output). getStack is meant to prepare the ground for async telescoping and ref columns instead of one column with a huge string.
References are now properly colored by the last telescoped value instead of only being colored when the first value was of type library/program/string/stack.

I think that settings to control telescoping should be added separately since there's a lot of variables there.

![stackupdated](https://user-images.githubusercontent.com/5659696/72113393-3b0b4180-3338-11ea-8d9d-6a937cf3a3a1.PNG)

**Test plan (required)**

* See that long strings have "..." appended to them in the display to indicate that they are partial
![truncated2](https://user-images.githubusercontent.com/5659696/72113482-80c80a00-3338-11ea-8446-241c65eaea33.PNG)
* Write `pxr 0x100 @ r:SP` in the console and compare the output
* Step in debug with the stackwidget open and verify that performance improved

**Closing issues**

ref #1968
