### PR TITLE
[WIP] adds ability to highlight lines in disassembly/graph view

### DIFF
--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -138,8 +138,8 @@ DisassemblyContextMenu::DisassemblyContextMenu(QWidget *parent, MainWindow *main
     addSetBitsMenu();
 
     structureOffsetMenu = addMenu(tr("Structure offset"));
-    connect(structureOffsetMenu, SIGNAL(triggered(QAction*)),
-            this, SLOT(on_actionStructureOffsetMenu_triggered(QAction*)));
+    connect(structureOffsetMenu, SIGNAL(triggered(QAction *)),
+            this, SLOT(on_actionStructureOffsetMenu_triggered(QAction *)));
 
     initAction(&actionLinkType, tr("Link Type to Address"),
                SLOT(on_actionLinkType_triggered()), getLinkTypeSequence());
@@ -327,7 +327,7 @@ void DisassemblyContextMenu::addBreakpointMenu()
                SLOT(on_actionAddBreakpoint_triggered()), getAddBPSequence());
     breakpointMenu->addAction(&actionAddBreakpoint);
     initAction(&actionAdvancedBreakpoint, tr("Advanced breakpoint"),
-               SLOT(on_actionAdvancedBreakpoint_triggered()), QKeySequence(Qt::CTRL+Qt::Key_F2));
+               SLOT(on_actionAdvancedBreakpoint_triggered()), QKeySequence(Qt::CTRL + Qt::Key_F2));
     breakpointMenu->addAction(&actionAdvancedBreakpoint);
 }
 
@@ -442,16 +442,16 @@ void DisassemblyContextMenu::aboutToShowSlot()
     QVariant memDisp; // Displacement
     if (instObject.contains("opex") && instObject["opex"].toObject().contains("operands")) {
         // Loop through both the operands of the instruction
-        for (const QJsonValue value: instObject["opex"].toObject()["operands"].toArray()) {
+        for (const QJsonValue value : instObject["opex"].toObject()["operands"].toArray()) {
             QJsonObject operand = value.toObject();
             if (operand.contains("type") && operand["type"].toString() == "mem" &&
                     operand.contains("base") && !operand["base"].toString().contains("bp") &&
                     operand.contains("disp") && operand["disp"].toVariant().toLongLong() > 0) {
 
-                    // The current operand is the one which has an immediate displacement
-                    memBaseReg = operand["base"].toString();
-                    memDisp = operand["disp"].toVariant();
-                    break;
+                // The current operand is the one which has an immediate displacement
+                memBaseReg = operand["base"].toString();
+                memDisp = operand["disp"].toVariant();
+                break;
 
             }
         }
@@ -564,7 +564,7 @@ void DisassemblyContextMenu::aboutToShowSlot()
     debugMenu->menuAction()->setVisible(Core()->currentlyDebugging);
     bool hasBreakpoint = Core()->breakpointIndexAt(offset) > -1;
     actionAddBreakpoint.setText(hasBreakpoint ?
-                                     tr("Remove breakpoint") : tr("Add breakpoint"));
+                                tr("Remove breakpoint") : tr("Add breakpoint"));
     actionAdvancedBreakpoint.setText(hasBreakpoint ?
                                      tr("Edit breakpoint") : tr("Advanced breakpoint"));
     QString progCounterName = Core()->getRegisterName("PC").toUpper();
@@ -576,7 +576,7 @@ void DisassemblyContextMenu::aboutToShowSlot()
             pluginAction->setData(QVariant::fromValue(offset));
         }
     }
-    
+
     // logic for disabling "unhighlight line"
     // when the line is not highlighted
     const auto disasLinePair = getDisassemblyLine(offset);
@@ -951,7 +951,7 @@ void DisassemblyContextMenu::on_actionDisplayOptions_triggered()
     dialog.exec();
 }
 
