### PR TITLE
Improve default line-width values on graph

### DIFF
--- a/src/dialogs/preferences/GraphOptionsWidget.ui
+++ b/src/dialogs/preferences/GraphOptionsWidget.ui
@@ -24,7 +24,17 @@
       </widget>
      </item>
      <item row="0" column="1">
-      <widget class="QSpinBox" name="maxColsSpinBox"/>
+      <widget class="QSpinBox" name="maxColsSpinBox">
+       <property name="minimum">
+        <number>25</number>
+       </property>
+       <property name="maximum">
+        <number>256</number>
+       </property>
+       <property name="value">
+        <number>100</number>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>


### PR DESCRIPTION


**Detailed description**

This Pull Request setting the default maximum line-width of graph to 100. In addition, it increases the limits of the possible value from 99 to 256 and limits the lower value from 0 to 25.

So now the line width should be `25 =< X <= 256`


**Test plan (required)**

1. Open a binary in Cutter
2. Got top the Graph options dialog (via settings) and see that the lowest allowed number is 25 and the highest is 256
3. Set it to whatever number you want
4. Go to graph view and set a long comment, longer than the maximum value you set before
5. See that the comment is truncated when reaches to the maximum allowed value
6. Repeat previous steps with different lengths


**Closing issues**

closes #2025
