### PR TITLE
Register refs widget improvements

### DIFF
--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -313,6 +313,11 @@ public:
      */
     QJsonObject getAddrRefs(RVA addr, int depth);
     /**
+     * @brief return a RefDescription with a formatted ref string and configured colors
+     * @param ref the "ref" JSON node from getAddrRefs
+     */
+    RefDescription formatRefDesc(QJsonObject ref);
+    /**
      * @brief Get a list of a given process's threads
      * @param pid The pid of the process, -1 for the currently debugged process
      * @return JSON object result of dptj
@@ -525,7 +530,11 @@ public:
     BlockStatistics getBlockStatistics(unsigned int blocksCount);
     QList<BreakpointDescription> getBreakpoints();
     QList<ProcessDescription> getAllProcesses();
-    QList<RegisterRefDescription> getRegisterRefs();
+    /**
+     * @brief returns a list of reg values and their telescoped references
+     * @param depth telescoping depth
+     */
+    QList<QJsonObject> getRegisterRefs(int depth = 6);
     QJsonObject getRegisterJson();
     QList<VariableDescription> getVariables(RVA at);
 

--- a/src/core/CutterDescriptions.h
+++ b/src/core/CutterDescriptions.h
@@ -9,6 +9,7 @@
 #include <QList>
 #include <QStringList>
 #include <QMetaType>
