### PR TITLE
docker/Dockerfile*: Use latest alpine image to fix GUI crashes in the…

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:edge AS builder
+FROM alpine:latest AS builder
 LABEL maintainer "Philipp Schmied <ps1337@mailbox.org>"
 
 # Prevent build fails because of interactive scripts when compiling
@@ -28,7 +28,7 @@ RUN cd /opt/cutter && \
     bash build.sh && \
     bash -c 'if [[ ! -x "/opt/cutter/build/Cutter" ]]; then exit -1; fi'
 
-FROM alpine:edge AS runner
+FROM alpine:latest AS runner
 
 # Add the dependencies we need for running
 RUN apk add --no-cache \

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM alpine:edge AS builder
+FROM alpine:latest AS builder
 LABEL maintainer "Philipp Schmied <ps1337@mailbox.org>"
 
 # Prevent build fails because of interactive scripts when compiling
@@ -36,7 +36,7 @@ COPY src /opt/cutter/src
 RUN bash build_cutter.sh && \
     bash -c 'if [[ ! -x "/opt/cutter/build/Cutter" ]]; then exit -1; fi'
 
-FROM alpine:edge AS runner
+FROM alpine:latest AS runner
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 
 # Add the dependencies we need for running


### PR DESCRIPTION
This fixes GUI crashes in the container by using the `latest` alpine docker image instead of `edge`. The cause seems to be a symbol that's missing in a QT library. We can switch to `edge` again at a later point as soon as this is fixed in alpine.

BTW: The docker image build should succeed as soon as the radare2 submodule was updated.