### PR TITLE
Limit amount of JSON dumped in case of error.

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -445,7 +445,14 @@ QJsonDocument CutterCore::parseJson(const char *res, const char *cmd)
         } else {
             eprintf("Failed to parse JSON: %s\n", jsonError.errorString().toLocal8Bit().constData());
         }
-        eprintf("%s\n", json.constData());
+        const int MAX_JSON_DUMP_SIZE = 8 * 1024;
+        if (json.length() > MAX_JSON_DUMP_SIZE) {
+            int originalSize = json.length();
+            json.resize(MAX_JSON_DUMP_SIZE);
+            eprintf("%d bytes total: %s ...\n", originalSize, json.constData());
+        } else {
+            eprintf("%s\n", json.constData());
+        }
     }
 
     return doc;


### PR DESCRIPTION
 <!-- Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request. -->


**Detailed description**
This slightly mitigates #2070 by reducing chance of buffer filling up while the GUI thread is locked but doesn't fix the actual problem.

Even though it doesn't fix it there is no point dumping megabytes of JSON to console widget in case of this and any other error.  If the JSON output contains data that's necessary for debugging it's probably better to manually repeat the command and redirect output to file.

Problem of string listing generating gigabyte of data remains. Problem of stdio redirection being blocked by GUI thread remains.

**Test plan (required)**

Try opening blender executable on Linux without analysis. Check the console for new error message. If the GUI freezes it's a test plan failure not code failure as changes aren't supposed to completely prevent the deadlock problem.

<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**

<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