-std::pair<DisassemblyLine*, RVA> DisassemblyContextMenu::getDisassemblyLine(RVA address)
+std::pair<DisassemblyLine *, RVA> DisassemblyContextMenu::getDisassemblyLine(RVA address)
 {
     // I wasn't able to call DisassemblyWidget::refreshDisasm
     // I believe that function will fix the stuff.
@@ -959,7 +959,7 @@ std::pair<DisassemblyLine*, RVA> DisassemblyContextMenu::getDisassemblyLine(RVA 
     QList<DisassemblyLine> lines = Core()->disassembleLines(offset, 10);
     for (int i = 0; i < lines.size() - 1; i++) {
         DisassemblyLine &line = lines[i];
-        DisassemblyLine &nextLine = lines[i+1];
+        DisassemblyLine &nextLine = lines[i + 1];
         if (line.offset <= address && address < nextLine.offset) {
             return {&line, nextLine.offset - line.offset};
         }
@@ -1024,13 +1024,12 @@ void DisassemblyContextMenu::on_actionSetAsStringAdvanced_triggered()
     dialog.setStringSizeValue(predictedStrSize);
     dialog.setStringStartAddress(offset);
 
-    if(!dialog.exec())
-    {
+    if (!dialog.exec()) {
         return;
     }
 
     uint64_t strAddr = 0U;
-    if( !dialog.getStringStartAddress(strAddr) ) {
+    if ( !dialog.getStringStartAddress(strAddr) ) {
         QMessageBox::critical(this->window(), tr("Wrong address"), tr("Can't edit string at this address"));
         return;
     }
@@ -1038,8 +1037,7 @@ void DisassemblyContextMenu::on_actionSetAsStringAdvanced_triggered()
 
     const auto strSize = dialog.getStringSizeValue();
     const auto strType = dialog.getStringType();
-    switch(strType)
-    {
+    switch (strType) {
     case EditStringDialog::StringType::Auto:
         coreStringType = CutterCore::StringTypeFormats::None;
         break;

--- a/src/menus/DisassemblyContextMenu.h
+++ b/src/menus/DisassemblyContextMenu.h
@@ -19,6 +19,7 @@ signals:
 public slots:
     void setOffset(RVA offset);
     void setCanCopy(bool enabled);
+    // QList<DisassemblyLine> getLines();
 
     /**
      * @brief Sets the value of curHighlightedWord
@@ -63,6 +64,8 @@ private slots:
     void on_actionSetAsStringAdvanced_triggered();
     void on_actionSetToData_triggered();
     void on_actionSetToDataEx_triggered();
+    std::pair<DisassemblyLine*, RVA> getDisassemblyLine(RVA address);
+    
 
     /**
      * @brief Executed on selecting an offset from the structureOffsetMenu
@@ -78,6 +81,12 @@ private slots:
      * to a type
      */
     void on_actionLinkType_triggered();
+
+    void on_actionHighlightLine_triggered();
+    void on_actionUnhighlightLine_triggered();
+
+protected:
+    QList<DisassemblyLine> lines;
 
 private:
     QKeySequence getCopySequence() const;
@@ -182,6 +191,9 @@ private:
     QList<QAction*> showTargetMenuActions;
     QMenu *pluginMenu = nullptr;
     QAction *pluginActionMenuAction = nullptr;
+
+    QAction actionHighlightLine;
+    QAction actionUnhighlightLine;
 
     // For creating anonymous entries (that are always visible)
     QAction *addAnonymousAction(QString name, const char *slot, QKeySequence shortcut);

--- a/src/menus/DisassemblyContextMenu.h
+++ b/src/menus/DisassemblyContextMenu.h
@@ -64,8 +64,8 @@ private slots:
     void on_actionSetAsStringAdvanced_triggered();
     void on_actionSetToData_triggered();
     void on_actionSetToDataEx_triggered();
-    std::pair<DisassemblyLine*, RVA> getDisassemblyLine(RVA address);
-    
+    std::pair<DisassemblyLine *, RVA> getDisassemblyLine(RVA address);
+
 
     /**
      * @brief Executed on selecting an offset from the structureOffsetMenu
@@ -188,7 +188,7 @@ private:
     QAction actionSetToDataQword;
 
     QAction showInSubmenu;
-    QList<QAction*> showTargetMenuActions;
+    QList<QAction *> showTargetMenuActions;
     QMenu *pluginMenu = nullptr;
     QAction *pluginActionMenuAction = nullptr;
 

--- a/src/widgets/DisassemblerGraphView.h
+++ b/src/widgets/DisassemblerGraphView.h
@@ -157,8 +157,6 @@ protected:
 
 private slots:
     void on_actionExportGraph_triggered();
-    void onActionHighlightBITriggered();
-    void onActionUnhighlightBITriggered();
 
 private:
     bool transition_dont_seek = false;
@@ -227,7 +225,6 @@ private:
 
     QAction actionExportGraph;
     QAction actionUnhighlight;
-    QAction actionUnhighlightInstruction;
 
     QLabel *emptyText = nullptr;
 

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -81,7 +81,7 @@ DisassemblyWidget::DisassemblyWidget(MainWindow *main, QAction *action)
     setFocusPolicy(Qt::ClickFocus);
 
     // Behave like all widgets: highlight on focus and hover
-    connect(qApp, &QApplication::focusChanged, this, [this](QWidget* , QWidget* now) {
+    connect(qApp, &QApplication::focusChanged, this, [this](QWidget *, QWidget * now) {
         QColor borderColor = this == now
                              ? palette().color(QPalette::Highlight)
                              : palette().color(QPalette::WindowText).darker();
@@ -107,7 +107,7 @@ DisassemblyWidget::DisassemblyWidget(MainWindow *main, QAction *action)
     setupFonts();
     setupColors();
 
-    disasmRefresh = createReplacingRefreshDeferrer<RVA>(false, [this](const RVA *offset) {
+    disasmRefresh = createReplacingRefreshDeferrer<RVA>(false, [this](const RVA * offset) {
         refreshDisasm(offset ? *offset : RVA_INVALID);
     });
 
@@ -220,7 +220,7 @@ void DisassemblyWidget::setPreviewMode(bool previewMode)
     }
     for (auto action : actions()) {
         if (action->shortcut() == Qt::Key_Space ||
-            action->shortcut() == Qt::Key_Escape) {
+                action->shortcut() == Qt::Key_Escape) {
             action->setEnabled(!previewMode);
         }
     }
@@ -251,7 +251,7 @@ QList<DisassemblyLine> DisassemblyWidget::getLines()
 
 void DisassemblyWidget::refreshDisasm(RVA offset)
 {
-    if(!disasmRefresh->attemptRefresh(offset == RVA_INVALID ? nullptr : new RVA(offset))) {
+    if (!disasmRefresh->attemptRefresh(offset == RVA_INVALID ? nullptr : new RVA(offset))) {
         return;
     }
 
@@ -632,10 +632,11 @@ void DisassemblyWidget::jumpToOffsetUnderCursor(const QTextCursor &cursor)
 bool DisassemblyWidget::eventFilter(QObject *obj, QEvent *event)
 {
     if (event->type() == QEvent::MouseButtonDblClick
-        && (obj == mDisasTextEdit || obj == mDisasTextEdit->viewport())) {
+            && (obj == mDisasTextEdit || obj == mDisasTextEdit->viewport())) {
         QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
 
-        const QTextCursor& cursor = mDisasTextEdit->cursorForPosition(QPoint(mouseEvent->x(), mouseEvent->y()));
+        const QTextCursor &cursor = mDisasTextEdit->cursorForPosition(QPoint(mouseEvent->x(),
+                                                                             mouseEvent->y()));
         jumpToOffsetUnderCursor(cursor);
 
         return true;
@@ -646,7 +647,7 @@ bool DisassemblyWidget::eventFilter(QObject *obj, QEvent *event)
 
 void DisassemblyWidget::keyPressEvent(QKeyEvent *event)
 {
-    if(event->key() == Qt::Key_Return) {
+    if (event->key() == Qt::Key_Return) {
         const QTextCursor cursor = mDisasTextEdit->textCursor();
         jumpToOffsetUnderCursor(cursor);
     }
@@ -785,7 +786,7 @@ struct Range {
     RVA from;
     RVA to;
 
-    inline bool contains(const Range& other) const
+    inline bool contains(const Range &other) const
     {
         return from <= other.from && to >= other.to;
     }
@@ -801,7 +802,8 @@ DisassemblyLeftPanel::DisassemblyLeftPanel(DisassemblyWidget *disas)
     this->disas = disas;
 }
 
-void DisassemblyLeftPanel::wheelEvent(QWheelEvent *event) {
+void DisassemblyLeftPanel::wheelEvent(QWheelEvent *event)
+{
     int count = -(event->angleDelta() / 15).y();
     count -= (count > 0 ? 5 : -5);
 
@@ -817,7 +819,7 @@ void DisassemblyLeftPanel::paintEvent(QPaintEvent *event)
     constexpr int distanceBetweenLines = 10;
     constexpr int arrowWidth = 5;
     int rightOffset = size().rwidth();
-    auto tEdit = qobject_cast<DisassemblyTextEdit*>(disas->getTextWidget());
+    auto tEdit = qobject_cast<DisassemblyTextEdit *>(disas->getTextWidget());
     int topOffset = int(tEdit->contentsMargins().top() + tEdit->textOffset());
     int lineHeight = disas->getFontMetrics().height();
     QColor arrowColorDown = ConfigColor("flow");
@@ -833,7 +835,7 @@ void DisassemblyLeftPanel::paintEvent(QPaintEvent *event)
     QMap<RVA, int> linesPixPosition;
     QMap<RVA, pair<RVA, int>> arrowInfo; /* offset -> (arrow, layer of arrow) */
     int nLines = 0;
-    for (const auto& line : lines) {
+    for (const auto &line : lines) {
         linesPixPosition[line.offset] = nLines * lineHeight + lineHeight / 2 + topOffset;
         nLines++;
         if (line.arrow != RVA_INVALID) {
@@ -870,7 +872,7 @@ void DisassemblyLeftPanel::paintEvent(QPaintEvent *event)
                 }
                 Range innerRange = { innerIt.key(), innerIt.value().first };
                 if (it.value().second == innerIt.value().second &&
-                    (currRange.contains(innerRange) || currRange.contains(innerRange.from))) {
+                        (currRange.contains(innerRange) || currRange.contains(innerRange.from))) {
                     it.value().second++;
                     correction = true;
                 }
@@ -892,9 +894,9 @@ void DisassemblyLeftPanel::paintEvent(QPaintEvent *event)
     const RVA currOffset = disas->getSeekable()->getOffset();
     qreal pixelRatio = qhelpers::devicePixelRatio(p.device());
     // Draw the lines
-    for (const auto& l : lines) {
+    for (const auto &l : lines) {
         int lineOffset = int((distanceBetweenLines * arrowInfo[l.offset].second + distanceBetweenLines) *
-                         pixelRatio);
+                             pixelRatio);
         // Skip until we reach a line that jumps to a destination
         if (l.arrow == RVA_INVALID) {
             continue;
@@ -914,8 +916,8 @@ void DisassemblyLeftPanel::paintEvent(QPaintEvent *event)
 
         if (lineArrowY == -1) {
             lineArrowY = jumpDown
-                              ? geometry().bottom()
-                              : 0;
+                         ? geometry().bottom()
+                         : 0;
             endVisible = false;
         }
 

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -278,7 +278,7 @@ void DisassemblyWidget::refreshDisasm(RVA offset)
     {
         TempConfig tempConfig;
         tempConfig.set("scr.color", COLOR_MODE_16M)
-		.set("asm.lines", false);
+        .set("asm.lines", false);
         lines = Core()->disassembleLines(topOffset, maxLines);
     }
 
@@ -292,11 +292,20 @@ void DisassemblyWidget::refreshDisasm(RVA offset)
             break;
         }
         cursor.insertHtml(line.text);
+
+        QColor backgroundColor;
         if (Core()->isBreakpoint(breakpoints, line.offset)) {
+            backgroundColor = ConfigColor("gui.breakpoint_background");
+        } else if (auto background = Core()->getBIHighlighter()->getBasicInstruction(line.offset)) {
+            backgroundColor = background->color;
+        }
+
+        if (backgroundColor.isValid()) {
             QTextBlockFormat f;
-            f.setBackground(ConfigColor("gui.breakpoint_background"));
+            f.setBackground(backgroundColor);
             cursor.setBlockFormat(f);
         }
+
         auto a = new DisassemblyTextBlockUserData(line);
         cursor.block().setUserData(a);
         cursor.insertBlock();

--- a/src/widgets/DisassemblyWidget.h
+++ b/src/widgets/DisassemblyWidget.h
@@ -86,7 +86,7 @@ private:
 
     void moveCursorRelative(bool up, bool page);
 
-    void jumpToOffsetUnderCursor(const QTextCursor&);
+    void jumpToOffsetUnderCursor(const QTextCursor &);
 };
 
 class DisassemblyScrollArea : public QAbstractScrollArea


### PR DESCRIPTION
**Detailed description**
Its in continuation of #1911 as author is not responding. This PR adds the ability to highlight lines/blocks in disassembly/graph view.

**Test plan (required)**
 - Highlighted instructions are properly synchronized between multiple widgets.
Code still has some issues which I wasn't able to resolve. As can be seen [here](https://github.com/nk521/cutter/blob/70c70e60c692b4420f1beda169fbe81517aaca06/src/menus/DisassemblyContextMenu.cpp#L959) I wanted to call `DisassemblyWidget::refreshDisasm` as I believe that this function will fix the stuff by calculating the correct value of `lines`. (I maybe wrong)

**Closing issues**
closes #444 
