### PR TITLE
Refresh monospace font after it gets reset by style or external font change

### DIFF
--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -392,6 +392,11 @@ void Configuration::setFont(const QFont &font)
     emit fontsUpdated();
 }
 
+void Configuration::refreshFont()
+{
+    emit fontsUpdated();
+}
+
 qreal Configuration::getZoomFactor() const {
   qreal fontZoom = s.value("zoomFactor", 1.0).value<qreal>();
   return qMax(fontZoom, 0.1);

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -171,7 +171,8 @@ public:
 
     bool getDecompilerAutoRefreshEnabled();
     void setDecompilerAutoRefreshEnabled(bool enabled);
-
+public slots:
+    void refreshFont();
 signals:
     void fontsUpdated();
     void colorsUpdated();

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -1599,6 +1599,20 @@ bool MainWindow::eventFilter(QObject *, QEvent *event)
     return false;
 }
 
+bool MainWindow::event(QEvent *event)
+{
+    if (event->type() == QEvent::FontChange
+        || event->type() == QEvent::StyleChange
+        || event->type() == QEvent::PaletteChange) {
+#if QT_VERSION < QT_VERSION_CHECK(5,10,0)
+        QMetaObject::invokeMethod(Config(), "refreshFont", Qt::ConnectionType::QueuedConnection);
+#else
+        QMetaObject::invokeMethod(Config(), &Configuration::refreshFont, Qt::ConnectionType::QueuedConnection);
+#endif
+    }
+    return QMainWindow::event(event);
+}
+
 /**
  * @brief Show a warning message box.
  *

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -193,6 +193,7 @@ private slots:
 
     void mousePressEvent(QMouseEvent *event) override;
     bool eventFilter(QObject *object, QEvent *event) override;
+    bool event(QEvent *event) override;
     void toggleDebugView();
     void chooseThemeIcons();
 

--- a/src/widgets/ConsoleWidget.cpp
+++ b/src/widgets/ConsoleWidget.cpp
@@ -111,7 +111,6 @@ ConsoleWidget::ConsoleWidget(MainWindow *main, QAction *action) :
     connect(ui->r2InputLineEdit, &QLineEdit::editingFinished, this, &ConsoleWidget::disableCompletion);
 
     connect(Config(), &Configuration::fontsUpdated, this, &ConsoleWidget::setupFont);
-    connect(Config(), &Configuration::interfaceThemeChanged, this, &ConsoleWidget::setupFont);
 
     connect(ui->inputCombo,
             static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),


### PR DESCRIPTION
**Detailed description**

<!-- Explain the **details** for making this change. What existing problem does the pull request solve? Please provide enough information so that others can review your pull request -->


**Test plan (required)**

* Change font in Cutter settings to something recognizable like large  size or strikeout
* Open  decompiler widget, console and disassembly
* Restart Cutter
* make sure decompiler and console are using the recognizable font
* change interface theme, make sure fonts are correct

<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**

<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
closes #1976 