### PR TITLE
Change column order in X-Refs dialog

### DIFF
--- a/src/dialogs/XrefsDialog.cpp
+++ b/src/dialogs/XrefsDialog.cpp
@@ -25,7 +25,7 @@ XrefsDialog::XrefsDialog(MainWindow *main, QWidget *parent) :
     ui->fromTreeWidget->setModel(&fromModel);
 
     // Modify the splitter's location to show more Disassembly instead of empty space. Not possible via Designer
-    ui->splitter->setSizes(QList<int>() << 100 << 200);
+    ui->splitter->setSizes(QList<int>() << 300 << 400);
 
     // Increase asm text edit margin
     QTextDocument *asm_docu = ui->previewTextEdit->document();
@@ -212,14 +212,14 @@ QVariant XrefModel::data(const QModelIndex &index, int role) const
         switch (index.column()) {
         case OFFSET:
             return to ? xref.from_str : xref.to_str;
+        case TYPE:
+            return xrefTypeString(xref.type);
         case CODE:
             if (to || xref.type != "DATA") {
                 return Core()->disassembleSingleInstruction(xref.from);
             } else {
                 return QString();
             }
-        case TYPE:
-            return xrefTypeString(xref.type);
         }
         return QVariant();
     case FlagDescriptionRole:
@@ -239,10 +239,10 @@ QVariant XrefModel::headerData(int section, Qt::Orientation orientation, int rol
         switch (section) {
         case OFFSET:
             return tr("Address");
-        case CODE:
-            return tr("Code");
         case TYPE:
             return tr("Type");
+        case CODE:
+            return tr("Code");
         default:
             return QVariant();
         }

--- a/src/dialogs/XrefsDialog.h
+++ b/src/dialogs/XrefsDialog.h
@@ -14,7 +14,7 @@ private:
     QList<XrefDescription> xrefs;
     bool to;
 public:
-    enum Columns { OFFSET = 0, CODE, TYPE, COUNT };
+    enum Columns { OFFSET = 0, TYPE, CODE, COUNT };
     static const int FlagDescriptionRole = Qt::UserRole;
 
     XrefModel(QObject *parent = nullptr);

--- a/src/dialogs/XrefsDialog.ui
+++ b/src/dialogs/XrefsDialog.ui
@@ -60,6 +60,9 @@
          <property name="indentation">
           <number>5</number>
          </property>
+         <property name="sortingEnabled">
+          <bool>true</bool>
+         </property>
         </widget>
        </item>
        <item>
@@ -79,6 +82,9 @@
          </property>
          <property name="indentation">
           <number>5</number>
+         </property>
+         <property name="sortingEnabled">
+          <bool>true</bool>
          </property>
         </widget>
        </item>


### PR DESCRIPTION


**Detailed description**

This Pull Request changes the column order in xrefs dialog and increases the size of the short preview.

Now the Type column moved to the middle, so the code column will have more space to grow.
![image](https://user-images.githubusercontent.com/20182642/75098199-fec83380-55bb-11ea-9da6-90114ab56aac.png)


**Test plan (required)**

UI thingy


**Closing issues**

closes #1364, closes #1362
