### PR TITLE
Temporary enable manual brew update.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,6 +101,7 @@ dist: bionic
 addons:
   homebrew:
     brewfile: scripts/Brewfile
+    update: true
 
 install:
   - if [[ "$BUILD_SYSTEM" != "cmake_nodep" ]]; then


### PR DESCRIPTION
 <!-- Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request. -->


**Detailed description**

Typical homebrew+Travis:
* Hombrew breaks something that requires updating it
* Updating homebrew helps but it makes the jobs much slower
* Travis takes forover to include hombrew update in their macOS images so that manual update can be removed

Follow https://travis-ci.community/t/macos-build-fails-because-of-homebrew-bundle-unknown-command/7296 for when this can be removed.

**Test plan (required)**

Wait for Travis to become green

**Closing issues**

<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
