### PR TITLE
Add configuration description getter to improve Initial Analysis dialog

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -912,6 +912,13 @@ bool CutterCore::getConfigb(const char *k)
     return r_config_get_i(core->config, k) != 0;
 }
 
+QString CutterCore::getConfigDescription(const char *k)
+{
+    CORE_LOCK();
+    RConfigNode *node = r_config_node_get (core->config, k);
+    return QString(node->desc);
+}
+
 void CutterCore::triggerRefreshAll()
 {
     emit refreshAll();

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -265,6 +265,7 @@ public:
     bool getConfigb(const QString &k) { return getConfigb(k.toUtf8().constData()); }
     QString getConfig(const char *k);
     QString getConfig(const QString &k) { return getConfig(k.toUtf8().constData()); }
+    QString getConfigDescription(const char *k);
     QList<QString> getColorThemes();
 
     /* Assembly\Hexdump related methods */

--- a/src/dialogs/InitialOptionsDialog.cpp
+++ b/src/dialogs/InitialOptionsDialog.cpp
@@ -31,16 +31,12 @@ InitialOptionsDialog::InitialOptionsDialog(MainWindow *main):
     for (const auto &plugin : asm_plugins) {
         ui->archComboBox->addItem(plugin, plugin);
     }
-    ui->archComboBox->setToolTip(QString("%1 (%2)")
-                                 .arg(core->getConfigDescription("asm.arch").trimmed())
-                                 .arg("asm.arch"));
+
+    setTooltipWithConfigHelp(ui->archComboBox,"asm.arch");
 
     // cpu combo box
     ui->cpuComboBox->lineEdit()->setPlaceholderText(tr("Auto"));
-
-    ui->cpuComboBox->setToolTip(QString("%1 (%2)")
-                                .arg(core->getConfigDescription("asm.cpu").trimmed())
-                                .arg("asm.cpu"));
+    setTooltipWithConfigHelp(ui->cpuComboBox, "asm.cpu");
 
     updateCPUComboBox();
 
@@ -48,13 +44,9 @@ InitialOptionsDialog::InitialOptionsDialog(MainWindow *main):
     for (const auto &plugin : core->cmdList("e asm.os=?")) {
         ui->kernelComboBox->addItem(plugin, plugin);
     }
-    ui->kernelComboBox->setToolTip(QString("%1 (%2)")
-                                   .arg(core->getConfigDescription("asm.os").trimmed())
-                                   .arg("asm.os"));
 
-    ui->bitsComboBox->setToolTip(QString("%1 (%2)")
-                                 .arg(core->getConfigDescription("asm.bits").trimmed())
-                                 .arg("asm.bits"));
+    setTooltipWithConfigHelp(ui->kernelComboBox, "asm.os");
+    setTooltipWithConfigHelp(ui->bitsComboBox, "asm.bits");
 
     for (const auto &plugin : core->getRBinPluginDescriptions("bin")) {
         ui->formatComboBox->addItem(plugin.name, QVariant::fromValue(plugin));
@@ -175,6 +167,14 @@ void InitialOptionsDialog::loadOptions(const InitialOptions &options)
 
     // TODO: all other options should also be applied to the ui
 }
+
+
+void InitialOptionsDialog::setTooltipWithConfigHelp(QWidget *w, const char *config) {
+    w->setToolTip(QString("%1 (%2)")
+                  .arg(core->getConfigDescription(config))
+                  .arg(config));
+}
+
 
 QString InitialOptionsDialog::getSelectedArch() const
 {

--- a/src/dialogs/InitialOptionsDialog.cpp
+++ b/src/dialogs/InitialOptionsDialog.cpp
@@ -31,20 +31,30 @@ InitialOptionsDialog::InitialOptionsDialog(MainWindow *main):
     for (const auto &plugin : asm_plugins) {
         ui->archComboBox->addItem(plugin, plugin);
     }
-    ui->archComboBox->setToolTip(core->cmd("e? asm.arch").trimmed());
+    ui->archComboBox->setToolTip(QString("%1 (%2)")
+                                 .arg(core->getConfigDescription("asm.arch").trimmed())
+                                 .arg("asm.arch"));
 
     // cpu combo box
     ui->cpuComboBox->lineEdit()->setPlaceholderText(tr("Auto"));
-    ui->cpuComboBox->setToolTip(core->cmd("e? asm.cpu").trimmed());
+
+    ui->cpuComboBox->setToolTip(QString("%1 (%2)")
+                                .arg(core->getConfigDescription("asm.cpu").trimmed())
+                                .arg("asm.cpu"));
+
     updateCPUComboBox();
 
     // os combo box
     for (const auto &plugin : core->cmdList("e asm.os=?")) {
         ui->kernelComboBox->addItem(plugin, plugin);
     }
-    ui->kernelComboBox->setToolTip(core->cmd("e? asm.os").trimmed());
+    ui->kernelComboBox->setToolTip(QString("%1 (%2)")
+                                   .arg(core->getConfigDescription("asm.os").trimmed())
+                                   .arg("asm.os"));
 
-    ui->bitsComboBox->setToolTip(core->cmd("e? asm.bits").trimmed());
+    ui->bitsComboBox->setToolTip(QString("%1 (%2)")
+                                 .arg(core->getConfigDescription("asm.bits").trimmed())
+                                 .arg("asm.bits"));
 
     for (const auto &plugin : core->getRBinPluginDescriptions("bin")) {
         ui->formatComboBox->addItem(plugin.name, QVariant::fromValue(plugin));

--- a/src/dialogs/InitialOptionsDialog.h
+++ b/src/dialogs/InitialOptionsDialog.h
@@ -65,6 +65,14 @@ private:
     QString getSelectedOS() const;
     QList<CommandDescription> getSelectedAdvancedAnalCmds() const;
 
+    /**
+     * @brief setTooltipWithConfigHelp is an helper function that add a tolltip to a widget with
+     * a description of a given radare2 eval config.
+     * @param w - a widget to which to add the tooltip
+     * @param config - name of a configuration variable such as "asm.bits".
+     */
+    void setTooltipWithConfigHelp(QWidget *w, const char *config);
+
 public:
     void loadOptions(const InitialOptions &options);
 


### PR DESCRIPTION

**Detailed description**

This Pull Request implements the **first part** of #1423 in which it uses r_config API to retrieve eval configuration descriptions instead of executing `e?conf.ig` to get the description.

This is a cleaner implementation that retrieves the same functionality and more.

![image](https://user-images.githubusercontent.com/20182642/76145498-85881080-6092-11ea-8cb8-fdbc7e486079.png)

The next parts will require moving all the configurations functions from Cutter core to Configuration.cpp.

https://github.com/radareorg/cutter/blob/6e4cced12e9f19d9c53bd4e32fd6943966dc2a48/src/core/Cutter.h#L251-L267

**Test plan (required)**
On Initial Analysis dialog, hover on the four configurations that were changed. Notice the little modification to the order (before: "config: desc", after: "dec (confg)"), Make sure that no regression introduced.



**Closing issues**

None
