### PR TITLE
Fix main window Icon on Wayland

### DIFF
--- a/src/CutterApplication.cpp
+++ b/src/CutterApplication.cpp
@@ -33,6 +33,7 @@ CutterApplication::CutterApplication(int &argc, char **argv) : QApplication(argc
 {
     // Setup application information
     setApplicationVersion(CUTTER_VERSION_FULL);
+    setDesktopFileName("org.radare.Cutter");
     setWindowIcon(QIcon(":/img/cutter.svg"));
     setAttribute(Qt::AA_UseHighDpiPixmaps);
     setLayoutDirection(Qt::LeftToRight);


### PR DESCRIPTION
It sets the filename of the desktop file, so it gives a precise info of
what desktop entry should be used for this application by the windowing
system.

**Detailed description**
The problem is that in Wayland (on Fedora 31) for some reasons the Icon of the main window does not work anymore. From reading around, it seems on wayland the app itself is not responsible anymore for setting that, but it is the window manager (or something) that does it. By setting the DesktopFileName you ensure that the window manager does not need to guess the relationship app <-> desktop file and it magically fix the icon issue as well.

**Test plan (required)**

I tested this on Fedora 30, both on Gnome on Xorg and Gnome on Wayland. Before the icon was working only on Gnome on Xorg, with this fix it works on Gnome on Wayland as well. I'm not sure of how this behaves on Windows or other systems though.

Before:
![before](https://user-images.githubusercontent.com/562321/73854679-2cc71d00-4833-11ea-8c29-298105b71b6b.png)


After:
![after](https://user-images.githubusercontent.com/562321/73854684-2f297700-4833-11ea-818a-dca3b3bc53f1.png)

