### PR TITLE
Added options for scaling graph bitmap exports along with option for transparent background

### DIFF
--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -16,9 +16,6 @@
 #include "common/ColorThemeWorker.h"
 #include "common/SyntaxHighlighter.h"
 
-double bitmapGraphExportScale = 1.0;
-bool bitmapGraphExportTransparency = false;
-
 /* Map with names of themes associated with its color palette
  * (Dark or Light), so for dark interface themes will be shown only Dark color themes
  * and for light - only light ones.

--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -16,6 +16,9 @@
 #include "common/ColorThemeWorker.h"
 #include "common/SyntaxHighlighter.h"
 
+double bitmapGraphExportScale = 1.0;
+bool bitmapGraphExportTransparency = false;
+
 /* Map with names of themes associated with its color palette
  * (Dark or Light), so for dark interface themes will be shown only Dark color themes
  * and for light - only light ones.
@@ -706,4 +709,24 @@ bool Configuration::getDecompilerAutoRefreshEnabled()
 void Configuration::setDecompilerAutoRefreshEnabled(bool enabled)
 {
     s.setValue("decompilerAutoRefresh", enabled);
+}
+
+bool Configuration::getBitmapTransparentState()
+{
+    return bitmapGraphExportTransparency;
+}
+
+double Configuration::getBitmapExportScaleFactor()
+{
+    return bitmapGraphExportScale;
+}
+
+void Configuration::setBitmapTransparentState(bool inputValueGraph)
+{
+    bitmapGraphExportTransparency = inputValueGraph;
+}
+
+void Configuration::setBitmapExportScaleFactor(double inputValueGraph)
+{
+    bitmapGraphExportScale = inputValueGraph;
 }

--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -710,20 +710,21 @@ void Configuration::setDecompilerAutoRefreshEnabled(bool enabled)
 
 bool Configuration::getBitmapTransparentState()
 {
-    return bitmapGraphExportTransparency;
+    return s.value("bitmapGraphExportTransparency", false).value<bool>();
 }
 
 double Configuration::getBitmapExportScaleFactor()
 {
-    return bitmapGraphExportScale;
+    return s.value("bitmapGraphExportScale", 1.0).value<double>();
 }
 
 void Configuration::setBitmapTransparentState(bool inputValueGraph)
 {
-    bitmapGraphExportTransparency = inputValueGraph;
+    s.setValue("bitmapGraphExportTransparency", inputValueGraph);
 }
 
 void Configuration::setBitmapExportScaleFactor(double inputValueGraph)
 {
-    bitmapGraphExportScale = inputValueGraph;
+    s.setValue("bitmapGraphExportScale", inputValueGraph);
 }
+

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -18,6 +18,11 @@ namespace KSyntaxHighlighting {
 class QSyntaxHighlighter;
 class QTextDocument;
 
+// Graph Export Settings
+extern double bitmapGraphExportScale;
+extern bool bitmapGraphExportTransparency;
+
+
 enum ColorFlags {
     LightFlag = 1,
     DarkFlag = 2,
@@ -171,6 +176,14 @@ public:
 
     bool getDecompilerAutoRefreshEnabled();
     void setDecompilerAutoRefreshEnabled(bool enabled);
+
+    /**
+     * @brief Getters and setters for the transaparent option state and scale factor for bitmap graph exports.
+     */
+    bool getBitmapTransparentState();
+    double getBitmapExportScaleFactor();
+    void setBitmapTransparentState(bool inputValueGraph);
+    void setBitmapExportScaleFactor(double inputValueGraph);
 public slots:
     void refreshFont();
 signals:

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -18,10 +18,6 @@ namespace KSyntaxHighlighting {
 class QSyntaxHighlighter;
 class QTextDocument;
 
-// Graph Export Settings
-extern double bitmapGraphExportScale;
-extern bool bitmapGraphExportTransparency;
-
 
 enum ColorFlags {
     LightFlag = 1,
@@ -41,6 +37,10 @@ private:
     QPalette nativePalette;
     QSettings s;
     static Configuration *mPtr;
+
+    // Graph Export Settings
+    double bitmapGraphExportScale = 1.0;
+    bool bitmapGraphExportTransparency = false;
 
 #ifdef CUTTER_ENABLE_KSYNTAXHIGHLIGHTING
     KSyntaxHighlighting::Repository *kSyntaxHighlightingRepository;
@@ -184,6 +184,7 @@ public:
     double getBitmapExportScaleFactor();
     void setBitmapTransparentState(bool inputValueGraph);
     void setBitmapExportScaleFactor(double inputValueGraph);
+
 public slots:
     void refreshFont();
 signals:

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -38,10 +38,6 @@ private:
     QSettings s;
     static Configuration *mPtr;
 
-    // Graph Export Settings
-    double bitmapGraphExportScale = 1.0;
-    bool bitmapGraphExportTransparency = false;
-
 #ifdef CUTTER_ENABLE_KSYNTAXHIGHLIGHTING
     KSyntaxHighlighting::Repository *kSyntaxHighlightingRepository;
 #endif

--- a/src/dialogs/preferences/GraphOptionsWidget.cpp
+++ b/src/dialogs/preferences/GraphOptionsWidget.cpp
@@ -14,7 +14,8 @@ GraphOptionsWidget::GraphOptionsWidget(PreferencesDialog *dialog)
       ui(new Ui::GraphOptionsWidget)
 {
     ui->setupUi(this);
-
+    ui->checkTransparent->setChecked(Config()->getBitmapTransparentState());
+    ui->bitmapGraphScale->setValue(Config()->getBitmapExportScaleFactor()*100.0);
     updateOptionsFromVars();
 
     connect(Core(), SIGNAL(graphOptionsChanged()), this, SLOT(updateOptionsFromVars()));
@@ -50,3 +51,22 @@ void GraphOptionsWidget::on_graphOffsetCheckBox_toggled(bool checked)
     Config()->setConfig("graph.offset", checked);
     triggerOptionsChanged();
 }
+
+void GraphOptionsWidget::on_checkTransparent_stateChanged(int checked)
+{
+    bool temp_transparency;
+    if(checked){
+        temp_transparency=true;
+    }else{
+        temp_transparency=false;
+    }
+    Config()->setBitmapTransparentState(checked);
+
+}
+
+void GraphOptionsWidget::on_bitmapGraphScale_valueChanged(double value)
+{
+    double value_decimal = value/(double)100.0;
+    Config()->setBitmapExportScaleFactor(value_decimal);
+}
+

--- a/src/dialogs/preferences/GraphOptionsWidget.cpp
+++ b/src/dialogs/preferences/GraphOptionsWidget.cpp
@@ -18,6 +18,9 @@ GraphOptionsWidget::GraphOptionsWidget(PreferencesDialog *dialog)
     ui->bitmapGraphScale->setValue(Config()->getBitmapExportScaleFactor()*100.0);
     updateOptionsFromVars();
 
+    connect<void(QDoubleSpinBox::*)(double)>(ui->bitmapGraphScale, (&QDoubleSpinBox::valueChanged), this, &GraphOptionsWidget::bitmapGraphScaleValueChanged);
+    connect(ui->checkTransparent, &QCheckBox::stateChanged, this, &GraphOptionsWidget::checkTransparentStateChanged);
+
     connect(Core(), SIGNAL(graphOptionsChanged()), this, SLOT(updateOptionsFromVars()));
 }
 
@@ -52,19 +55,12 @@ void GraphOptionsWidget::on_graphOffsetCheckBox_toggled(bool checked)
     triggerOptionsChanged();
 }
 
