### PR TITLE
Add -B option for Base Address

### DIFF
--- a/src/CutterApplication.cpp
+++ b/src/CutterApplication.cpp
@@ -85,6 +85,11 @@ CutterApplication::CutterApplication(int &argc, char **argv) : QApplication(argc
                                     QObject::tr("name"));
     cmd_parser.addOption(formatOption);
 
+    QCommandLineOption baddrOption({"B", "base"},
+                                    QObject::tr("Load binary at a specific base address"),
+                                    QObject::tr("base address"));
+    cmd_parser.addOption(baddrOption);
+
     QCommandLineOption scriptOption("i",
                                     QObject::tr("Run script file"),
                                     QObject::tr("file"));
@@ -184,6 +189,13 @@ CutterApplication::CutterApplication(int &argc, char **argv) : QApplication(argc
         InitialOptions options;
         options.filename = args[0];
         options.forceBinPlugin = cmd_parser.value(formatOption);
+        if (cmd_parser.isSet(baddrOption)) {
+            bool ok;
+            RVA baddr = cmd_parser.value(baddrOption).toULongLong(&ok, 0);
+            if (ok) {
+                options.binLoadAddr = baddr;
+            }
+        }
         if (analLevelSpecified) {
             switch (analLevel) {
             case 0:

--- a/src/dialogs/InitialOptionsDialog.cpp
+++ b/src/dialogs/InitialOptionsDialog.cpp
@@ -159,6 +159,10 @@ void InitialOptionsDialog::loadOptions(const InitialOptions &options)
         ui->formatComboBox->setCurrentIndex(0);
     }
 
+    if (options.binLoadAddr != RVA_INVALID) {
+        ui->entry_loadOffset->setText(RAddressString(options.binLoadAddr));
+    }
+
     // TODO: all other options should also be applied to the ui
 }
 


### PR DESCRIPTION
**Detailed description**

see title

**Test plan (required)**

* Start cutter like `Cutter -B 0x1337 <filename>`, then observe that the base address in the Options Dialog is filled with 0x1337
* Start cutter like `Cutter -B 0x1337 -A 1 <filename>`, then observe that the file is loaded at 0x1337.