### PR TITLE
Add realname and libname to Flags and Imports widgets

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -66,6 +66,7 @@ namespace RJsonKey {
     R_JSON_KEY(license);
     R_JSON_KEY(methods);
     R_JSON_KEY(name);
+    R_JSON_KEY(realname);
     R_JSON_KEY(nargs);
     R_JSON_KEY(nbbs);
     R_JSON_KEY(nlocals);
@@ -73,6 +74,7 @@ namespace RJsonKey {
     R_JSON_KEY(opcode);
     R_JSON_KEY(opcodes);
     R_JSON_KEY(ordinal);
+    R_JSON_KEY(libname);
     R_JSON_KEY(outdegree);
     R_JSON_KEY(paddr);
     R_JSON_KEY(path);
@@ -2385,6 +2387,7 @@ QList<ImportDescription> CutterCore::getAllImports()
         import.ordinal = importObject[RJsonKey::ordinal].toInt();
         import.bind = importObject[RJsonKey::bind].toString();
         import.type = importObject[RJsonKey::type].toString();
+        import.libname = importObject[RJsonKey::libname].toString();
         import.name = importObject[RJsonKey::name].toString();
 
         ret << import;
@@ -2622,6 +2625,7 @@ QList<FlagDescription> CutterCore::getAllFlags(QString flagspace)
         flag.offset = flagObject[RJsonKey::offset].toVariant().toULongLong();
         flag.size = flagObject[RJsonKey::size].toVariant().toULongLong();
         flag.name = flagObject[RJsonKey::name].toString();
+        flag.realname = flagObject[RJsonKey::realname].toString();
 
         ret << flag;
     }

--- a/src/core/CutterDescriptions.h
+++ b/src/core/CutterDescriptions.h
@@ -36,6 +36,7 @@ struct ImportDescription {
     QString bind;
     QString type;
     QString name;
+    QString libname;
 };
 
 struct ExportDescription {
@@ -117,6 +118,7 @@ struct FlagDescription {
     RVA offset;
     RVA size;
     QString name;
+    QString realname;
 };
 
 struct SectionDescription {

--- a/src/widgets/FlagsWidget.cpp
+++ b/src/widgets/FlagsWidget.cpp
@@ -42,6 +42,8 @@ QVariant FlagsModel::data(const QModelIndex &index, int role) const
             return RAddressString(flag.offset);
         case NAME:
             return flag.name;
+        case REALNAME:
+            return flag.realname;
         default:
             return QVariant();
         }
@@ -63,6 +65,8 @@ QVariant FlagsModel::headerData(int section, Qt::Orientation, int role) const
             return tr("Offset");
         case NAME:
             return tr("Name");
+        case REALNAME:
+            return tr("Real Name");
         default:
             return QVariant();
         }
@@ -83,6 +87,12 @@ QString FlagsModel::name(const QModelIndex &index) const
     return flag.name;
 }
 
