### PR TITLE
Make breakpoints available outside of debug

### DIFF
--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -1208,7 +1208,12 @@ void MainWindow::showDebugDocks()
 
 void MainWindow::enableDebugWidgetsMenu(bool enable)
 {
-    ui->menuAddDebugWidgets->setEnabled(enable);
+    for (QAction *action : ui->menuAddDebugWidgets->actions()) {
+        // The breakpoints menu should be available outside of debug
+        if (!action->text().contains("Breakpoints")) {
+            action->setEnabled(enable);
+        }
+    }
 }
 
 void MainWindow::resetToDefaultLayout()

--- a/src/core/MainWindow.ui
+++ b/src/core/MainWindow.ui
@@ -145,7 +145,6 @@
      <addaction name="actionSymbols"/>
      <addaction name="actionVTables"/>
      <addaction name="actionZignatures"/>
-     <addaction name="actionBreakpoint"/>
     </widget>
     <widget class="QMenu" name="menuAddDebugWidgets">
      <property name="title">

--- a/src/core/MainWindow.ui
+++ b/src/core/MainWindow.ui
@@ -145,6 +145,7 @@
      <addaction name="actionSymbols"/>
      <addaction name="actionVTables"/>
      <addaction name="actionZignatures"/>
+     <addaction name="actionBreakpoint"/>
     </widget>
     <widget class="QMenu" name="menuAddDebugWidgets">
      <property name="title">

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -151,6 +151,7 @@ DisassemblyContextMenu::DisassemblyContextMenu(QWidget *parent, MainWindow *main
 
     addSeparator();
 
+    addBreakpointMenu();
     addDebugMenu();
 
     connect(this, &DisassemblyContextMenu::aboutToShow,
@@ -287,16 +288,21 @@ void DisassemblyContextMenu::addEditMenu()
     editMenu->addAction(&actionJmpReverse);
 }
 
-void DisassemblyContextMenu::addDebugMenu()
+void DisassemblyContextMenu::addBreakpointMenu()
 {
-    debugMenu = addMenu(tr("Debug"));
+    breakpointMenu = addMenu(tr("Breakpoint"));
 
     initAction(&actionAddBreakpoint, tr("Add/remove breakpoint"),
                SLOT(on_actionAddBreakpoint_triggered()), getAddBPSequence());
-    debugMenu->addAction(&actionAddBreakpoint);
+    breakpointMenu->addAction(&actionAddBreakpoint);
     initAction(&actionAdvancedBreakpoint, tr("Advanced breakpoint"),
                SLOT(on_actionAdvancedBreakpoint_triggered()), QKeySequence(Qt::CTRL+Qt::Key_F2));
-    debugMenu->addAction(&actionAdvancedBreakpoint);
+    breakpointMenu->addAction(&actionAdvancedBreakpoint);
+}
+
+void DisassemblyContextMenu::addDebugMenu()
+{
+    debugMenu = addMenu(tr("Debug"));
 
     initAction(&actionContinueUntil, tr("Continue until line"),
                SLOT(on_actionContinueUntil_triggered()));

--- a/src/menus/DisassemblyContextMenu.h
+++ b/src/menus/DisassemblyContextMenu.h
@@ -157,9 +157,11 @@ private:
 
     QMenu *debugMenu;
     QAction actionContinueUntil;
+    QAction actionSetPC;
+
+    QMenu *breakpointMenu;
     QAction actionAddBreakpoint;
     QAction actionAdvancedBreakpoint;
-    QAction actionSetPC;
 
     QAction actionSetToCode;
 
@@ -195,6 +197,7 @@ private:
     void addSetAsMenu();
     void addSetToDataMenu();
     void addEditMenu();
+    void addBreakpointMenu();
     void addDebugMenu();
 
     struct ThingUsedHere {


### PR DESCRIPTION
**Detailed description**

The breakpoints widget and adding breakpoints through the disassembly context menu should be available before and after debug sessions.

**Test plan (required)**

* Check if the breakpoint menu is available in the disassembly context menu when not in debug
* Check if the breakpoints widget is available through the info menu

**Closing issues**

closes #1936
