### PR TITLE
Add virtual-size to section widget

### DIFF
--- a/src/widgets/SectionsWidget.cpp
+++ b/src/widgets/SectionsWidget.cpp
@@ -57,11 +57,13 @@ QVariant SectionsModel::data(const QModelIndex &index, int role) const
         case SectionsModel::NameColumn:
             return section.name;
         case SectionsModel::SizeColumn:
-            return RSizeString(section.vsize);
+            return RSizeString(section.size);
         case SectionsModel::AddressColumn:
             return RAddressString(section.vaddr);
         case SectionsModel::EndAddressColumn:
             return RAddressString(section.vaddr + section.vsize);
+        case SectionsModel::VirtualSizeColumn:
+            return RSizeString(section.vsize);
         case SectionsModel::PermissionsColumn:
             return section.perm;
         case SectionsModel::EntropyColumn:
@@ -88,11 +90,13 @@ QVariant SectionsModel::headerData(int section, Qt::Orientation, int role) const
         case SectionsModel::NameColumn:
             return tr("Name");
         case SectionsModel::SizeColumn:
-            return tr("Virtual Size");
+            return tr("Size");
         case SectionsModel::AddressColumn:
             return tr("Address");
         case SectionsModel::EndAddressColumn:
             return tr("End Address");
+        case SectionsModel::VirtualSizeColumn:
+            return tr("Virtual Size");
         case SectionsModel::PermissionsColumn:
             return tr("Permissions");
         case SectionsModel::EntropyColumn:
@@ -134,12 +138,14 @@ bool SectionsProxyModel::lessThan(const QModelIndex &left, const QModelIndex &ri
     case SectionsModel::NameColumn:
         return leftSection.name < rightSection.name;
     case SectionsModel::SizeColumn:
-        return leftSection.vsize < rightSection.vsize;
+        return leftSection.size < rightSection.size;
     case SectionsModel::AddressColumn:
     case SectionsModel::EndAddressColumn:
         if (leftSection.vaddr != rightSection.vaddr) {
             return leftSection.vaddr < rightSection.vaddr;
         }
+        return leftSection.vsize < rightSection.vsize;
+    case SectionsModel::VirtualSizeColumn:
         return leftSection.vsize < rightSection.vsize;
     case SectionsModel::PermissionsColumn:
         return leftSection.perm < rightSection.perm;

--- a/src/widgets/SectionsWidget.cpp
+++ b/src/widgets/SectionsWidget.cpp
@@ -178,7 +178,7 @@ void SectionsWidget::initSectionsTable()
     proxyModel = new SectionsProxyModel(sectionsModel, this);
     setModels(proxyModel);
 
-    ui->treeView->sortByColumn(SectionsModel::NameColumn, Qt::AscendingOrder);
+    ui->treeView->sortByColumn(SectionsModel::AddressColumn, Qt::AscendingOrder);
 }
 
 void SectionsWidget::initQuickFilter()

--- a/src/widgets/SectionsWidget.h
+++ b/src/widgets/SectionsWidget.h
@@ -36,7 +36,7 @@ private:
     QList<SectionDescription> *sections;
 
 public:
-    enum Column { NameColumn = 0, SizeColumn, AddressColumn, EndAddressColumn, PermissionsColumn, EntropyColumn, ColumnCount };
+    enum Column { NameColumn = 0, SizeColumn, AddressColumn, EndAddressColumn, VirtualSizeColumn, PermissionsColumn, EntropyColumn, ColumnCount };
     enum Role { SectionDescriptionRole = Qt::UserRole };
 
     SectionsModel(QList<SectionDescription> *sections, QObject *parent = nullptr);


### PR DESCRIPTION

**Detailed description**

This pull request adds the virtual size column to Sections widget. Also, now the table will be sorted by section address by default.


**Test plan (required)**
1. Open a binary in Cutter
2. Go to sections widget
3. See that the Virtual Size column exists

![image](https://user-images.githubusercontent.com/20182642/73053064-7016a880-3e8f-11ea-9826-6b34183988cd.png)

**Closing issues**

<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
