### PR TITLE
Refactor hashes in dashboard to support newly added hashes

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -535,7 +535,7 @@ bool CutterCore::loadFile(QString path, ut64 baddr, ut64 mapaddr, int perms, int
     }
 
     ut64 hashLimit = getConfigut64("cfg.hashlimit");
-    r_bin_file_hash(core->bin, hashLimit, path.toUtf8().constData(), NULL);
+    r_bin_file_compute_hashes(core->bin, hashLimit);
 
     fflush(stdout);
     return true;

--- a/src/widgets/Dashboard.ui
+++ b/src/widgets/Dashboard.ui
@@ -56,7 +56,7 @@
          <x>0</x>
          <y>0</y>
          <width>1055</width>
-         <height>982</height>
+         <height>980</height>
         </rect>
        </property>
        <layout class="QHBoxLayout" name="horizontalLayout_5">
@@ -1017,7 +1017,7 @@
             </widget>
            </item>
            <item>
-            <layout class="QHBoxLayout" name="horizontalLayout_3">
+            <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="2,1">
              <property name="topMargin">
               <number>0</number>
              </property>
@@ -1058,12 +1058,15 @@
             </layout>
            </item>
            <item>
-            <layout class="QHBoxLayout" name="horizontalLayout_4">
+            <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="2,1">
              <property name="topMargin">
               <number>0</number>
              </property>
              <item>
               <layout class="QVBoxLayout" name="verticalLayout_4">
+               <property name="rightMargin">
+                <number>5</number>
+               </property>
                <item>
                 <layout class="QFormLayout" name="formLayout_2">
                  <property name="fieldGrowthPolicy">
@@ -1075,99 +1078,6 @@
                  <property name="verticalSpacing">
                   <number>3</number>
                  </property>
-                 <item row="0" column="0">
-                  <widget class="QLabel" name="label_32">
-                   <property name="font">
-                    <font>
-                     <weight>75</weight>
-                     <bold>true</bold>
-                    </font>
-                   </property>
-                   <property name="text">
-                    <string>MD5:</string>
-                   </property>
-                   <property name="textInteractionFlags">
-                    <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="1">
-                  <widget class="QLineEdit" name="md5Edit">
-                   <property name="text">
-                    <string/>
-                   </property>
-                   <property name="frame">
-                    <bool>false</bool>
-                   </property>
-                   <property name="readOnly">
-                    <bool>true</bool>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="0">
-                  <widget class="QLabel" name="label_33">
-                   <property name="font">
-                    <font>
-                     <weight>75</weight>
-                     <bold>true</bold>
-                    </font>
-                   </property>
-                   <property name="text">
-                    <string>SHA1:</string>
-                   </property>
-                   <property name="textInteractionFlags">
-                    <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="1">
-                  <widget class="QLineEdit" name="sha1Edit">
-                   <property name="text">
-                    <string/>
-                   </property>
-                   <property name="frame">
-                    <bool>false</bool>
-                   </property>
-                   <property name="readOnly">
-                    <bool>true</bool>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="2" column="0">
-                  <widget class="QLabel" name="label_8">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="font">
-                    <font>
-                     <weight>75</weight>
-                     <bold>true</bold>
-                    </font>
-                   </property>
-                   <property name="text">
-                    <string>Entropy:</string>
-                   </property>
-                   <property name="textInteractionFlags">
-                    <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="2" column="1">
-                  <widget class="QLabel" name="lblEntropy">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="text">
-                    <string notr="true"/>
-                   </property>
-                  </widget>
-                 </item>
                 </layout>
                </item>
                <item>


### PR DESCRIPTION



**Detailed description**

This Pull Request refactors the way hashes are fetches from radare2 and displayed on the dashboard. Now, instead of hard-coding some hashes and have their controls in the UI, the hashes will be automatically fetched from `itj` and displayed based on their name.
Naturally, this PR will fetch any hash and always be up-to-date with radare2. Thus, sha256 is now automatically added to the dashboard for all files.

Special cases are hashes like Authentihash, which only exists in `itj` for signed PE files.
For example, some binaries have Authentihash in the results of `itj`, this will make sure to display it if available, and any other hash that will be added later.

Binary without Authentihash:
![image](https://user-images.githubusercontent.com/20182642/75096364-98391a80-55a7-11ea-811e-818b9c7c9693.png)

Binary with Authentihash:
![image](https://user-images.githubusercontent.com/20182642/75096319-3c6e9180-55a7-11ea-8e69-f288fc920f6c.png)

Finally, this PR upgrades the radare2 submodule and fixes a regression in which the API responsible for fetching hashes changed.

**Test plan (required)**

1. Open any binary before and after the change and see that all the hashes and their values are the same. Minor UI tweaks may be possible.
2. Open a binary with Authentihash and see that it is shown in the dashboard. Example: https://github.com/radareorg/radare2-testbins/blob/master/pe/signature.exe


**Closing issues**

closes #2064 
