### PR TITLE
Fix builds by using python 3.7.x instead of 3.7.5

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, ubuntu-16.04, macos-latest]
-        python-version: [3.7.5]
+        python-version: [3.7.6]
       # Prevent one job from pausing the rest
       fail-fast: false
     steps:

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, ubuntu-16.04, macos-latest]
-        python-version: [3.7.6]
+        python-version: [3.7.x]
       # Prevent one job from pausing the rest
       fail-fast: false
     steps:


### PR DESCRIPTION
Build is currently failing. Trying to use python 3.7.6
![image](https://user-images.githubusercontent.com/20182642/72712076-0470ca80-3b73-11ea-9881-cbfe6dd48de8.png)
