### PR TITLE
Add initial user documentation and improve layout and style

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,7 @@ matrix:
          - python3-sphinx
          - python3-breathe
          - python3-sphinx-rtd-theme
+         - python3-recommonmark
          - libgraphviz-dev
     install: ~
     before_script: ~

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ You can create an issue by clicking on [this link](https://github.com/radareorg/
 
 Note that cutter is still under development and many parts of the code are to be improved.
 The best way is to check the opened issues [here](https://github.com/radareorg/cutter/issues) or discuss with radareorg team.
-Please follow our contribution guidelines: https://cutter.re/docs/dev-doc.html
+Please follow our contribution guidelines: https://cutter.re/docs/developers-docs.html
 
 ## Contributing to the documentation
 

--- a/docs/cutter_theme/static/cutter.css_t
+++ b/docs/cutter_theme/static/cutter.css_t
@@ -102,7 +102,7 @@ div.sphinxsidebar h3,
 div.sphinxsidebar h4 {
     font-family: Content-font, Roboto, sans-serif;
     color: #444;
-    font-size: 24px;
+    font-size: 18px;
     font-weight: normal;
     margin: 0 0 5px 0;
     padding: 0;

--- a/docs/cutter_theme/static/cutter.css_t
+++ b/docs/cutter_theme/static/cutter.css_t
@@ -439,3 +439,58 @@ code.descname {
         margin-left: 0;
     }
 }
+/* Kbd Style */
+
+kbd {
+    font-family: Consolas, "Lucida Console", monospace;
+    display: inline-block;
+    border-radius: 3px;
+    padding: 0px 4px;
+    box-shadow: 1px 1px 1px #777;
+    margin: 2px;
+    font-size: small;
+    vertical-align: text-bottom;
+    background: #eee;
+    font-weight: 500;
+    color: #555;
+    cursor: pointer;
+    font-variant: small-caps;
+    font-weight: 600;
+    letter-spacing: 0.5px;
+    letter-spacing: 1px;
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+}
+
+kbd:hover,
+kbd:hover * {
+    color: black;
+    box-shadow: 1px 1px 1px #333;
+}
+
+kbd:active,
+kbd:active * {
+    color: black;
+    box-shadow: 1px 1px 0px #ddd inset;
+}
+
+kbd kbd {
+    padding: 0px;
+    margin: 0 1px;
+    box-shadow: 0px 0px 0px black;
+    vertical-align: baseline;
+    background: none;
+}
+
+kbd kbd:hover {
+    box-shadow: 0px 0px 0px black;
+}
+
+kbd:active kbd {
+    box-shadow: 0px 0px 0px black;
+    background: none;
+}

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,7 +1,7 @@
 .. _api:
 
 API Reference
-===========
+==============
 
 .. toctree::
    :glob:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -40,6 +40,7 @@ release = '1.10.1'
 # ones.
 extensions = [
     'breathe',
+    'recommonmark',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -49,7 +50,10 @@ templates_path = ['_templates']
 # You can specify multiple suffix as a list of string:
 #
 # source_suffix = '.rst'
-source_suffix = ['.rst', '.md']
+source_suffix = {
+    '.rst': 'restructuredtext',
+    '.md': 'markdown',
+}
 
 # The master toctree document.
 master_doc = 'index'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -109,7 +109,7 @@ html_logo = '../../src/img/cutter.ico'
 #   'using/windows': ['windowssidebar.html', 'searchbox.html'],
 # }
 html_sidebars = {
-   '**': ['globaltoc.html'],
+   '**': ['globaltoc.html', 'searchbox.html'],
 }
 
 # -- Options for HTMLHelp output ---------------------------------------------

--- a/docs/source/developers-docs.rst
+++ b/docs/source/developers-docs.rst
@@ -4,10 +4,10 @@ Developer documentation
 This page shows some hints about the coding conventions.
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
    :glob:
 
-   dev-doc/*
+   developers-docs/*
    crash-handling-system
 
 

--- a/docs/source/developers-docs/first-time.rst
+++ b/docs/source/developers-docs/first-time.rst
@@ -9,7 +9,7 @@ The first step before starting to add code to Cutter, is to build it on your env
 Read documentation
 ------------------
 
-Read :doc:`../dev-doc`.
+Read :doc:`../developers-docs`.
 
 Get familiar with current situation
 -----------------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -50,7 +50,8 @@ to learn how you can help improve the project!
    shortcuts
    building
    common-errors
-   dev-doc
+   developers-docs
+   user-docs
    plugins
    api
 

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -10,7 +10,7 @@ Instead, you will want to implement a radare2 plugin, which is documented `here 
 
 
 Loading and Overview
---------------------
+----------------------
 
 Plugins are loaded from an OS-dependent user-level directory.
 To get the location of this directory and a list of currently loaded plugins, navigate to Edit -> Preferences -> Plugins.
@@ -27,7 +27,7 @@ which will be created automatically by Cutter.
 
 
 Creating Plugins
----------------
+------------------
 
 .. toctree::
    :glob:

--- a/docs/source/user-docs.rst
+++ b/docs/source/user-docs.rst
@@ -1,0 +1,14 @@
+User documentation
+=======================
+
+This page shows contains information about the different menus in Cutter.
+
+Cutter is an advanced reverse engineering platform that is powered by radare2. This user's guide provides detailed information on how to use Cutter. The documentation for users is still on its early stages and will be improved over time.
+
+
+.. toctree::
+   :maxdepth: 2
+   :glob:
+
+   user-docs/menus
+

--- a/docs/source/user-docs/menus.rst
+++ b/docs/source/user-docs/menus.rst
@@ -1,0 +1,13 @@
+Menus
+======
+
+This part of the user documentation will provide the reader with information about the different menus and context menu item they can find on Cutter. Each item has a description that explains about its actions, as well as how to reach this feature from the UI and a keyboard shortcut, if one assigned to the feature.
+
+
+.. toctree::
+   :maxdepth: 2
+   :glob:
+
+   menus/*
+
+ 

--- a/docs/source/user-docs/menus/breakpoints-widget-context-menu.rst
+++ b/docs/source/user-docs/menus/breakpoints-widget-context-menu.rst
@@ -1,5 +1,5 @@
 Breakpoints Widget Context Menu 
-==============================
+================================
 
 
 Edit a breakpoint

--- a/docs/source/user-docs/menus/breakpoints-widget-context-menu.rst
+++ b/docs/source/user-docs/menus/breakpoints-widget-context-menu.rst
@@ -1,0 +1,25 @@
+Breakpoints Widget Context Menu 
+==============================
+
+
+Edit a breakpoint
+----------------------------------------
+**Description:** Open the Advanced Breakpoint Edit dialog to edit the selected breakpoint. In this dialog you can define a software or hardware breakpoint, use conditionals and more.    
+
+**Steps:** Right click on an item in the Breakpoints widget and choose ``Edit``.  
+
+Toggle breakpoint state
+----------------------------------------
+**Description:** Enable or disable a breakpoint, depending on its current state. An active breakpoint will be disabled, and an inactive breakpoint will be enabled.  
+
+**Steps:** Right click on an item in the Breakpoints widget and choose ``Toggle breakpoint``.   
+
+**Shortcut:** :kbd:`Space`  
+
+Delete Breakpoint
+----------------------------------------
+**Description:** This options will disable and remove the selected breakpoint from the program.  
+
+**Steps:** Right click on an item in the Breakpoints widget and choose ``Delete breakpoint``  
+
+**Shortcut:** :kbd:`Del`

--- a/docs/source/user-docs/menus/debug-->-view-menu.rst
+++ b/docs/source/user-docs/menus/debug-->-view-menu.rst
@@ -1,0 +1,64 @@
+Debug -> View Menu
+==============================
+
+Show Backtrace
+----------------------------------------
+**Description:** Display the Backtrace window.  
+***Note:** This view only available on Debug mode.*
+
+
+**Steps:** Debug -> View -> Backtrace  
+
+Show Breakpoints
+----------------------------------------
+**Description:** Show the Breakpoints widget in which you can list, manage, add, remove and define breakpoints.  
+
+**Steps:** Debug -> View -> Breakpoints  
+
+Show Threads
+----------------------------------------
+**Description:** List the threads of the running application.  
+***Note:** This view only available on Debug mode.*
+
+
+**Steps:** Debug -> View -> Threads  
+
+Show Processes
+----------------------------------------
+**Description:** The processes widget shows all the child processes and allows the user to switch between them. This is useful feature for kernel debugging or for following forks.  
+***Note:** This view only available on Debug mode.*
+
+
+**Steps:** Debug -> View -> Processes  
+
+Show Memory Map
+----------------------------------------
+**Description:** Show the Memory Map widget which shows the mapped memory pages of the running process. Including mapped memory of loaded libraries and dynamically allocated maps.  
+***Note:** This view only available on Debug mode.*
+
+
+**Steps:** Debug -> View -> Memory map  
+
+Show Registers
+----------------------------------------
+**Description:** Show the Registers widget with information of the registers and their value of the running process. The widget allows not only to view registers and flags, but also to manipulate and modify them.  
+***Note:** This view only available on Debug mode.*
+
+
+**Steps:** Debug -> View -> Registers  
+
+Show Register References
+----------------------------------------
+**Description:** The Register References widget is an extended view of the Register widget which allows you to "telescope", dereference, the register values in multiple depths.  
+***Note:** This view only available on Debug mode.*
+
+
+**Steps:** Debug -> View -> Register References  
+
+Show Stack
+----------------------------------------
+**Description:** Show the Stack widget, listing the stack values and structure of the running process.  
+***Note:** This view only available on Debug mode.*
+
+
+**Steps:** Debug -> View -> Stack

--- a/docs/source/user-docs/menus/debug-buttons-toolbar.rst
+++ b/docs/source/user-docs/menus/debug-buttons-toolbar.rst
@@ -1,0 +1,20 @@
+Debug Buttons Toolbar
+==============================
+
+Continue Until Main 
+----------------------------------------
+**Description:** Continue the execution of the program until the Main function is reached.  
+
+**Steps:**  Continue until main  
+
+Continue Until Call
+----------------------------------------
+**Description:** Continue the execution of the program until a function call is reached.  
+
+**Steps:**  Continue until call  
+
+Continue Until Syscall
+----------------------------------------
+**Description:** Continue the execution of the program until a Syscall is reached.  
+
+**Steps:**  Continue until syscall

--- a/docs/source/user-docs/menus/debug-context-menu.rst
+++ b/docs/source/user-docs/menus/debug-context-menu.rst
@@ -1,0 +1,14 @@
+Debug Context Menu
+==============================
+
+Continue until line
+----------------------------------------
+**Description:** Continue the execution of the program until reached the selected offset. The program is not guaranteed to ever reach this address and will keep running until exited or until reached another breakpoint. If other breakpoints hit before reaching this line, they will be triggered and pause the execution. *This option is only available on Debug or Emulation modes*.      
+
+**Steps:** While in Debug or Emulation modes, right-click and address and choose ``Debug -> Continue until line``.  
+
+Set Program Counter (PC)
+----------------------------------------
+**Description:** Set the Program Counter of the debuggee to the current offset. For example, on Intel 64bit program, Cutter will set the value of the RIP register to the curren address.  *This option is only available on Debug or Emulation modes*.  
+
+**Steps:** While in Debug or Emulation modes, right-click and address and choose ``Debug -> Set PC``.

--- a/docs/source/user-docs/menus/debug-menu.rst
+++ b/docs/source/user-docs/menus/debug-menu.rst
@@ -1,0 +1,73 @@
+Debug Menu
+==============================
+
+
+Start Debugging
+----------------------------------------
+**Description:** Start the debugging session of the current loaded binary.  
+
+**Steps:** Debug -> Start debug  
+
+**Shortcut:** :kbd:`F9`  
+
+Start Emulation
+----------------------------------------
+**Description:** Start an emulation session on the current loaded binary. Cutter supports emulation of different file formats. Unlike debugging, emulation isn't really executing the binary, but only emulating the instructions. This is very strong feature for analysis of self-contained functions or programs, to analyze cryptographic algorithms or to deobfuscate data. Emulation isn't limited by the running platform, so Linux files such as ELF can be emulated on Windows platforms, and DLL can be emulated on Linux.  
+
+**Steps:** Debug -> Start emulation  
+
+Attach to process
+----------------------------------------
+**Description:** Attach Cutter's debugger to a running process, instead of spawning a new process.  
+
+**Steps:** Debug -> Attach to process  
+
+Connect to a Remote Debugger
+----------------------------------------
+**Description:** Connect Cutter to a remote debugger such as GDB ot WinDbg by providing IP and Port of the remote debugger..  
+
+**Steps:** Debug -> Connect to a remote debugger  
+
+Step Into
+----------------------------------------
+**Description:** Execute a single assembler instruction, stepping into functions and loops.  
+
+**Steps:** Debug -> Step  
+
+**Shortcut:** :kbd:`F7`  
+
+Step Over
+----------------------------------------
+**Description:** Execute a single assembler instruction, stepping over functions and procedures. The functions will not be skipped and will be executed by Cutter. The execution will pause when reaching the instruction after the function call.    
+
+**Steps:** Debug -> Step over  
+
+**Shortcut:** :kbd:`F8`  
+
+Step Out
+----------------------------------------
+**Description:** Execute the code and suspends execution when the current function returns  
+
+**Steps:** Debug -> Step out  
+
+**Shortcut:** :kbd:`Ctrl` + :kbd:`F8`  
+
+Continue
+----------------------------------------
+**Description:** Continue the execution of the running program. The execution will stop when reached a breakpoint, when manually suspended by the user, or when the running program quits.   
+
+**Steps:** Debug -> Continue  
+
+**Shortcut:** :kbd:`F5`  
+
+Continue Until Call
+----------------------------------------
+**Description:** Continue the execution of the program until a function call is reached.  
+
+**Steps:** Debug -> Continue until call  
+
+Continue Until Syscall
+----------------------------------------
+**Description:** Continue the execution of the program until a Syscall is reached.  
+
+**Steps:** Debug -> Continue until syscall

--- a/docs/source/user-docs/menus/disassembly-context-menu.rst
+++ b/docs/source/user-docs/menus/disassembly-context-menu.rst
@@ -1,0 +1,121 @@
+Disassembly Context Menu 
+==============================
+
+Copy
+----------------------------------------
+**Description:** Copy the selected text.  
+
+**Steps:**  Right click on a selected text and choose ``Copy``  
+
+**Shortcut:** :kbd:`Ctrl` + :kbd:`C`  
+
+Copy Address
+----------------------------------------
+**Description:** Copy the address of the location under the cursor.  
+
+**Steps:**  Right click on a location and choose ``Copy address``  
+
+**Shortcut:** :kbd:`Ctrl` + :kbd:`Shift` + :kbd:`C`  
+
+Show address in another widget
+----------------------------------------
+**Description:** Show the selected address or item in another opened widget, or open a new one.  
+
+**Steps:**  Right click an address or an item in an instruction and choose the ``Show in`` sub-menu 
+
+Add Comment
+----------------------------------------
+**Description:** Add a comment in the current location.  
+
+**Steps:** Right click an address and choose `Add Comment`.  
+
+**Shortcut:** :kbd:`;`  
+
+Add Flag
+----------------------------------------
+**Description:** Add flag to the selected item or location by bookmarking and giving it a name.  
+
+**Steps:** Right-click an address or item and choose ``Add Flag``. This will open the Flag dialog in which you can name the location.  
+
+Rename
+----------------------------------------
+**Description:** Rename the flag in the current location.  
+
+**Steps:** Right-click an address or item and choose ``Rename``  
+
+**Shortcut:** :kbd:`N`  
+
+Edit Function
+----------------------------------------
+**Description:** Open the Function edit dialog in which you can define the name of the function, its start address, stack size, calling convention and more.  
+
+**Steps:**  Right click on a location inside a function and choose ``Edit function``.  
+
+**Shortcut:** :kbd:`Shift` + :kbd:`P`  
+
+Rename Flag/Function/Variable
+----------------------------------------
+**Description:** Rename a specific flag, variable or function under the cursor.  
+
+**Steps:**  -> Rename Flag/Fcn/Var Used Here  
+
+**Shortcut:** :kbd:`Shift` + :kbd:`N`  
+
+Re-type function local variables  
+----------------------------------------
+**Description:** Rename or set the types of the function's variables and arguments.  
+
+**Steps:** Right click anywhere inside a function and then choose ``Re-type function local vars``.  
+
+**Shortcut:** :kbd:`Y`  
+
+Delete a comment
+----------------------------------------
+**Description:** Delete the comment at the current address. This option only available for addresses with user-defined comments. 
+
+**Steps:** Right click on an instruction with a user-defined comment and choose ``Delete comment``  
+
+Delete a flag
+----------------------------------------
+**Description:**   Delete the flag at the current location.
+
+**Steps:** Right click on a location with a flag and choose ``Delete flag``.  
+
+Undefine a function
+----------------------------------------
+**Description:** Undefine the current function. This will remove the function and its associated meta-data. You can always re-define the function, but every change that was made to the previously defined function (e.g variable renaming) would not be restored.  
+
+**Steps:**  Right-Click on the name of the function and choose ``Undefine function``.  
+
+**Shortcut:** :kbd:`U`  
+
+Define a function
+----------------------------------------
+**Description:** Define a function starting from the current location. Cutter will automatically guess the size of the function. This can later be changed using the function editor.  
+
+**Steps:** Right click on an instruction and choose ``Define function here``.  
+
+**Shortcut:** :kbd:`P`  
+
+Set structure offset
+----------------------------------------
+**Description:** Present the current value is an offset in a structure. 
+
+**Steps:**  -> Structure offset  
+
+Link a type to address
+----------------------------------------
+**Description:** You can link type, enum or structure to a specific address. Types, structures and enums can be defined in the Types widget.  
+
+**Steps:** Right click on an instruction and choose ``Link Type to Address``.  
+
+**Shortcut:** :kbd:`L`  
+
+
+Show Cross References
+----------------------------------------
+**Description:** Show X-Refs from and to the specific location. This option will open Cutter's X-Refs dialog in which you will be able to see list of X-Refs from and to the selected location, in addition to a preview of each cross reference to quickly inspect the different usages.  
+
+**Steps:** Right click on an instruction and choose ``Show X-Refs``  
+
+**Shortcut:** :kbd:`X`

--- a/docs/source/user-docs/menus/edit-menu.rst
+++ b/docs/source/user-docs/menus/edit-menu.rst
@@ -1,0 +1,30 @@
+Edit Menu
+==============================
+
+Show Search widget
+----------------------------------------
+**Description:** Show the Search widget  
+
+**Steps:** Edit -> Search  
+
+Go back
+----------------------------------------
+**Description:** Seek backward to your previous location.  
+
+**Steps:** Edit -> Undo Seek  
+
+**Shortcut:** :kbd:`Alt` + :kbd:`Left`  
+
+Redo Seek
+----------------------------------------
+**Description:** Seek forward a location.   
+
+**Steps:** Edit -> Redo Seek  
+
+**Shortcut:** :kbd:`Alt` + :kbd:`Right`  
+
+Preferences
+----------------------------------------
+**Description:** Open the preferences dialog to access and define Cutter's configurations.  
+
+**Steps:** Edit -> Preferences

--- a/docs/source/user-docs/menus/file-menu.rst
+++ b/docs/source/user-docs/menus/file-menu.rst
@@ -1,0 +1,64 @@
+File Menu
+==============================
+
+New Instance of Cutter
+----------------------------------------
+**Description:** Open a new instance of Cutter to start a new session. This option will open a new window of Cutter without exiting the current session.  
+
+**Steps:** File -> New  
+
+**Shortcut:** :kbd:`Ctrl` + :kbd:`N`  
+
+Map a new file
+----------------------------------------
+**Description:** Cutter allows you to map the contents of other files into the same I/O space used to contain the loaded binary. The new contents can be placed at random or specific offsets.
+Specifically, Cutter is able to open files and map portions of them at random or specific places in memory. It is the perfect basic tooling to reproduce an environment like a core file, a debug session, or a framework by also loading and mapping all the libraries and files the binary depends on.  
+
+**Steps:** File -> Open  
+
+**Shortcut:** :kbd:`Ctrl` + :kbd:`O`  
+
+Import a PDB file
+----------------------------------------
+**Description:** Cutter allows you to load additional debugging information by loading external PDB files. Unlike other platforms, Cutter does not rely on Windows API to parse a PDB files, thus they can be loaded on any other supported platform like Linux or macOS.    
+
+**Steps:** File -> Import PDB  
+
+Save project
+----------------------------------------
+**Description:** Save your session to a project. If no project file assigned to your session, the "Save as..." dialog will open.  
+
+**Steps:** File -> Save  
+
+**Shortcut:** :kbd:`Ctrl` + :kbd:`S`  
+
+Save project as...
+----------------------------------------
+**Description:** Save the current state of your session, including function names, comments, and more.
+On the saving dialog, choose the project type that fits your needs.  
+***Note:** This feature is currently unstable and under constructions.*
+
+
+**Steps:** File -> Save As...  
+
+Export to code
+----------------------------------------
+**Description:** Export the entire binary in different formats that later can be used in your favorite programming language. The feature supports many formats such as Python arrays, java, several C array formats, javascript, and more.   
+***Note:** This isn't a decompilation feature.*
+
+
+**Steps:** File -> Export as code  
+
+Run a radare2 script
+----------------------------------------
+**Description:** Cutter allows you to execute radare2 scripts to automate task or transfer information.   
+
+**Steps:** File -> Run Script  
+
+Quit Cutter
+----------------------------------------
+**Description:** Quit and exit your current session of Cutter. On exit, you'll be asked whether you want to save your session in order to avoid losing data.   
+
+**Steps:** File -> Quit  
+
+**Shortcut:** :kbd:`Ctrl` + :kbd:`Q`

--- a/docs/source/user-docs/menus/graph-widget-context-menu.rst
+++ b/docs/source/user-docs/menus/graph-widget-context-menu.rst
@@ -1,0 +1,65 @@
+Graph Widget Context Menu 
+==============================
+
+
+Highlight Block
+----------------------------------------
+**Description:** Open the Color Picker dialog to set a background color for the selected block in the Graph view.  
+
+**Steps:** Right click on a node\block in the Graph view and choose ``Highlight block``.  
+
+UnHighlight Block
+----------------------------------------
+**Description:** If a block in the Graph view is highlighted, this option will unhighlight it and restore the original color.  
+
+**Steps:** Right click on an highlighted node\block in the Graph view and choose ``Unhighlight block``.  
+
+Highlight Instruction
+----------------------------------------
+**Description:** Open the Color Picker dialog to set a background color for the selected instruction in the Graph view.    
+
+**Steps:** Right click on an instruction in the Graph view and choose ``Highlight instruction``.  
+
+UnHighlight Instruction
+----------------------------------------
+**Description:** If an instruction in the Graph view is highlighted, this option will unhighlight it and restore the original color.   
+
+**Steps:** Right click on an highlighted instruction in the Graph view and choose ``Unhighlight instruction``.  
+
+Export Graph
+----------------------------------------
+**Description:** Export the current graph to one of the following formats:
+ - PNG Image
+ - JPEG Image
+ - SVG Image
+
+When Graphviz is installed, the following options are also available:
+ - Graphviz PostScript File
+ - Graphviz Dot File
+ - Graphviz JSON File
+ - Graphviz Gif Image
+ - Graphviz PNG Image
+ - Graphviz JPG Image
+ - Graphviz SVG Image
+ -   
+
+**Steps:** Right click anywhere on the Graph view and choose ``Export Graph``.  
+
+
+Choose Graph Layout
+----------------------------------------
+**Description:** Choose the layout to be used by Cutter to display the Graph. Cutter supports the following Graph layout algorithms:
+
+ - Grid narrow  
+ - Grid medium  
+ - Grid wide  
+ 
+When Graphviz is installed, the following options are also available:
+
+ - Graphviz polyline  
+ - Graphviz polyline LR  
+ - Graphviz ortho  
+ - Graphviz ortho LR  
+
+
+**Steps:** Right click anywhere on the Graph view and choose a layout from the ``Layout`` sub-menu.

--- a/docs/source/user-docs/menus/help-menu.rst
+++ b/docs/source/user-docs/menus/help-menu.rst
@@ -1,0 +1,14 @@
+Help Menu
+==============================
+
+About
+----------------------------------------
+**Description:**  Learn more about Cutter. View the current version of the application, the installed plugins, the authors, building options, the license, and more.  
+
+**Steps:** Help -> About  
+
+Report an issue
+----------------------------------------
+**Description:** Quickly report an issue to Cutter's GitHub repository. Clicking this option will navigate your browser to the new-issue page in Cutter's GitHub repository. It will also automatically fill relevant information inside the issue template.    
+
+**Steps:** Help -> Report an issue

--- a/docs/source/user-docs/menus/hexdump-widget-context-menu.rst
+++ b/docs/source/user-docs/menus/hexdump-widget-context-menu.rst
@@ -1,0 +1,15 @@
+Hexdump Widget Context Menu
+==============================
+
+Bytes Per Row
+----------------------------------------
+**Description:** Select how many bytes should be displayed by Cutter in each row in the Hexdump widget.
+
+Available options are:   
+ - 1 byte
+ - 2 bytes
+ - 4 bytes
+ - 8 bytes
+ - 16 bytes
+ - 32 bytes
+ - Power of 2 (Auto)

--- a/docs/source/user-docs/menus/information-windows-menu.rst
+++ b/docs/source/user-docs/menus/information-windows-menu.rst
@@ -1,0 +1,92 @@
+Information Windows Menu
+==============================
+
+Info sub-menu
+----------------------------------------
+**Description:** This is a sub-menu of the Windows menu. It contains a list of available widgets to get more information about the opened binary.
+
+**Steps:** Windows -> Info...  
+
+Show Classes
+----------------------------------------
+**Description:** List the classes that were detected in the binary.  
+
+**Steps:** Windows -> Info... -> Classes  
+
+Show Entry Points
+----------------------------------------
+**Description:** List the entry points of the binary  
+
+**Steps:** Windows -> Info... -> Entry Points  
+
+Show Exports
+----------------------------------------
+**Description:** Show a list of exported functions in the binary.  
+
+**Steps:** Windows -> Info... -> Exports  
+
+Show Flags
+----------------------------------------
+**Description:** Show the Flags widget. Flags are conceptually similar to bookmarks. They associate a name with a given offset in a file. Function names, strings, and more are considered flags.  
+
+**Steps:** Windows -> Info... -> Flags  
+
+Show Headers
+----------------------------------------
+**Description:** Show the Headers widget, displaying information about the opened file headers.  
+
+**Steps:** Windows -> Info... -> Headers  
+
+Show Imports
+----------------------------------------
+**Description:** Show the Imports widget with a list of all the imported functions required by the binary.  
+
+**Steps:** Windows -> Info... -> Imports  
+
+Show Relocations
+----------------------------------------
+**Description:** Show the Relocations widget, displaying list of relocation information.  
+
+**Steps:** Windows -> Info... -> Relocs  
+
+Show Resources
+----------------------------------------
+**Description:** Show the resources widget, which contains a list of the resources inside the binary.  
+
+**Steps:** Windows -> Info... -> Resources  
+
+Show SDB Browser
+----------------------------------------
+**Description:** Show the SDB browser widget.  
+
+**Steps:** Windows -> Info... -> SDB Browser  
+
+Show Sections
+----------------------------------------
+**Description:** Show the Sections widget which contains a list of all the sections found in the binary. The view also contains a nice visualization of raw and virtual memory layout.  
+
+**Steps:** Windows -> Info... -> Sections  
+
+Show Segments
+----------------------------------------
+**Description:** Show the Segments widget with a list of the binary segments.  
+
+**Steps:** Windows -> Info... -> Segments  
+
+Show Symbols
+----------------------------------------
+**Description:** Show the Symbols widget, with a list of symbol information from the binary, such as function names, and more.  
+
+**Steps:** Windows -> Info... -> Symbols  
+
+Show VTables
+----------------------------------------
+**Description:** Show the VTables widget, which contains information about the Virtual Tables found in the binary.  
+
+**Steps:** Windows -> Info... -> VTables  
+
+Show Zignatures
+----------------------------------------
+**Description:** Cutter has its own format of signatures, called Zignatures. This widget lists all the loaded Zignatures.  
+
+**Steps:** Windows -> Info... -> Zignatures

--- a/docs/source/user-docs/menus/manage-breakpoints-context-menu.rst
+++ b/docs/source/user-docs/menus/manage-breakpoints-context-menu.rst
@@ -1,0 +1,18 @@
+Manage Breakpoints Context Menu
+================================
+
+Add or Remove a Breakpoint
+----------------------------------------
+**Description:** Add a breakpoint at the current address. If a breakpoint already exists, Cutter will remove it.  
+
+**Steps:** Right click on an instruction and choose ``Breakpoint -> Add/remove breakpoint``  
+
+**Shortcut:** :kbd:`F2`  
+
+Advanced Breakpoint dialog
+----------------------------------------
+**Description:** Open the advanced breakpoint dialog. This dialog lets you define not only a regular breakpoint in this address, but also  an Hardware breakpoint, a conditional breakpoint, and more.
+
+**Steps:** Right click on an instruction and choose ``Breakpoint -> Advanced breakpoint``.  
+
+**Shortcut:** :kbd:`Ctrl` + :kbd:`F2`

--- a/docs/source/user-docs/menus/patching.rst
+++ b/docs/source/user-docs/menus/patching.rst
@@ -1,0 +1,26 @@
+Patching
+==============================
+
+Edit Instruction
+----------------------------------------
+**Description:** Edit the current instruction by typing a sequence of one or more instructions. Cutter will automatically fetch a preview of the bytes that are constructing the instruction.  
+
+**Steps:** Right click on an instruction and choose ``Edit -> Instruction``  
+
+Edit Bytes
+----------------------------------------
+**Description:** Edit the bytes of the current instruction by typing a sequence of bytes. Cutter will automatically disassemble a preview of the instructions that are create by the typed bytes.  
+
+**Steps:** Right click on an instruction and choose ``Edit -> Bytes``  
+
+NOP Instruction
+----------------------------------------
+**Description:** Fill the content of the instruction with NOP instructions. Cutter will fill the instructions with NOP as the length of the bytes constructing the instruction.   
+
+**Steps:** Right click on an instruction and choose ``Edit -> Nop Instruction``  
+
+Reverse Jump
+----------------------------------------
+**Description:** On conditional jumps, Cutter will detect the inverted conditional instruction and will replace it. For example, from ``je`` to ``jne``.  
+
+**Steps:** Right click on an instruction and choose ``Edit -> Reverse Jump``

--- a/docs/source/user-docs/menus/plugins-menu.rst
+++ b/docs/source/user-docs/menus/plugins-menu.rst
@@ -1,0 +1,8 @@
+Plugins Menu
+==============================
+
+Plugins sub-menu
+----------------------------------------
+**Description:** This menu will contain the windows and views created by the loaded plugins. By default, this menu is empty unless plugins added their actions and items to the menu.    
+
+**Steps:** Windows -> Plugins

--- a/docs/source/user-docs/menus/registers-widget-context-menu.rst
+++ b/docs/source/user-docs/menus/registers-widget-context-menu.rst
@@ -1,0 +1,14 @@
+Registers Widget Context Menu 
+==============================
+
+Copy Register Value
+----------------------------------------
+**Description:** Copy the value of the selected register. *This option is only available on Debug or Emulation modes*.   
+
+**Steps:** Right-click a register in the widget and choose ``Copy register value``.  
+
+Copy Register Reference
+----------------------------------------
+**Description:** Copy the value of the data referenced from the selected register. *This option is only available on Debug or Emulation modes*.  
+
+**Steps:** Right-click a register in the widget and choose ``Copy register reference``.

--- a/docs/source/user-docs/menus/set-as-code-data-string.rst
+++ b/docs/source/user-docs/menus/set-as-code-data-string.rst
@@ -1,0 +1,62 @@
+Set as Code\Data\String
+==============================
+
+Set as Code
+----------------------------------------
+**Description:** Set the current instruction to Code. This will force Cutter to display the current instruction as Code.  
+
+**Steps:** Set as... -> Code  
+
+**Shortcut:** :kbd:`C`    
+
+Set as String (auto-detect length) 
+----------------------------------------
+**Description:** Set the current location to String. This will tell Cutter to treat the current address as a string and will auto-detect the length (e.g by looking for a string null-terminator).   
+
+**Steps:** Right click on an instruction and choose ``Set as... -> String... -> Auto-detect``  
+
+**Shortcut:** :kbd:`A`  
+
+Remove string definition
+----------------------------------------
+**Description:** Remove a defined string in this address. Cutter will then treat this location as a code.  
+
+**Steps:** Right click on an instruction and choose ``Set as... -> String... -> Remove``.  
+
+Set as String (Advance dialog)
+----------------------------------------
+**Description:** Set the current location to String. This will open a String definition dialog in which the user will supply the length and the type (ASCII, UTF8, ...) of the string. Cutter will then treat the current address as the defined string.  
+
+**Steps:** Right click on an instruction and choose ``Set as... -> String... -> Advanced``.  
+
+Set as data (bytes)
+----------------------------------------
+**Description:** Convert the instruction to data of Bytes.   
+
+**Steps:** Right click on an instruction and choose ``Set as... -> Data... -> Byte``  
+
+Set as data (Word)
+----------------------------------------
+**Description:** Convert the instruction to data of Words.  
+
+**Steps:** Right click on an instruction and choose ``Set as... -> Data... -> Word``  
+
+Set as data (Dword)
+----------------------------------------
+**Description:** Convert the instruction to data of Dwords.  
+
+**Steps:** Right click on an instruction and choose ``Set as... -> Data... -> Dword``  
+
+Set as data (Qword)
+----------------------------------------
+**Description:** Convert the instruction to data of Qwords.  
+
+**Steps:** Right click on an instruction and choose ``Set as... -> Data... -> Qword``  
+
+Set as data (Advanced)
+----------------------------------------
+**Description:** Open an advanced dialog to define the custom data type of the current instruction.  
+
+**Steps:** Right click on an instruction and choose ``Set as... -> Data... -> ...``  
+
+**Shortcut:** :kbd:`*`

--- a/docs/source/user-docs/menus/set-current-bits.rst
+++ b/docs/source/user-docs/menus/set-current-bits.rst
@@ -1,0 +1,20 @@
+Set Current Bits
+==============================
+
+Set current bits to 16
+----------------------------------------
+**Description:** Set the current instruction to 16-bit.  
+
+**Steps:** Right click on an instruction and choose ``Set current bits to... -> 16``  
+
+Set current bits to 32
+----------------------------------------
+**Description:** Set the current instruction to 32-bit.    
+
+**Steps:** Right click on an instruction and choose ``Set current bits to... -> 32``  
+
+Set current bits to 64
+----------------------------------------
+**Description:** Set the current instruction to 64-bit.    
+
+**Steps:** Right click on an instruction and choose ``Set current bits to... -> 64``

--- a/docs/source/user-docs/menus/set-immediate-base.rst
+++ b/docs/source/user-docs/menus/set-immediate-base.rst
@@ -1,0 +1,50 @@
+Set Immediate Base
+==============================
+
+Set immediate base to Binary
+----------------------------------------
+**Description:** Set the immediate value of the operand to a Binary representation.
+
+**Steps:** Right click on an immediate base of instruction and choose ``Set Immediate Base to... -> Binary``  
+
+Set immediate base to Octal
+----------------------------------------
+**Description:** Set the immediate value of the operand to an Octal representation.
+
+**Steps:** Right click on an immediate base of instruction and choose ``Set Immediate Base to... -> Octal``  
+
+Set immediate base to Decimal
+----------------------------------------
+**Description:** Set the immediate value of the operand to a Decimal representation.
+
+**Steps:** Right click on an immediate base of instruction and choose ``Set Immediate Base to... -> Decimal``  
+
+Set immediate base to Hexadecimal
+----------------------------------------
+**Description:** Set the immediate value of the operand to Hexadecimal.  
+
+**Steps:** Right click on an immediate base of instruction and choose ``Set Immediate Base to... -> Hexadecimal``  
+
+Set immediate base to Network Port
+----------------------------------------
+**Description:** Set the immediate value of the operand to a Network Port  
+
+**Steps:** Right click on an immediate base of instruction and choose ``Set Immediate Base to... -> Network Port``  
+
+Set immediate base to IP Address
+----------------------------------------
+**Description:** Set the immediate value of the operand to an IP Address  
+
+**Steps:** Right click on an immediate base of instruction and choose ``Set Immediate Base to... -> IP Address``  
+
+Set immediate base to Syscall
+----------------------------------------
+**Description:** Set the immediate value of the operand to Syscall  
+
+**Steps:** Right click on an immediate base of instruction and choose ``Set Immediate Base to... -> Syscall``  
+
+Set immediate base to String
+----------------------------------------
+**Description:** Set the immediate value of the operand to String   
+
+**Steps:** Right click on an immediate base of instruction and choose ``Set Immediate Base to... -> String``

--- a/docs/source/user-docs/menus/set-table-layout.rst
+++ b/docs/source/user-docs/menus/set-table-layout.rst
@@ -1,0 +1,14 @@
+Set Table Layout
+==============================
+
+Set Table Layout to Horizontal
+----------------------------------------
+**Description:** This option sets the layout of the current widget to Horizontal, in which each row contains one or more columns with relevant information (such as offset, size, name, etc). This is the default view in most of the widgets in Cutter. 
+
+**Steps:** Right click on a widget title and select ``Horizontal``.  
+
+Set Table Layout to Vertical
+----------------------------------------
+**Description:** This option sets the layout of the current widget to Vertical, in which the items are displayed in tree-like view, where every item can be expanded to view more information.  
+
+**Steps:** Right click on a widget title and select ``Vertical``

--- a/docs/source/user-docs/menus/stack-widget-context-menu.rst
+++ b/docs/source/user-docs/menus/stack-widget-context-menu.rst
@@ -1,0 +1,9 @@
+Stack Widget Context Menu 
+==============================
+
+
+Edit Stack Value
+----------------------------------------
+**Description:** Edit the value of the current stack item using a dialog. 
+
+**Steps:** Right click on an item in the Stack widget and choose ``Edit stack value...`` to open the edit dialog.

--- a/docs/source/user-docs/menus/syncing-a-widget.rst
+++ b/docs/source/user-docs/menus/syncing-a-widget.rst
@@ -1,0 +1,9 @@
+Syncing a widget 
+==============================
+
+Sync widget to an offset
+----------------------------------------
+**Description:** By default, widgets like Disassembly, Graph, 
+Decompiler and Hexdump are synchronized with each other, pointing to the same address. A change in one widget will affect th others. We consider this feature as a Global-Seek. By unsyncing a widget, the widget will be independent of the global seek and will have its own seek location. Navigating in an unsynced widget will not change the Global-Seek of the rest of the widgets, and vice versa - Changing the Global-Seek will not affect the unsynced widget. Multiple widgets can be unsynced independently.  
+
+**Steps:**  -> Sync/unsync offset

--- a/docs/source/user-docs/menus/view-menu.rst
+++ b/docs/source/user-docs/menus/view-menu.rst
@@ -1,0 +1,66 @@
+View Menu
+==============================
+
+Refresh contents
+----------------------------------------
+**Description:** In some cases, not all the displayed information on Cutter's widgets will be up-to-date, for example - after defining a new function from the integrated radare2 console. By refreshing the contents, Cutter will fetch the most up to date information from the session and will update the different views.
+
+***Note:** In the future, Cutter will be aware to any underlying change and will update everything automatically. This is currently a work-in-progress.*
+
+
+**Steps:** View -> Refresh Contents  
+
+Reset to default layout
+----------------------------------------
+**Description:** Reset the current layout to the default layout provided by Cutter. Future additions will include custom and user-defined layouts to which you'll be able to reset.
+
+**Steps:** View -> Reset Layout  
+
+Reset to default settings
+----------------------------------------
+**Description:** Reset the current settings to the default settings defined by Cutter.  
+
+**Steps:** View -> Reset Settings  
+
+Lock and Unlock panels
+----------------------------------------
+**Description:** Allow or disable locking the different widgets.  
+
+**Steps:** View -> Unlock Panels  
+
+Show Tabs at the Top
+----------------------------------------
+**Description:** Toggle the position of the tab bar.  
+
+**Steps:** View -> Show Tabs at the Top  
+
+Grouped dock dragging
+----------------------------------------
+**Description:** When enabled, dragging a widget will also drag the widgets which are grouped to it. You can drag a specific widget from a group by dragging from the tab itself and not from the title bar. Disable this option to always drag individual widgets.   
+
+**Steps:** View -> Grouped dock dragging  
+
+
+Zoom In
+----------------------------------------
+**Description:** Zoom-In inside different widgets such as Graph, Disassembly and Hexdump.     
+
+**Steps:** View -> Zoom -> Zoom In  
+
+**Shortcut:** :kbd:`Ctrl` + :kbd:`+`  
+
+Zoom Out
+----------------------------------------
+**Description:** Zoom-Out inside different widgets such as Graph, Disassembly and Hexdump.   
+
+**Steps:** View -> Zoom -> Zoom Out  
+
+**Shortcut:** :kbd:`Ctrl` + :kbd:`-`  
+
+Reset Zoom
+----------------------------------------
+**Description:** Reset the zoom to its default size.   
+
+**Steps:** View -> Zoom -> Reset  
+
+**Shortcut:** :kbd:`Ctrl` + :kbd:`=`

--- a/docs/source/user-docs/menus/windows-menu.rst
+++ b/docs/source/user-docs/menus/windows-menu.rst
@@ -1,0 +1,91 @@
+Windows Menu
+==============================
+
+Show Dashboard
+----------------------------------------
+**Description:** Show the Dashboard panel. Cutter's dashboard contains basic information about the binary. On the Dashboard you can find:
+ - File name
+ - Binary format (PE, ELF64, ...)  
+ - Bits (16, 32, 64, ...)
+ - Binary Architecture (x86, ARM, ...)
+ - Access mode (Read, Write, Execute)
+ - Size
+ - Binary type
+ - Written Language
+ - Compiler detection
+ - Stack Canaries
+ - NX bit
+ - Position independent code
+ - Checksums (MD5, SHA1, ...)
+ - Entropy
+ - and more...
+
+
+**Steps:** Windows -> Dashboard  
+
+Show Functions
+----------------------------------------
+**Description:** Display the list of functions identified by Cutter. The list also contains information about each function such as name, address, size, and more. Some functions like Main, Entrypoint and external functions are highlighted with specific colors to make them easier to spot.   
+
+**Steps:** Windows -> Functions  
+
+Show Decompiler
+----------------------------------------
+**Description:** Cutter releases are shipped with two decompilers by default - [r2ghidra](https://github.com/radareorg/r2ghidra-dec) and [r2dec](https://github.com/radareorg/r2dec-js). The Decompiler view will display the decompilation of the current function. The widget is interactive and support address-syncing, renaming, re-typing and more. Cutter can be extended with more decompilers.   
+
+**Steps:** Windows -> Decompiler  
+
+Show Graph
+----------------------------------------
+**Description:** One of the main views of Cutter allows you to navigate inside functions in a graph mode. This view displays the flow of a functions where each node on the graph represents a basic block in the function. The edges coming-to and getting-out of the blocks represents the control flow.    
+
+**Steps:** Windows -> Graph Overview  
+
+Show Search
+----------------------------------------
+**Description:** Show the Search panel in which you can search data, strings, hex and more in the opened binary.  
+
+**Steps:** Windows -> Search  
+
+Show Strings
+----------------------------------------
+**Description:** Show the Strings view that will display all the printable strings in the program. A combo-box will allow the user to choose whether they want to view strings from the entire binary or from specific segments and sections.    
+
+**Steps:** Windows -> Strings  
+
+Show Types
+----------------------------------------
+**Description:** Show the Types widget in which you can define, load, export and manage data types such as Structures and Enums,  
+
+**Steps:** Windows -> Types  
+
+Add a new instance of the Disassembly widget
+----------------------------------------------
+**Description:** Create a new instance of the Disassembly widget in order to view one or multiple locations at the same time.   
+
+**Steps:** Windows -> Add Disassembly  
+
+Add a new instance of the Graph widget
+----------------------------------------
+**Description:** Create a new instance of the Graph widget in order to view one or multiple locations at the same time. 
+
+**Steps:** Windows -> Add Graph  
+
+Add a new instance of the Hexdump widget
+-------------------------------------------
+**Description:** Create a new instance of the Hexdump widget in order to view one or multiple locations at the same time.   
+
+**Steps:** Windows -> Add Hexdump  
+ 
+
+Show Comments
+----------------------------------------
+**Description:** Show the comments widgets in order to view the automatic and user-defined comments in this session.  
+
+**Steps:** Windows -> Comments  
+
+Show Console
+----------------------------------------
+**Description:** Open the integrated radare2 console. This will allow you to execute radare2 commands straight from Cutter.   
+
+**Steps:** Windows -> Console


### PR DESCRIPTION
### Detailed description

The main part of this pull-request is to add documentation of the menus and menu-items inside Cutter's interface. This is our first step toward providing rich and full documentation for our users. The goal of having all the menu items documented is to allow people to find how-to answers, mainly when searching on Google and other search platforms. This documentation of Menus isn't supposed to be read linearly. The initial output was produced using a Cutter plugin that iterated over all the QMenu items and their actions, and extracted names, tootlips and assigned shortcuts.

Are the results enough? Not at all. There are a lot of things to improve, but this is a great start.

In addition to this, the Pull Request also added or changed the following:
- Improve documentation CSS
    - Add support for the `<kbd>` syntax
    - Fix title header sizes
- Changed file names and layout names
- Add support for Markdown to the documentation
- Enable the Search Box
- Fix some building warning in the docs

### Screenshots

**Sidebar**
Notice the "Developer documentation" and "USer documentation". Also, the TOC title size changed and now it is smaller. Added Quick Search.
![image](https://user-images.githubusercontent.com/20182642/75693389-8ba37900-5caf-11ea-96fc-d09054b061a0.png)

**User documentation**
Notice the "Menus" submenu in the "User documentation". This page also has a description I wrote. It shows the sub items, all the menus.
![image](https://user-images.githubusercontent.com/20182642/75693525-b42b7300-5caf-11ea-8720-f8a716ad51e9.png)

**Menu item example**
Here is an example for a page describing the File menu in the interface. Notice the KBD support and the structure. Each of the titles is an anchor that can be shared.= specifically.

![image](https://user-images.githubusercontent.com/20182642/75693629-e210b780-5caf-11ea-9e39-c752eb290b1e.png)



**Test plan (required)**

Build the docs and see that you are satisfied with the changes. You can build them by executing `make html` on the docs folder, or `make quick` for the quicker option.