+#include <QColor>
 #include "core/CutterCommon.h"
 
 struct FunctionDescription {
@@ -308,10 +309,9 @@ struct ProcessDescription {
     QString path;
 };
 
-struct RegisterRefDescription {
-    QString reg;
-    QString value;
+struct RefDescription {
     QString ref;
+    QColor refColor;
 };
 
 struct VariableDescription {
@@ -357,7 +357,7 @@ Q_DECLARE_METATYPE(MemoryMapDescription)
 Q_DECLARE_METATYPE(BreakpointDescription)
 Q_DECLARE_METATYPE(BreakpointDescription::PositionType)
 Q_DECLARE_METATYPE(ProcessDescription)
-Q_DECLARE_METATYPE(RegisterRefDescription)
+Q_DECLARE_METATYPE(RefDescription)
 Q_DECLARE_METATYPE(VariableDescription)
 
 #endif // DESCRIPTIONS_H

--- a/src/widgets/RegisterRefsWidget.h
+++ b/src/widgets/RegisterRefsWidget.h
@@ -5,6 +5,7 @@
 #include "core/Cutter.h"
 #include "CutterDockWidget.h"
 #include "CutterTreeWidget.h"
+#include "menus/AddressableItemContextMenu.h"
 
 #include <QAbstractListModel>
 #include <QSortFilterProxyModel>
@@ -21,6 +22,12 @@ class RegisterRefsWidget;
 class MainWindow;
 class QTreeWidgetItem;
 
+struct RegisterRefDescription {
+    QString reg;
+    QString value;
+    RefDescription refDesc;
+};
+Q_DECLARE_METATYPE(RegisterRefDescription)
 
 class RegisterRefModel: public QAbstractListModel
 {
@@ -43,8 +50,6 @@ public:
     QVariant data(const QModelIndex &index, int role) const;
     QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
 };
-
-
 
 class RegisterRefProxyModel : public QSortFilterProxyModel
 {
@@ -71,7 +76,8 @@ private slots:
     void on_registerRefTreeView_doubleClicked(const QModelIndex &index);
     void refreshRegisterRef();
     void copyClip(int column);
-    void showRegRefContextMenu(const QPoint &pt);
+    void customMenuRequested(QPoint pos);
+    void onCurrentChanged(const QModelIndex &current, const QModelIndex &previous);
 
 private:
     std::unique_ptr<Ui::RegisterRefsWidget> ui;
@@ -79,10 +85,12 @@ private:
     RegisterRefModel *registerRefModel;
     RegisterRefProxyModel *registerRefProxyModel;
     QList<RegisterRefDescription> registerRefs;
-    QAction *actionCopyValue;
-    QAction *actionCopyRef;
     CutterTreeWidget *tree;
     void setScrollMode();
 
     RefreshDeferrer *refreshDeferrer;
+
+    QAction *actionCopyValue;
+    QAction *actionCopyRef;
+    AddressableItemContextMenu addressableItemContextMenu;
 };

--- a/src/widgets/StackWidget.cpp
+++ b/src/widgets/StackWidget.cpp
@@ -165,47 +165,8 @@ void StackModel::reload()
 
         item.offset = stackItem["addr"].toVariant().toULongLong();
         item.value = RAddressString(stackItem["value"].toVariant().toULongLong());
+        item.refDesc = Core()->formatRefDesc(stackItem["ref"].toObject());
 
-        QJsonObject refItem = stackItem["ref"].toObject();
-        if (!refItem.empty()) {
-            QString str = refItem["string"].toVariant().toString();
-            if (!str.isEmpty()) {
-                item.description = str;
-                item.descriptionColor = ConfigColor("comment");
-            } else {
-                QString type, string;
-                do {
-                    item.description += " ->";
-                    append_var(item.description, refItem["reg"].toVariant().toString(), " @", "");
-                    append_var(item.description, refItem["mapname"].toVariant().toString(), " (", ")");
-                    append_var(item.description, refItem["section"].toVariant().toString(), " (", ")");
-                    append_var(item.description, refItem["func"].toVariant().toString(), " ", "");
-                    type = append_var(item.description, refItem["type"].toVariant().toString(), " ", "");
-                    append_var(item.description, refItem["perms"].toVariant().toString(), " ", "");
-                    append_var(item.description, refItem["asm"].toVariant().toString(), " \"", "\"");
-                    string = append_var(item.description, refItem["string"].toVariant().toString(), " ", "");
-                    if (!string.isNull()) {
-                        // There is no point in adding ascii and addr info after a string
-                        break;
-                    }
-                    if (!refItem["value"].isNull()) {
-                        append_var(item.description, RAddressString(refItem["value"].toVariant().toULongLong()), " ", "");
-                    }
-                    refItem = refItem["ref"].toObject();
-                } while (!refItem.empty());
-
-                // Set the description's color according to the last item type
-                if (type == "ascii" || !string.isEmpty()) {
-                    item.descriptionColor = ConfigColor("comment");
-                } else if (type == "program") {
-                    item.descriptionColor = ConfigColor("fname");
-                } else if (type == "library") {
-                    item.descriptionColor = ConfigColor("floc");
-                } else if (type == "stack") {
-                    item.descriptionColor = ConfigColor("offset");
-                }
-            }
-        }
         values.push_back(item);
     }
     endResetModel();
@@ -236,14 +197,14 @@ QVariant StackModel::data(const QModelIndex &index, int role) const
         case ValueColumn:
             return item.value;
         case DescriptionColumn:
-            return item.description;
+            return item.refDesc.ref;
         default:
             return QVariant();
         }
     case Qt::ForegroundRole:
         switch (index.column()) {
         case DescriptionColumn:
-            return item.descriptionColor;
+            return item.refDesc.refColor;
         default:
             return QVariant();
         }

--- a/src/widgets/StackWidget.cpp
+++ b/src/widgets/StackWidget.cpp
@@ -144,16 +144,6 @@ StackModel::StackModel(QObject *parent)
 {
 }
 
-// Utility function to check if a telescoped item exists and add it with prefixes to the desc
-static inline const QString append_var(QString &dst, const QString val, const QString prepend_val,
-                                       const QString append_val)
-{
-    if (!val.isEmpty()) {
-        dst += prepend_val + val + append_val;
-    }
-    return val;
-}
-
 void StackModel::reload()
 {
     QList<QJsonObject> stackItems = Core()->getStack();

--- a/src/widgets/StackWidget.h
+++ b/src/widgets/StackWidget.h
@@ -22,8 +22,7 @@ public:
     struct Item {
         RVA offset;
         QString value;
-        QString description;
-        QVariant descriptionColor;
+        RefDescription refDesc;
     };
 
     enum Column { OffsetColumn = 0, ValueColumn, DescriptionColumn, ColumnCount};


### PR DESCRIPTION
**Detailed description**

Moved it to the new telescoping function instead of `drrj` and added AddressableContextMenu support

![regref](https://user-images.githubusercontent.com/5659696/73405479-e847f880-42eb-11ea-95c0-3d09c1fa15b7.PNG)

**Test plan (required)**

* Check that the telescoping is as good as `drrj`
* Check that stack widget telescoping still works
* See that RegisterRefsWidget's addressable context menu options and the custom widget options that are appended to it(copy register value and ref) work
