### PR TITLE
Fix themes bug in welcome dialog

### DIFF
--- a/src/dialogs/WelcomeDialog.ui
+++ b/src/dialogs/WelcomeDialog.ui
@@ -210,6 +210,11 @@
            </item>
            <item>
             <property name="text">
+             <string>Midnight Theme</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
              <string>Light Theme</string>
             </property>
            </item>


### PR DESCRIPTION

**Detailed description**

This pull request is adding the Midnight theme to the Welcome dialog. Not only this, it fixed a hidden bug in which choosing "Light theme" from the combo box showed Midnight theme. So while Light theme was there, it was actually midnight.


**Test plan (required)**

1. Reset Settings to trigger the show of Welcome dialog when opening cutter again
2. Open Cutter
3. Check that all the themes in the combo box are working

**Closing issues**

closes #2042 
