### PR TITLE
Don't set functions and comments widgets to vertical when resizing

### DIFF
--- a/src/widgets/CommentsWidget.cpp
+++ b/src/widgets/CommentsWidget.cpp
@@ -4,7 +4,6 @@
 #include "common/Helpers.h"
 
 #include <QMenu>
-#include <QResizeEvent>
 #include <QShortcut>
 
 CommentsModel::CommentsModel(QList<CommentDescription> *comments,
@@ -285,20 +284,6 @@ void CommentsWidget::onActionVerticalToggled(bool checked)
 void CommentsWidget::showTitleContextMenu(const QPoint &pt)
 {
     titleContextMenu->exec(this->mapToGlobal(pt));
-}
-
-void CommentsWidget::resizeEvent(QResizeEvent *event)
-{
-    if (mainWindow->responsive && isVisible()) {
-        if (event->size().width() >= event->size().height()) {
-            // Set horizontal view (list)
-            actionHorizontal.setChecked(true);
-        } else {
-            // Set vertical view (Tree)
-            actionVertical.setChecked(true);
-        }
-    }
-    QDockWidget::resizeEvent(event);
 }
 
 void CommentsWidget::refreshTree()

--- a/src/widgets/CommentsWidget.h
+++ b/src/widgets/CommentsWidget.h
@@ -78,9 +78,6 @@ public:
     explicit CommentsWidget(MainWindow *main, QAction *action = nullptr);
     ~CommentsWidget() override;
 
-protected:
-    void resizeEvent(QResizeEvent *event) override;
-
 private slots:
     void onActionHorizontalToggled(bool checked);
     void onActionVerticalToggled(bool checked);

--- a/src/widgets/FunctionsWidget.cpp
+++ b/src/widgets/FunctionsWidget.cpp
@@ -16,7 +16,6 @@
 #include <QShortcut>
 #include <QJsonArray>
 #include <QJsonObject>
-#include <QResizeEvent>
 
 namespace {
 
@@ -578,20 +577,6 @@ void FunctionsWidget::onActionVerticalToggled(bool enable)
         functionModel->setNested(true);
         ui->treeView->setIndentation(20);
     }
-}
-
-void FunctionsWidget::resizeEvent(QResizeEvent *event)
-{
-    if (mainWindow->responsive && isVisible()) {
-        if (event->size().width() >= event->size().height()) {
-            // Set horizontal view (list)
-            actionHorizontal.setChecked(true);
-        } else {
-            // Set vertical view (Tree)
-            actionVertical.setChecked(true);
-        }
-    }
-    QDockWidget::resizeEvent(event);
 }
 
 /**

--- a/src/widgets/FunctionsWidget.h
+++ b/src/widgets/FunctionsWidget.h
@@ -105,9 +105,6 @@ private slots:
     void setTooltipStylesheet();
     void refreshTree();
 
-protected:
-    void resizeEvent(QResizeEvent *event) override;
-
 private:
     QSharedPointer<FunctionsTask> task;
     QList<FunctionDescription> functions;


### PR DESCRIPTION

**Detailed description**

Old implementation of vertical mode in Functions and Comments widgets set the view to vertical when resizing the widgets to a certain proportion. This PR removes this undesired behavior.

**Closing issues**

closes #2044 
