### PR TITLE
Add AddressableItemContextMenu bindings

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,7 +44,7 @@ project(Cutter VERSION "${CUTTER_VERSION_FULL}")
 
 set(CMAKE_CXX_STANDARD 11)
 
-include_directories(core widgets common plugins)
+include_directories(core widgets common plugins menus)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)

--- a/src/Cutter.pro
+++ b/src/Cutter.pro
@@ -87,7 +87,7 @@ win32:defined(CUTTER_DEPS_DIR, var) {
     !defined(PYSIDE_TYPESYSTEMS, var)           PYSIDE_TYPESYSTEMS="$${CUTTER_DEPS_DIR}/pyside/share/PySide2/typesystems"
 }
 
-INCLUDEPATH *= . core widgets dialogs common plugins
+INCLUDEPATH *= . core widgets dialogs common plugins menus
 
 win32 {
     # Generate debug symbols in release mode

--- a/src/bindings/bindings.h
+++ b/src/bindings/bindings.h
@@ -9,5 +9,6 @@
 #include "../core/MainWindow.h"
 #include "../widgets/CutterDockWidget.h"
 #include "../plugins/CutterPlugin.h"
+#include "../menus/AddressableItemContextMenu.h"
 
 #endif //CUTTER_BINDINGS_H

--- a/src/bindings/bindings.xml
+++ b/src/bindings/bindings.xml
@@ -14,6 +14,7 @@
         <enum-type name="ContextMenuType" />
     </object-type>
     <object-type name="BasicBlockHighlighter" />
+    <object-type name="AddressableItemContextMenu" />
     <object-type name="CutterDockWidget" />
 
     <template name="plugin_meta_get">

--- a/src/menus/AddressableItemContextMenu.cpp
+++ b/src/menus/AddressableItemContextMenu.cpp
@@ -13,31 +13,32 @@
 AddressableItemContextMenu::AddressableItemContextMenu(QWidget *parent, MainWindow *mainWindow)
     : QMenu(parent)
     , mainWindow(mainWindow)
-    , actionShowInMenu(tr("Show in"), this)
-    , actionCopyAddress(tr("Copy address"), this)
-    , actionShowXrefs(tr("Show X-Refs"), this)
-    , actionAddcomment(tr("Add comment"), this)
 {
-    connect(&actionCopyAddress, &QAction::triggered, this,
+    actionShowInMenu = new QAction(tr("Show in"), this);
+    actionCopyAddress = new QAction(tr("Copy address"), this);
+    actionShowXrefs = new QAction(tr("Show X-Refs"), this);
+    actionAddcomment = new QAction(tr("Add comment"), this);
+
+    connect(actionCopyAddress, &QAction::triggered, this,
             &AddressableItemContextMenu::onActionCopyAddress);
-    actionCopyAddress.setShortcuts({Qt::CTRL + Qt::SHIFT + Qt::Key_C});
-    actionCopyAddress.setShortcutContext(Qt::ShortcutContext::WidgetWithChildrenShortcut);
+    actionCopyAddress->setShortcuts({Qt::CTRL + Qt::SHIFT + Qt::Key_C});
+    actionCopyAddress->setShortcutContext(Qt::ShortcutContext::WidgetWithChildrenShortcut);
 
-    connect(&actionShowXrefs, &QAction::triggered, this,
+    connect(actionShowXrefs, &QAction::triggered, this,
             &AddressableItemContextMenu::onActionShowXrefs);
-    actionShowXrefs.setShortcut({Qt::Key_X});
-    actionShowXrefs.setShortcutContext(Qt::ShortcutContext::WidgetWithChildrenShortcut);
+    actionShowXrefs->setShortcut({Qt::Key_X});
+    actionShowXrefs->setShortcutContext(Qt::ShortcutContext::WidgetWithChildrenShortcut);
 
-    connect(&actionAddcomment, &QAction::triggered, this,
+    connect(actionAddcomment, &QAction::triggered, this,
             &AddressableItemContextMenu::onActionAddComment);
-    actionAddcomment.setShortcut({Qt::Key_Semicolon});
-    actionAddcomment.setShortcutContext(Qt::ShortcutContext::WidgetWithChildrenShortcut);
+    actionAddcomment->setShortcut({Qt::Key_Semicolon});
+    actionAddcomment->setShortcutContext(Qt::ShortcutContext::WidgetWithChildrenShortcut);
 
-    addAction(&actionShowInMenu);
-    addAction(&actionCopyAddress);
-    addAction(&actionShowXrefs);
+    addAction(actionShowInMenu);
+    addAction(actionCopyAddress);
+    addAction(actionShowXrefs);
     addSeparator();
-    addAction(&actionAddcomment);
+    addAction(actionAddcomment);
 
     addSeparator();
     pluginMenu = mainWindow->getContextMenuExtensions(MainWindow::ContextMenuType::Addressable);
@@ -100,10 +101,10 @@ void AddressableItemContextMenu::onActionAddComment()
 
 void AddressableItemContextMenu::aboutToShowSlot()
 {
-    if (actionShowInMenu.menu()) {
-        actionShowInMenu.menu()->deleteLater();
+    if (actionShowInMenu->menu()) {
+        actionShowInMenu->menu()->deleteLater();
     }
-    actionShowInMenu.setMenu(mainWindow->createShowInMenu(this, offset));
+    actionShowInMenu->setMenu(mainWindow->createShowInMenu(this, offset));
 
     pluginMenuAction->setVisible(!pluginMenu->isEmpty());
     for (QAction *pluginAction : pluginMenu->actions()) {

--- a/src/menus/AddressableItemContextMenu.h
+++ b/src/menus/AddressableItemContextMenu.h
@@ -39,10 +39,10 @@ private:
     bool hasTarget = false;
 protected:
     void setHasTarget(bool hasTarget);
-    QAction actionShowInMenu;
-    QAction actionCopyAddress;
-    QAction actionShowXrefs;
-    QAction actionAddcomment;
+    QAction *actionShowInMenu;
+    QAction *actionCopyAddress;
+    QAction *actionShowXrefs;
+    QAction *actionAddcomment;
 
     QString name;
     bool wholeFunction = false;

--- a/src/meson.build
+++ b/src/meson.build
@@ -77,6 +77,7 @@ if get_option('enable_python')
                              join_paths(meson.current_source_dir(), 'common'),
                              join_paths(meson.current_source_dir(), 'widgets'),
                              join_paths(meson.current_source_dir(), 'plugins'),
+                             join_paths(meson.current_source_dir(), 'menus'),
                              join_paths(meson.current_source_dir(), 'subprojects/radare2/libr/include'),
                              join_paths(meson.current_build_dir(), 'subprojects/radare2'),
                              qt5core_dep.get_pkgconfig_variable('includedir'),


### PR DESCRIPTION
**Detailed description**

Bindings to give python plugins access to AddressableItemContextMenu(see the example in the test plan). I need this for AngrCutter, probably useful for other widgets with custom tables.

**Test plan (required)**

Use this example plugin(just right click somewhere in it) and see that the options point to the given offset(0x64 in the example, you can edit `setTarget`):

```
import cutter

from PySide2.QtWidgets import QAction, QTableWidget, QTableWidgetItem, QMenu

class TestWidget(cutter.CutterDockWidget):
    def __init__(self, parent, action):
        super(TestWidget, self).__init__(parent, action)
        self.parent = parent

    def contextMenuEvent(self, event):
        menu = cutter.AddressableItemContextMenu(self, self.parent)
        menu.setTarget(0x64)
        menu.exec_(self.mapToGlobal(event.pos()))

class TestPlugin(cutter.CutterPlugin):
    def setupInterface(self, main):
        action = QAction("test", main)
        widget = TestWidget(main, action)
        main.addPluginDockWidget(widget, action)

def create_cutter_plugin():
    return TestPlugin()
```