### PR TITLE
Improve flag and string widget performance

### DIFF
--- a/src/widgets/CutterTreeView.cpp
+++ b/src/widgets/CutterTreeView.cpp
@@ -7,6 +7,7 @@ CutterTreeView::CutterTreeView(QWidget *parent) :
 {
     ui->setupUi(this);
     this->setSelectionMode(QAbstractItemView::ExtendedSelection);
+    this->setUniformRowHeights(true);
 }
 
 CutterTreeView::~CutterTreeView() {}

--- a/src/widgets/FlagsWidget.cpp
+++ b/src/widgets/FlagsWidget.cpp
@@ -73,8 +73,8 @@ QVariant FlagsModel::headerData(int section, Qt::Orientation, int role) const
 
 RVA FlagsModel::address(const QModelIndex &index) const
 {
-   const FlagDescription &flag = flags->at(index.row());
-   return flag.offset;
+    const FlagDescription &flag = flags->at(index.row());
+    return flag.offset;
 }
 
 QString FlagsModel::name(const QModelIndex &index) const
@@ -105,7 +105,7 @@ bool FlagsSortFilterProxyModel::filterAcceptsRow(int row, const QModelIndex &par
 
 bool FlagsSortFilterProxyModel::lessThan(const QModelIndex &left, const QModelIndex &right) const
 {
-    auto source = static_cast<FlagsModel*>(sourceModel());
+    auto source = static_cast<FlagsModel *>(sourceModel());
     auto left_flag = source->description(left);
     auto right_flag = source->description(right);
 
@@ -254,7 +254,7 @@ void FlagsWidget::refreshFlags()
     flags_model->endResetModel();
 
     tree->showItemsNumber(flags_proxy_model->rowCount());
-    
+
     // TODO: this is not a very good place for the following:
     QStringList flagNames;
     for (const FlagDescription &i : flags)

--- a/src/widgets/FlagsWidget.cpp
+++ b/src/widgets/FlagsWidget.cpp
@@ -253,8 +253,6 @@ void FlagsWidget::refreshFlags()
     flags = Core()->getAllFlags(flagspace);
     flags_model->endResetModel();
 
-    //qhelpers::adjustColumns(ui->flagsTreeView, 2, 0);
-
     tree->showItemsNumber(flags_proxy_model->rowCount());
     
     // TODO: this is not a very good place for the following:

--- a/src/widgets/FlagsWidget.h
+++ b/src/widgets/FlagsWidget.h
@@ -35,7 +35,8 @@ public:
     int columnCount(const QModelIndex &parent = QModelIndex()) const override;
 
     QVariant data(const QModelIndex &index, int role) const override;
-    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+    QVariant headerData(int section, Qt::Orientation orientation,
+                        int role = Qt::DisplayRole) const override;
 
     RVA address(const QModelIndex &index) const override;
     QString name(const QModelIndex &index) const override;

--- a/src/widgets/FlagsWidget.h
+++ b/src/widgets/FlagsWidget.h
@@ -5,6 +5,7 @@
 
 #include <QAbstractItemModel>
 #include <QSortFilterProxyModel>
+#include <QStandardItemModel>
 
 #include "core/Cutter.h"
 #include "CutterDockWidget.h"
@@ -38,6 +39,8 @@ public:
 
     RVA address(const QModelIndex &index) const override;
     QString name(const QModelIndex &index) const override;
+
+    const FlagDescription *description(QModelIndex index) const;
 };
 
 
@@ -81,6 +84,7 @@ private:
     std::unique_ptr<Ui::FlagsWidget> ui;
     MainWindow *main;
 
+    bool disableFlagRefresh = false;
     FlagsModel *flags_model;
     FlagsSortFilterProxyModel *flags_proxy_model;
     QList<FlagDescription> flags;

--- a/src/widgets/StringsWidget.cpp
+++ b/src/widgets/StringsWidget.cpp
@@ -202,6 +202,12 @@ StringsWidget::StringsWidget(MainWindow *main, QAction *action) :
             tree->showItemsNumber(proxyModel->rowCount());
         }
     );
+
+    auto header = ui->stringsTreeView->header();
+    header->setSectionResizeMode(QHeaderView::ResizeMode::ResizeToContents);
+    header->setSectionResizeMode(StringsModel::StringColumn, QHeaderView::ResizeMode::Stretch);
+    header->setStretchLastSection(false);
+    header->setResizeContentsPrecision(256);
 }
 
 StringsWidget::~StringsWidget() {}
@@ -239,9 +245,6 @@ void StringsWidget::stringSearchFinished(const QList<StringDescription> &strings
     model->beginResetModel();
     this->strings = strings;
     model->endResetModel();
-
-    if (ui->stringsTreeView->columnWidth(1) > 300)
-        ui->stringsTreeView->setColumnWidth(1, 300);
 
     tree->showItemsNumber(proxyModel->rowCount());
 

--- a/src/widgets/StringsWidget.cpp
+++ b/src/widgets/StringsWidget.cpp
@@ -112,7 +112,7 @@ bool StringsProxyModel::filterAcceptsRow(int row, const QModelIndex &parent) con
 
 bool StringsProxyModel::lessThan(const QModelIndex &left, const QModelIndex &right) const
 {
-    auto model = static_cast<StringsModel*>(sourceModel());
+    auto model = static_cast<StringsModel *>(sourceModel());
     auto leftStr = model->description(left);
     auto rightStr = model->description(right);
 
@@ -181,7 +181,8 @@ StringsWidget::StringsWidget(MainWindow *main, QAction *action) :
     });
 
     QShortcut *searchShortcut = new QShortcut(QKeySequence::Find, this);
