### PR TITLE
Switch to meson 0.52.1 in Ubuntu 16.04 to fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ matrix:
     before_install:
       - pyenv install 3.5.2
       - pyenv global 3.5.2
-      - pip install meson
+      - pip install meson==0.52.1
 
 
   - name: macOS QMake + Deploy


### PR DESCRIPTION
Meson 0.53.0 broke compatibility with Python 3.5.2, we should revert until they fix it.

ref [#6427](https://github.com/mesonbuild/meson/issues/6427)