-void GraphOptionsWidget::on_checkTransparent_stateChanged(int checked)
+void GraphOptionsWidget::checkTransparentStateChanged(int checked)
 {
-    bool temp_transparency;
-    if(checked){
-        temp_transparency=true;
-    }else{
-        temp_transparency=false;
-    }
     Config()->setBitmapTransparentState(checked);
-
 }
 
-void GraphOptionsWidget::on_bitmapGraphScale_valueChanged(double value)
+void GraphOptionsWidget::bitmapGraphScaleValueChanged(double value)
 {
     double value_decimal = value/(double)100.0;
     Config()->setBitmapExportScaleFactor(value_decimal);

--- a/src/dialogs/preferences/GraphOptionsWidget.h
+++ b/src/dialogs/preferences/GraphOptionsWidget.h
@@ -20,9 +20,7 @@ class GraphOptionsWidget : public QDialog
 
 public:
     explicit GraphOptionsWidget(PreferencesDialog *dialog);
-    bool getExportBitmapTransparency();
     ~GraphOptionsWidget();
-    bool exportGraphTranparency();
 private:
     std::unique_ptr<Ui::GraphOptionsWidget> ui;
 
@@ -34,8 +32,9 @@ private slots:
     void on_maxColsSpinBox_valueChanged(int value);
     void on_graphOffsetCheckBox_toggled(bool checked);
 
-    void on_bitmapGraphScale_valueChanged(double value);
-    void on_checkTransparent_stateChanged(int checked);
+    void checkTransparentStateChanged(int checked);
+    void bitmapGraphScaleValueChanged(double value);
+  
 };
 
 

