### PR TITLE
Show realname on disassembly context menu

### DIFF
--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -483,8 +483,17 @@ void DisassemblyContextMenu::aboutToShowSlot()
         actionRename.setVisible(true);
         actionRename.setText(tr("Rename function \"%1\"").arg(fcn->name));
     } else if (f) {
+        QString name;
+
+        // Check if Realname is enabled. If yes, show it instead of the full flag-name.
+        if (Config()->getConfigBool("asm.flags.real") && f->realname) {
+            name = f->realname;
+        } else {
+            name = f->name;
+        }
+
         actionRename.setVisible(true);
-        actionRename.setText(tr("Rename flag \"%1\"").arg(f->name));
+        actionRename.setText(tr("Rename flag \"%1\"").arg(name));
     } else {
         actionRename.setVisible(false);
     }

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -327,7 +327,15 @@ QVector<DisassemblyContextMenu::ThingUsedHere> DisassemblyContextMenu::getThingU
     for (const auto &thing : array) {
         auto obj = thing.toObject();
         RVA offset = obj["offset"].toVariant().toULongLong();
-        QString name = obj["name"].toString();
+        QString name;
+
+        // If real names display is enabled, show flag's real name instead of full flag name
+        if (Config()->getConfigBool("asm.flags.real") && obj.contains("realname")) {
+            name = obj["realname"].toString();
+        } else {
+            name = obj["name"].toString();
+        }
+
         QString typeString = obj["type"].toString();
         ThingUsedHere::Type type = ThingUsedHere::Type::Address;
         if (typeString == "var") {


### PR DESCRIPTION
**WIP:** Do not merge


**Detailed description**

This Pull Request checks if `asm.flags.real` is enabled, and if so - shows flag's real name instead of full flag name in Disassembly context menu.

![image](https://user-images.githubusercontent.com/20182642/73715118-98b66200-471b-11ea-881d-3bf6e14de0c2.png)

*Please notice: I decided not to display the realname of a flag on the item that literally says `rename flag "full.name.of.flag"`*

**Test plan (required)**

1. Open Cutter without thi PR, choose a binary which is affected by this configuration variable (e.g PE)
2. Go to a function and seek usage of a flag (e.g `call <import_function>`)
3. Right-click and see that the flag shown by its full name
4. Fetch and build this PR
5. Open the same binary in Cutter 
6. Right click the same location and see that the realname is shown


**Closing issues**

<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
closes #2047 