### PR TITLE
Toggle remove option for string definition of instruction (#2059)

### DIFF
--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -459,13 +459,9 @@ void DisassemblyContextMenu::aboutToShowSlot()
 
     actionAnalyzeFunction.setVisible(true);
 
-    Core()->seek(offset);
-    QString stringDefiniton = Core()->cmd("Cs.");
-    if (stringDefiniton.isNull() || stringDefiniton.isEmpty()) {
-        actionSetAsStringRemove.setVisible(false);
-    } else {
-        actionSetAsStringRemove.setVisible(true);
-    }
+    // Show the option to remove a defined string only if a string is defined in this address
+    QString stringDefinition = Core()->cmd("Cs. @ " + RAddressString(offset));
+    actionSetAsStringRemove.setVisible(!stringDefinition.isEmpty());
 
     QString comment = Core()->cmd("CC." + RAddressString(offset));
     if (comment.isNull() || comment.isEmpty()) {

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -459,6 +459,14 @@ void DisassemblyContextMenu::aboutToShowSlot()
 
     actionAnalyzeFunction.setVisible(true);
 
+    Core()->seek(offset);
+    QString stringDefiniton = Core()->cmd("Cs.");
+    if (stringDefiniton.isNull() || stringDefiniton.isEmpty()) {
+        actionSetAsStringRemove.setVisible(false);
+    } else {
+        actionSetAsStringRemove.setVisible(true);
+    }
+
     QString comment = Core()->cmd("CC." + RAddressString(offset));
     if (comment.isNull() || comment.isEmpty()) {
         actionDeleteComment.setVisible(false);


### PR DESCRIPTION
<!-- Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request. -->
**Things to be discussed:**
- The way the functionality is implemented.

**Detailed description**

**Functional Changes**
- The remove option would be visible once the String definition is set.
- The remove option would be hidden once the String definition is removed.

**Code Changes**
In **DisassemblyContextMenu.cpp**, following changes are added:
- Seek to instruction offset `seek(offset)`.
- Retrieve string definition at the address using `Cs.`. 
- If the string definition is present, set the visibility of `actionSetAsStringRemove` to true, otherwise, set it to false.

<!-- Explain the **details** for making this change. What existing problem does the pull request solve? Please provide enough information so that others can review your pull request -->
**Problem solved by pull request**
- The option to remove the definition of a String will only be there when the instruction is defined as String.

**Test plan (required)**

**Changes in the UI**
- For instruction at address `0x000021c4`, we verify that the remove option is hidden when the string definition is not set:
![test-1](https://user-images.githubusercontent.com/7266024/76692819-e0ee6b80-665b-11ea-878b-667984bc6647.png)

- Once the String definition is set for instruction at `0x000021c4`, we check the remove option for another instruction at address `0x000021e1` and we make sure that it is not visible in the menu: 
![test-2](https://user-images.githubusercontent.com/7266024/76692820-eba90080-665b-11ea-8976-f1e4c5d786a7.png)

- Finally, for the instruction at `0x000021c4`, we ensure that the remove option is now visible in the menu as the string definition is set:
![test-3](https://user-images.githubusercontent.com/7266024/76692822-f06db480-665b-11ea-96ba-5da9bae3d2bb.png)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**

<!-- put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Closes #2059