+QString FlagsModel::realname(const QModelIndex &index) const
+{
+    const FlagDescription &flag = flags->at(index.row());
+    return flag.realname;
+}
+
 const FlagDescription *FlagsModel::description(QModelIndex index) const
 {
     if (index.row() < flags->size()) {
@@ -100,7 +110,7 @@ bool FlagsSortFilterProxyModel::filterAcceptsRow(int row, const QModelIndex &par
 {
     QModelIndex index = sourceModel()->index(row, 0, parent);
     FlagDescription flag = index.data(FlagsModel::FlagDescriptionRole).value<FlagDescription>();
-    return flag.name.contains(filterRegExp());
+    return flag.name.contains(filterRegExp()) || flag.realname.contains(filterRegExp());
 }
 
 bool FlagsSortFilterProxyModel::lessThan(const QModelIndex &left, const QModelIndex &right) const
@@ -120,6 +130,10 @@ bool FlagsSortFilterProxyModel::lessThan(const QModelIndex &left, const QModelIn
     // fallthrough
     case FlagsModel::NAME:
         return left_flag->name < right_flag->name;
+    // fallthrough
+    case FlagsModel::REALNAME:
+        return left_flag->realname < right_flag->realname;
+
     default:
         break;
     }

--- a/src/widgets/FlagsWidget.cpp
+++ b/src/widgets/FlagsWidget.cpp
@@ -87,12 +87,6 @@ QString FlagsModel::name(const QModelIndex &index) const
     return flag.name;
 }
 
-QString FlagsModel::realname(const QModelIndex &index) const
-{
-    const FlagDescription &flag = flags->at(index.row());
-    return flag.realname;
-}
-
 const FlagDescription *FlagsModel::description(QModelIndex index) const
 {
     if (index.row() < flags->size()) {

--- a/src/widgets/FlagsWidget.cpp
+++ b/src/widgets/FlagsWidget.cpp
@@ -130,7 +130,7 @@ bool FlagsSortFilterProxyModel::lessThan(const QModelIndex &left, const QModelIn
     // fallthrough
     case FlagsModel::NAME:
         return left_flag->name < right_flag->name;
-    // fallthrough
+    
     case FlagsModel::REALNAME:
         return left_flag->realname < right_flag->realname;
 

--- a/src/widgets/FlagsWidget.h
+++ b/src/widgets/FlagsWidget.h
@@ -40,7 +40,6 @@ public:
 
     RVA address(const QModelIndex &index) const override;
     QString name(const QModelIndex &index) const override;
-    QString realname(const QModelIndex &index) const;
 
     const FlagDescription *description(QModelIndex index) const;
 };

--- a/src/widgets/FlagsWidget.h
+++ b/src/widgets/FlagsWidget.h
@@ -26,7 +26,7 @@ private:
     QList<FlagDescription> *flags;
 
 public:
-    enum Columns { OFFSET = 0, SIZE, NAME, COUNT };
+    enum Columns { OFFSET = 0, SIZE, NAME, REALNAME, COUNT };
     static const int FlagDescriptionRole = Qt::UserRole;
 
     FlagsModel(QList<FlagDescription> *flags, QObject *parent = nullptr);
@@ -40,6 +40,7 @@ public:
 
     RVA address(const QModelIndex &index) const override;
     QString name(const QModelIndex &index) const override;
+    QString realname(const QModelIndex &index) const;
 
     const FlagDescription *description(QModelIndex index) const;
 };

--- a/src/widgets/ImportsWidget.cpp
+++ b/src/widgets/ImportsWidget.cpp
@@ -46,6 +46,8 @@ QVariant ImportsModel::data(const QModelIndex &index, int role) const
             return import.type;
         case ImportsModel::SafetyColumn:
             return banned.match(import.name).hasMatch() ? tr("Unsafe") : QStringLiteral("");
+        case ImportsModel::LibraryColumn:
+            return import.libname;
         case ImportsModel::NameColumn:
             return import.name;
         default:
@@ -72,6 +74,8 @@ QVariant ImportsModel::headerData(int section, Qt::Orientation, int role) const
             return tr("Type");
         case ImportsModel::SafetyColumn:
             return tr("Safety");
+        case ImportsModel::LibraryColumn:
+            return tr("Library");
         case ImportsModel::NameColumn:
             return tr("Name");
         default:
@@ -91,6 +95,12 @@ QString ImportsModel::name(const QModelIndex &index) const
 {
     const ImportDescription &import = imports->at(index.row());
     return import.name;
+}
+
+QString ImportsModel::libname(const QModelIndex &index) const
+{
+    const ImportDescription &import = imports->at(index.row());
+    return import.libname;
 }
 
 ImportsProxyModel::ImportsProxyModel(ImportsModel *sourceModel, QObject *parent)
@@ -126,6 +136,8 @@ bool ImportsProxyModel::lessThan(const QModelIndex &left, const QModelIndex &rig
         return leftImport.type < rightImport.type;
     case ImportsModel::SafetyColumn:
         break;
+    case ImportsModel::LibraryColumn:
+        return leftImport.libname < rightImport.libname;
     case ImportsModel::NameColumn:
         return leftImport.name < rightImport.name;
     default:
@@ -148,7 +160,8 @@ ImportsWidget::ImportsWidget(MainWindow *main, QAction *action) :
     setObjectName("ImportsWidget");
 
     setModels(importsProxyModel);
-    ui->treeView->sortByColumn(ImportsModel::NameColumn, Qt::AscendingOrder);
+    // Sort by library name by default to create a solid context per each group of imports
+    ui->treeView->sortByColumn(ImportsModel::LibraryColumn, Qt::AscendingOrder);
     QShortcut *toggle_shortcut = new QShortcut(widgetShortcuts["ImportsWidget"], main);
     connect(toggle_shortcut, &QShortcut::activated, this, [=] (){ 
             toggleDockWidget(true); 

--- a/src/widgets/ImportsWidget.cpp
+++ b/src/widgets/ImportsWidget.cpp
@@ -137,9 +137,12 @@ bool ImportsProxyModel::lessThan(const QModelIndex &left, const QModelIndex &rig
     case ImportsModel::SafetyColumn:
         break;
     case ImportsModel::LibraryColumn:
-        return leftImport.libname < rightImport.libname;
+        if (leftImport.libname != rightImport.libname)
+            return leftImport.libname < rightImport.libname;
+    // Fallthrough. Sort by Library and then by import name
     case ImportsModel::NameColumn:
         return leftImport.name < rightImport.name;
+        
     default:
         break;
     }

--- a/src/widgets/ImportsWidget.h
+++ b/src/widgets/ImportsWidget.h
@@ -43,7 +43,7 @@ private:
     QList<ImportDescription> *imports;
 
 public:
-    enum Column { AddressColumn = 0, TypeColumn, SafetyColumn, NameColumn, ColumnCount };
+    enum Column { AddressColumn = 0, TypeColumn, LibraryColumn, NameColumn, SafetyColumn, ColumnCount };
     enum Role { ImportDescriptionRole = Qt::UserRole, AddressRole };
 
     ImportsModel(QList<ImportDescription> *imports, QObject *parent = nullptr);
@@ -56,6 +56,8 @@ public:
 
     RVA address(const QModelIndex &index) const override;
     QString name(const QModelIndex &index) const override;
+    QString libname(const QModelIndex &index) const;
+
 };
 
 class ImportsProxyModel : public AddressableFilterProxyModel


### PR DESCRIPTION
**Detailed description**

This pull request continues the work we've done with implementing RealName and LibName in radare and adds the following to Cutter:
1) Adds the Real Name column to the Flags widget

![image](https://user-images.githubusercontent.com/20182642/72872820-ecc24f00-3cf6-11ea-8ccf-700354046c35.png)


2) Adds the Library column to the Imports widget

![image](https://user-images.githubusercontent.com/20182642/72872777-d3b99e00-3cf6-11ea-82e7-8415d157e679.png)


**Test plan (required)**

1) Open a binary in Cutter
2) Go to the Flags widget and see that the Real Name column was added successfully
3) Sort by real name and observe that the sort works
4) Search for a string that exists in Real Name and not in the regular flag name. See that searching there is supported

4) Go to the Imports widget and see that the Library column was added successfully
5) Sort by Library name and see that it works


