### PR TITLE
Context menu extensions

### DIFF
--- a/src/bindings/bindings.xml
+++ b/src/bindings/bindings.xml
@@ -6,7 +6,9 @@
 
     <primitive-type name="bool"/>
 
-    <object-type name="CutterCore" />
+    <object-type name="CutterCore">
+        <enum-type name="ContextMenuType" />
+    </object-type>
     <object-type name="Configuration" />
     <object-type name="MainWindow" >
         <enum-type name="MenuType" />

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -207,6 +207,13 @@ void CutterCore::initialize()
 
     // Initialize Async tasks manager
     asyncTaskManager = new AsyncTaskManager(this);
+
+    // Initialize context menu extensions for plugins
+    disassemblyContextMenuExtensions = new QMenu(tr("Plugins"));
+    disassemblyContextMenuExtensions->menuAction()->setVisible(false);
+    disassemblyContextMenuExtensions->setEnabled(false);
+    addressableContextMenuExtensions = new QMenu(tr("Plugins"));
+    addressableContextMenuExtensions->menuAction()->setVisible(false);
 }
 
 CutterCore::~CutterCore()
@@ -2230,6 +2237,39 @@ QStringList CutterCore::getAnalPluginNames()
     }
 
     return ret;
+}
+
+QMenu *CutterCore::getContextMenuExtensions(ContextMenuType type)
+{
+    switch (type) {
+    case ContextMenuType::Disassembly:
+        return disassemblyContextMenuExtensions;
+    case ContextMenuType::Addressable:
+        return addressableContextMenuExtensions;
+    default:
+        return nullptr;
+    }
+}
+
+void CutterCore::addContextMenuExtensionAction(ContextMenuType type, QAction *action)
+{
+    QMenu *menu = getContextMenuExtensions(type);
+    if (menu) {
+        // The submenu should be invisible and disabled while it's empty
+        if (menu->isEmpty()) {
+            menu->menuAction()->setVisible(true);
+            menu->setEnabled(true);
+        }
+        menu->addAction(action);
+    }
+}
+
+void CutterCore::addContextMenuExtensionSeparator(ContextMenuType type)
+{
+    QMenu *menu = getContextMenuExtensions(type);
+    if (menu) {
+        menu->addSeparator();
+    }
 }
 
 QStringList CutterCore::getProjectNames()

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -6,6 +6,7 @@
 #include "common/BasicInstructionHighlighter.h"
 
 #include <QMap>
+#include <QMenu>
 #include <QDebug>
 #include <QObject>
 #include <QStringList>
@@ -419,6 +420,17 @@ public:
     QStringList getAsmPluginNames();
     QStringList getAnalPluginNames();
 
+    /* Context menu plugins */
+    enum class ContextMenuType { Disassembly, Addressable };
+    /**
+     * @brief Fetches the pointer to a context menu extension of type
+     * @param type - the type of the context menu
+     * @return plugins submenu of the selected context menu
+     */
+    QMenu *getContextMenuExtensions(ContextMenuType type);
+    void addContextMenuExtensionAction(ContextMenuType type, QAction *action);
+    void addContextMenuExtensionSeparator(ContextMenuType type);
+
     /* Projects */
     QStringList getProjectNames();
     void openProject(const QString &name);
@@ -628,6 +640,9 @@ private:
 
     QSharedPointer<R2Task> debugTask;
     R2TaskDialog *debugTaskDialog;
+
+    QMenu *disassemblyContextMenuExtensions = nullptr;
+    QMenu *addressableContextMenuExtensions = nullptr;
 };
 
 class RCoreLocked

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -408,11 +408,6 @@ void MainWindow::addExtraWidget(CutterDockWidget *extraDock)
     restoreExtraDock.restoreWidth(extraDock->widget());
 }
 
-/**
- * @brief Getter for MainWindow's different menus
- * @param type The type which represents the desired menu
- * @return The requested menu or nullptr if "type" is invalid
-**/
 QMenu *MainWindow::getMenuByType(MenuType type)
 {
     switch (type) {

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -101,6 +101,11 @@ public:
 
     void addPluginDockWidget(QDockWidget *dockWidget, QAction *action);
     enum class MenuType { File, Edit, View, Windows, Debug, Help, Plugins };
+    /**
+     * @brief Getter for MainWindow's different menus
+     * @param type The type which represents the desired menu
+     * @return The requested menu or nullptr if "type" is invalid
+     */
     QMenu *getMenuByType(MenuType type);
     void addMenuFileAction(QAction *action);
 

--- a/src/menus/AddressableItemContextMenu.cpp
+++ b/src/menus/AddressableItemContextMenu.cpp
@@ -39,7 +39,13 @@ AddressableItemContextMenu::AddressableItemContextMenu(QWidget *parent, MainWind
     addSeparator();
     addAction(&actionAddcomment);
 
+    addSeparator();
+    pluginMenu = Core()->getContextMenuExtensions(CutterCore::ContextMenuType::Addressable);
+    addMenu(pluginMenu);
+    addSeparator();
+
     setHasTarget(hasTarget);
+
     connect(this, &QMenu::aboutToShow, this, &AddressableItemContextMenu::aboutToShowSlot);
 }
 
@@ -98,6 +104,10 @@ void AddressableItemContextMenu::aboutToShowSlot()
         actionShowInMenu.menu()->deleteLater();
     }
     actionShowInMenu.setMenu(mainWindow->createShowInMenu(this, offset));
+
+    for (QAction *pluginAction : pluginMenu->actions()) {
+        pluginAction->setData(QVariant::fromValue(offset));
+    }
 }
 
 void AddressableItemContextMenu::setHasTarget(bool hasTarget)