-    connect(searchShortcut, &QShortcut::activated, ui->quickFilterView, &ComboQuickFilterView::showFilter);
+    connect(searchShortcut, &QShortcut::activated, ui->quickFilterView,
+            &ComboQuickFilterView::showFilter);
     searchShortcut->setContext(Qt::WidgetWithChildrenShortcut);
 
     QShortcut *clearShortcut = new QShortcut(QKeySequence(Qt::Key_Escape), this);

--- a/src/widgets/StringsWidget.h
+++ b/src/widgets/StringsWidget.h
@@ -42,6 +42,7 @@ public:
     QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
 
     RVA address(const QModelIndex &index) const override;
+    const StringDescription *description(const QModelIndex &index) const;
 };
 
 

--- a/src/widgets/StringsWidget.h
+++ b/src/widgets/StringsWidget.h
@@ -39,7 +39,8 @@ public:
     int columnCount(const QModelIndex &parent = QModelIndex()) const override;
 
     QVariant data(const QModelIndex &index, int role) const override;
-    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+    QVariant headerData(int section, Qt::Orientation orientation,
+                        int role = Qt::DisplayRole) const override;
 
     RVA address(const QModelIndex &index) const override;
     const StringDescription *description(const QModelIndex &index) const;

--- a/src/widgets/VTablesWidget.cpp
+++ b/src/widgets/VTablesWidget.cpp
@@ -163,6 +163,8 @@ VTablesWidget::VTablesWidget(MainWindow *main, QAction *action) :
     
     connect(Core(), &CutterCore::codeRebased, this, &VTablesWidget::refreshVTables);
     connect(Core(), &CutterCore::refreshAll, this, &VTablesWidget::refreshVTables);
+
+    refreshDeferrer = createRefreshDeferrer([this](){ refreshVTables(); });
 }
 
 VTablesWidget::~VTablesWidget()
@@ -171,6 +173,10 @@ VTablesWidget::~VTablesWidget()
 
 void VTablesWidget::refreshVTables()
 {
+    if (!refreshDeferrer->attemptRefresh(nullptr)) {
+        return;
+    }
+
     model->beginResetModel();
     vtables = Core()->getAllVTables();
     model->endResetModel();

--- a/src/widgets/VTablesWidget.cpp
+++ b/src/widgets/VTablesWidget.cpp
@@ -160,11 +160,11 @@ VTablesWidget::VTablesWidget(MainWindow *main, QAction *action) :
     connect(ui->quickFilterView, &QuickFilterView::filterTextChanged, this, [this] {
         tree->showItemsNumber(proxy->rowCount());
     });
-    
+
     connect(Core(), &CutterCore::codeRebased, this, &VTablesWidget::refreshVTables);
     connect(Core(), &CutterCore::refreshAll, this, &VTablesWidget::refreshVTables);
 
-    refreshDeferrer = createRefreshDeferrer([this](){ refreshVTables(); });
+    refreshDeferrer = createRefreshDeferrer([this]() { refreshVTables(); });
 }
 
 VTablesWidget::~VTablesWidget()

--- a/src/widgets/VTablesWidget.h
+++ b/src/widgets/VTablesWidget.h
@@ -70,6 +70,7 @@ private:
     QSortFilterProxyModel *proxy;
     QList<VTableDescription> vtables;
     CutterTreeWidget *tree;
+    RefreshDeferrer *refreshDeferrer;
 };
 
 #endif // VTABLESWIDGET_H


### PR DESCRIPTION
 <!-- Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request. -->


**Detailed description**

Times bellow are from test executable described in #2020 

* Use refreshDeferrer for VtableWidget saves ~4s if its not used
* Don't do duplicate flag refreshes 3x450ms -> 1x450ms
* setUniformRowHeights(false) - saves ~ 4-5s for strings widget and flag widget each . 
* replace qHelpers::adjustColumns with appropriate Qt properties. String widget now stretches the string column instead of last one containing section.  adjustColumns might not be as bad as I thought, it might have triggered the rowHeight recalculation causing misleading time measurements.
* reduce the overhead during sorting, saves a few hundred ms in debug mode. Didn't retest in release mode.
* Don't sort strings unless requested by user, order returned by r2 is somewhat reasonable.

**Test plan (required)**

* Open test executable described in #2020 and strings widget
* Press F5 to refresh all, observe delay. Took 25s in debug and 21s in release mode before fix, 4.7s after the fix.
* try searching string "tst" quick filter and changing sorting column. Took 3-4s before fix, ~100ms after even when pattern matches most of the strings.  Different search queries like "123" may take longer, but it is still better than before.
* Searching in flag widget should have similar improvements as strings.

<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Other issues observed during testing**
* Sections selection in strings widget are broken, also affects master
* Trying to debug the test executable causes some kind of deadlock. Repeatable using master without this PR. Rebase signal triggers widget refresh, which causes access to r2 and everything gets stuck
* Section listing always triggers reading of memory for calculating checksums even when list of requested checksums is empty due to `"" != NULL`. Might cause unnecessary slowdown especially during debugging. 

**Closing issues**

First part for #2020 doesn't close it. Other widgets need to be tested with appropriate test executables.
<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