--- a/src/dialogs/preferences/GraphOptionsWidget.h
+++ b/src/dialogs/preferences/GraphOptionsWidget.h
@@ -20,8 +20,9 @@ class GraphOptionsWidget : public QDialog
 
 public:
     explicit GraphOptionsWidget(PreferencesDialog *dialog);
+    bool getExportBitmapTransparency();
     ~GraphOptionsWidget();
-
+    bool exportGraphTranparency();
 private:
     std::unique_ptr<Ui::GraphOptionsWidget> ui;
 
@@ -32,6 +33,9 @@ private slots:
 
     void on_maxColsSpinBox_valueChanged(int value);
     void on_graphOffsetCheckBox_toggled(bool checked);
+
+    void on_bitmapGraphScale_valueChanged(double value);
+    void on_checkTransparent_stateChanged(int checked);
 };
 
 

--- a/src/dialogs/preferences/GraphOptionsWidget.ui
+++ b/src/dialogs/preferences/GraphOptionsWidget.ui
@@ -45,11 +45,20 @@
      </item>
      <item row="1" column="1">
       <widget class="QDoubleSpinBox" name="bitmapGraphScale">
+       <property name="suffix">
+        <string>%</string>
+       </property>
+       <property name="decimals">
+        <number>0</number>
+       </property>
        <property name="minimum">
         <double>100.000000000000000</double>
        </property>
        <property name="maximum">
         <double>30000.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>50.000000000000000</double>
        </property>
       </widget>
      </item>

--- a/src/dialogs/preferences/GraphOptionsWidget.ui
+++ b/src/dialogs/preferences/GraphOptionsWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>567</width>
-    <height>79</height>
+    <width>557</width>
+    <height>175</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -36,6 +36,23 @@
        </property>
       </widget>
      </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="bitmapGraphScaleLabel">
+       <property name="text">
+        <string>Graph Bitmap Export Scale: </string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QDoubleSpinBox" name="bitmapGraphScale">
+       <property name="minimum">
+        <double>100.000000000000000</double>
+       </property>
+       <property name="maximum">
+        <double>30000.000000000000000</double>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item>
@@ -57,6 +74,19 @@
       </property>
       <property name="text">
        <string>Show offsets (graph.offset)</string>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="checkTransparent">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>30</y>
