### PR TITLE
Fix crash when opening theme editing window.

### DIFF
--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -156,8 +156,10 @@ DisassemblyContextMenu::DisassemblyContextMenu(QWidget *parent, MainWindow *main
 
     addSeparator();
 
-    pluginMenu = mainWindow->getContextMenuExtensions(MainWindow::ContextMenuType::Disassembly);
-    pluginActionMenuAction = addMenu(pluginMenu);
+    if (mainWindow) {
+        pluginMenu = mainWindow->getContextMenuExtensions(MainWindow::ContextMenuType::Disassembly);
+        pluginActionMenuAction = addMenu(pluginMenu);
+    }
 
     addSeparator();
 
@@ -529,9 +531,11 @@ void DisassemblyContextMenu::aboutToShowSlot()
     QString progCounterName = Core()->getRegisterName("PC").toUpper();
     actionSetPC.setText("Set " + progCounterName + " here");
 
-    pluginActionMenuAction->setVisible(!pluginMenu->isEmpty());
-    for (QAction *pluginAction : pluginMenu->actions()) {
-        pluginAction->setData(QVariant::fromValue(offset));
+    if (pluginMenu) {
+        pluginActionMenuAction->setVisible(!pluginMenu->isEmpty());
+        for (QAction *pluginAction : pluginMenu->actions()) {
+            pluginAction->setData(QVariant::fromValue(offset));
+        }
     }
 }
 

--- a/src/menus/DisassemblyContextMenu.h
+++ b/src/menus/DisassemblyContextMenu.h
@@ -163,8 +163,6 @@ private:
     QAction actionAddBreakpoint;
     QAction actionAdvancedBreakpoint;
 
-    QMenu *pluginMenu;
-
     QAction actionSetToCode;
 
     QAction actionSetAsStringAuto;
@@ -182,7 +180,8 @@ private:
 
     QAction showInSubmenu;
     QList<QAction*> showTargetMenuActions;
-    QAction *pluginActionMenuAction;
+    QMenu *pluginMenu = nullptr;
+    QAction *pluginActionMenuAction = nullptr;
 
     // For creating anonymous entries (that are always visible)
     QAction *addAnonymousAction(QString name, const char *slot, QKeySequence shortcut);


### PR DESCRIPTION
 <!-- Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request. -->


**Detailed description**

**Test plan (required)**
* Follow the steps described in #2048
* Make sure cutter doesn't crash
* Right click on disassembly text, make sure nothing bad happens.

**Closing issues**
Closes #2048 
<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
