### PR TITLE
Fix typo "Adanced" -> "Advanced"

### DIFF
--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -240,7 +240,7 @@ void DisassemblyContextMenu::addSetAsMenu()
                SLOT(on_actionSetAsString_triggered()), getSetAsStringSequence());
     initAction(&actionSetAsStringRemove, tr("Remove"),
                SLOT(on_actionSetAsStringRemove_triggered()));
-    initAction(&actionSetAsStringAdvanced, tr("Adanced"),
+    initAction(&actionSetAsStringAdvanced, tr("Advanced"),
                SLOT(on_actionSetAsStringAdvanced_triggered()));
 
 


### PR DESCRIPTION
 <!-- Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request. -->


**Detailed description**

This small Pull Request fixes a typo in the context menu where it is written "Adanced" instead of "Advanced"


**Test plan (required)**

Right click on an instruction and choose `Set as... -> String...`. See that one of the options is "Adanced". 

![image](https://user-images.githubusercontent.com/20182642/74554388-20913d00-4f62-11ea-8187-0825e8d7690f.png)


**Closing issues**
None