+        <width>361</width>
+        <height>31</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Export Transparent Bitmap Graphs</string>
       </property>
      </widget>
     </widget>

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -1157,12 +1157,14 @@ void DisassemblerGraphView::onActionUnhighlightBITriggered()
 
 void DisassemblerGraphView::exportGraph(QString filePath, GraphExportType type)
 {
+    bool graphTransparent = Config()->getBitmapTransparentState();
+    double graphScaleFactor = Config()->getBitmapExportScaleFactor();
     switch (type) {
     case GraphExportType::Png:
-        this->saveAsBitmap(filePath, "png");
+        this->saveAsBitmap(filePath, "png", graphScaleFactor, graphTransparent);
         break;
     case GraphExportType::Jpeg:
-        this->saveAsBitmap(filePath, "jpg");
+        this->saveAsBitmap(filePath, "jpg", graphScaleFactor, false);
         break;
     case GraphExportType::Svg:
         this->saveAsSvg(filePath);

--- a/src/widgets/GraphView.cpp
+++ b/src/widgets/GraphView.cpp
@@ -397,13 +397,17 @@ void GraphView::paint(QPainter &p, QPoint offset, QRect viewport, qreal scale, b
     }
 }
 
-void GraphView::saveAsBitmap(QString path, const char *format)
+void GraphView::saveAsBitmap(QString path, const char *format, double scaler, bool transparent)
 {
-    QImage image(width, height, QImage::Format_RGB32);
-    image.fill(backgroundColor);
+    QImage image(width*scaler, height*scaler, QImage::Format_ARGB32);
+    if(transparent){
+        image.fill(qRgba(0, 0, 0, 0));
+    }else{
+        image.fill(backgroundColor);
+    }
     QPainter p;
     p.begin(&image);
-    paint(p, QPoint(0, 0), image.rect(), 1.0, false);
+    paint(p, QPoint(0, 0), image.rect(), scaler, false);
     p.end();
     if (!image.save(path, format)) {
         qWarning() << "Could not save image";

--- a/src/widgets/GraphView.h
+++ b/src/widgets/GraphView.h
@@ -82,7 +82,7 @@ public:
 
     void paint(QPainter &p, QPoint offset, QRect area, qreal scale = 1.0, bool interactive = true);
 
-    void saveAsBitmap(QString path, const char *format = nullptr);
+    void saveAsBitmap(QString path, const char *format = nullptr, double scaler = 1.0, bool transparent = false);
     void saveAsSvg(QString path);
 protected:
     std::unordered_map<ut64, GraphBlock> blocks;


### PR DESCRIPTION
 <!-- Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request. -->


**Detailed description**

<!-- Explain the **details** for making this change. What existing problem does the pull request solve? Please provide enough information so that others can review your pull request -->
**Functionalities added:**
- Edit -> Preferences -> Disassembly-Graph, user can choose if they want the exported bitmap image to be transparent or not. [Checkbox]
At the same location, there is Double SpinBox using which user can select the scaling factor (>=100% to 30000%). The maximum being 30000% is pure arbitrary choice that I made as a factor even as large as 30000% is not useful for any situations I could think of. This can be increased if needed, but I don't think there is a point.
- Normal export, if the user selects the extensions png/jpg (bitmap), this will export with the given scaling factor. If the option transaparent is selected, png export will be transparent. **Note : jpg doesn't support transparency** So if a user select transparent for a jpg export, by default the background will be the ui background color.
- In a session, if a user selects the scaling factor and transparency for the exported bitmap images once, it will remain so as long they are in the current session. User can change this at any point if they want.

**Changes made to code and additions.**

- Defined two **private** variables **_double bitmapGraphExportScale_** and **_bool bitmapGraphExportTransparency_** in _common/Configuration.h_  in _common/Configuration.cpp_.

These variables store the details about how much graph should be scaled while exporting and if it should be transparent or not.

- Made _getter_ and _setter_ functions for _bitmapGraphExportScale_ and _bitmapGraphExportTransparency_ in Configuration.cpp.

- In _dialogs/preferences/GraphOptionsWidget_ made a checkbox for transparency and double spinbox for scaling factor.

- When changes are made to the transparency and/or spinbox, call the respective setter function in _Configuration.cpp_ to update the value of transparency and/or spinbox.

- In _src/widgets/Graphview.cpp,_ changed the function definition of _saveAsBitmap_ from 
`void void saveAsBitmap(QString path, const char *format = nullptr)`
to
`void saveAsBitmap(QString path, const char *format = nullptr, double scaler = 1.0, bool transparent = false);`
The file saved by the _saveAsBitmap_ functions is according to the scaling factor and transparent [or not] option selected by the user.

- In _src/widgets/DisassemblerGraphView.cpp,_ in function _DisassemblerGraphView::exportGraph_ two variables are assigned the current value of both _bitmapGraphExportScale_ and _bitmapGraphExportTransparency_. These variables are passed arguments if the graph is exported in bitmap format.

**Test plan (required)**

The UI in Edit -> Preferences -> Disassembly-Graph will change from 
![GraphOptionsWidgetEarlier](https://user-images.githubusercontent.com/18501167/76172493-ab113900-61bc-11ea-8e1a-b0d4c6aebd0e.png)
     to the following [updated with the changes requested]
![graph-options-updated](https://user-images.githubusercontent.com/18501167/76238061-4229cf80-6255-11ea-844e-0820a633f8f5.png)


_**Bitmap exported graphs before and after selecting scaling factor and transparency**_

Native theme
![5-native-normal](https://user-images.githubusercontent.com/18501167/76172547-4bfff400-61bd-11ea-9d36-771264f5e618.png)
this has been scaled to 300% and exported selecting transparent background. Result is the following.
![6-native-scaled-trans](https://user-images.githubusercontent.com/18501167/76172562-72be2a80-61bd-11ea-8573-997dc4aa3b3a.png)

Midnight theme
![3-midnight-normal](https://user-images.githubusercontent.com/18501167/76172575-8cf80880-61bd-11ea-92ec-6fcd3e5c35e7.png)
this has been exported as transparent with default scaling(100%). Result is the follwing
![4-midnight-normal-trans](https://user-images.githubusercontent.com/18501167/76172594-a4cf8c80-61bd-11ea-93d4-2ca13a97d74f.png)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**
closes #1998 
<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
