### PR TITLE
If available, set r2ghidra the default decompiler

### DIFF
--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -56,6 +56,11 @@ DecompilerWidget::DecompilerWidget(MainWindow *main, QAction *action) :
 
     auto decompilers = Core()->getDecompilers();
     auto selectedDecompilerId = Config()->getSelectedDecompiler();
+    if (selectedDecompilerId.isEmpty()) {
+        // If no decompiler was previously chosen. set r2ghidra as default decompiler
+        selectedDecompilerId = "r2ghidra";
+    }
+
     for (auto dec : decompilers) {
         ui->decompilerComboBox->addItem(dec->getName(), dec->getId());
         if (dec->getId() == selectedDecompilerId) {
@@ -66,9 +71,6 @@ DecompilerWidget::DecompilerWidget(MainWindow *main, QAction *action) :
 
     decompilerSelectionEnabled = decompilers.size() > 1;
     ui->decompilerComboBox->setEnabled(decompilerSelectionEnabled);
-    // if available, set r2ghidra as default decompiler
-    ui->decompilerComboBox->setCurrentText("Ghidra");
-
 
     if (decompilers.isEmpty()) {
         ui->textEdit->setPlainText(tr("No Decompiler available."));

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -66,6 +66,9 @@ DecompilerWidget::DecompilerWidget(MainWindow *main, QAction *action) :
 
     decompilerSelectionEnabled = decompilers.size() > 1;
     ui->decompilerComboBox->setEnabled(decompilerSelectionEnabled);
+    // if available, set r2ghidra as default decompiler
+    ui->decompilerComboBox->setCurrentText("Ghidra");
+
 
     if (decompilers.isEmpty()) {
         ui->textEdit->setPlainText(tr("No Decompiler available."));


### PR DESCRIPTION

**Detailed description**

This simple PR will set r2ghidra the default decompiler, if available. It takes advantage of the `setCurrentText` function.


**Test plan (required)**

1. Install r2dec and r2ghidra
2. Open Cutter, and see that r2ghidra decompiler is the default
3. Remove r2ghidra and see that r2dec is selected
4. Remove both and see that nothing has changed and no regression introduced

**Additional info**
While this solution works, in the future it would be better to have priority management and each plugin will assign a desired priority to itself. 

**Closing issues**

closes https://github.com/radareorg/cutter/issues/1761