--- a/src/menus/AddressableItemContextMenu.h
+++ b/src/menus/AddressableItemContextMenu.h
@@ -31,6 +31,7 @@ private:
 
     virtual void aboutToShowSlot();
 
+    QMenu *pluginMenu;
     MainWindow *mainWindow;
 
     RVA offset;

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -153,6 +153,13 @@ DisassemblyContextMenu::DisassemblyContextMenu(QWidget *parent, MainWindow *main
 
     addDebugMenu();
 
+    addSeparator();
+
+    pluginMenu = Core()->getContextMenuExtensions(CutterCore::ContextMenuType::Disassembly);
+    addMenu(pluginMenu);
+
+    addSeparator();
+
     connect(this, &DisassemblyContextMenu::aboutToShow,
             this, &DisassemblyContextMenu::aboutToShowSlot);
 }
@@ -515,6 +522,10 @@ void DisassemblyContextMenu::aboutToShowSlot()
                                      tr("Edit breakpoint") : tr("Advanced breakpoint"));
     QString progCounterName = Core()->getRegisterName("PC").toUpper();
     actionSetPC.setText("Set " + progCounterName + " here");
+
+    for (QAction *pluginAction : pluginMenu->actions()) {
+        pluginAction->setData(QVariant::fromValue(offset));
+    }
 }
 
 QKeySequence DisassemblyContextMenu::getCopySequence() const

--- a/src/menus/DisassemblyContextMenu.h
+++ b/src/menus/DisassemblyContextMenu.h
@@ -161,6 +161,8 @@ private:
     QAction actionAdvancedBreakpoint;
     QAction actionSetPC;
 
+    QMenu *pluginMenu;
+
     QAction actionSetToCode;
 
     QAction actionSetAsStringAuto;


### PR DESCRIPTION
**Detailed description**

This PR adds a way for plugins to add options to a group of context menus, currently disassemblyContextMenu and addressableContextMenu. The plugins will show up in a submenu and it's also possible to add separators for a cleaner look if there are multiple plugins/different action categories for the plugins.

Since widgets with new instances of context menus can be created during runtime, having a persistent menu item seemed like a better solution than signals.
I tried connecting to the contextmenu's trigger signal but it fires after the action's trigger signal is handled so I chose to pass the data by setting it in advance in the plugin's actions. The alternative is providing getters/setters in CutterCore.

![disas menu](https://user-images.githubusercontent.com/5659696/73028134-d1596000-3e2c-11ea-9766-60a80f9f211b.PNG)
![addrmenu](https://user-images.githubusercontent.com/5659696/73028135-d1f1f680-3e2c-11ea-88c3-543c785381f6.PNG)

**Test plan (required)**

See that added actions are shown when right clicking various widgets that support Disassembly/Addressable context menus.

<details> 
  <summary>python plugin for testing</summary>

```

import cutter

from PySide2.QtWidgets import QAction

class TestWidget(cutter.CutterDockWidget):
    def __init__(self, parent, action):
        super(TestWidget, self).__init__(parent, action)
        self.testAddrAction = QAction("Test addressable", self)
        self.testAddrAction2 = QAction("Test addressable2", self)
        self.testDisasAction = QAction("Test disassembly", self)
        self.testDisasAction2 = QAction("Test disassembly2", self)

        cutter.core().addContextMenuExtensionAction(
                cutter.CutterCore.ContextMenuType.Disassembly, self.testDisasAction)
        cutter.core().addContextMenuExtensionSeparator(
                cutter.CutterCore.ContextMenuType.Disassembly)
        cutter.core().addContextMenuExtensionAction(
                cutter.CutterCore.ContextMenuType.Disassembly, self.testDisasAction2)

        cutter.core().addContextMenuExtensionAction(
                cutter.CutterCore.ContextMenuType.Addressable, self.testAddrAction)
        cutter.core().addContextMenuExtensionSeparator(
                cutter.CutterCore.ContextMenuType.Addressable)
        cutter.core().addContextMenuExtensionAction(
                cutter.CutterCore.ContextMenuType.Addressable, self.testAddrAction2)

        self.testAddrAction.triggered.connect(self.handleAddr)
        self.testAddrAction2.triggered.connect(self.handleAddr)
        self.testDisasAction.triggered.connect(self.handleDisas)
        self.testDisasAction2.triggered.connect(self.handleDisas)

    def handleAddr(self):
        print(hex(self.testAddrAction.data()))

    def handleDisas(self):
        print(hex(self.testDisasAction.data()))

class TestPlugin(cutter.CutterPlugin):
    def setupInterface(self, main):
        action = QAction("test", main)
        widget = TestWidget(main, action)
        main.addPluginDockWidget(widget, action)

def create_cutter_plugin():
    return TestPlugin()

```

</details>