### PR TITLE
Install sphinx from Pypi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,11 +69,13 @@ matrix:
       apt:
         packages:
          - doxygen
-         - python3-sphinx
-         - python3-breathe
-         - python3-sphinx-rtd-theme
-         - python3-recommonmark
          - libgraphviz-dev
+    before_install:
+      - pyenv global 3.7
+      - pip install -U sphinx
+      - pip install -U breathe
+      - pip install -U sphinx-rtd-theme
+      - pip install -U recommonmark
     install: ~
     before_script: ~
     after_success: ~


### PR DESCRIPTION

**Detailed description**

Sphinx from Ubutu's apt is an old version. In order to enjoy the latest features, including the support for the `<kbd>` tags, upgrading sphinx is required.


**Test plan (required)**

Check if built correctly and `<kbd>` objects now supported.
