### PR TITLE
Improve cmake building instructions to support older versions

### DIFF
--- a/docs/source/building.rst
+++ b/docs/source/building.rst
@@ -53,18 +53,29 @@ Then invoke CMake to build Cutter and its dependency radare2.
 
 .. code:: sh
 
-   cd cutter/src
-   mkdir build
-   cmake -B build -DCUTTER_USE_BUNDLED_RADARE2=ON
+   cd cutter
+   mkdir build && cd build
+   cmake -DCUTTER_USE_BUNDLED_RADARE2=ON ../src
+   cmake --build .
+
+If your operating system has a newer version of CMake (> v3.12) you can use this cleaner solution:
+
+.. code:: sh
+
+   cd cutter
+   cmake -S src -B build -DCUTTER_USE_BUNDLED_RADARE2=ON
    cmake --build build
 
 
-If you are interested in building Cutter with support for Python plugins,
-Syntax Highlighting, Crash Reporting and more,
-please look at the full list of `CMake Building Options`_.
+.. note::
 
-After the build process is complete, you should be provided with Cutter executable
-that you can start like this:
+   If you are interested in building Cutter with support for Python plugins,
+   Syntax Highlighting, Crash Reporting and more,
+   please look at the full list of `CMake Building Options`_.
+
+
+After the build process is complete, you should have the Cutter executable in the `build` folder.
+You can now execute Cutter like this:
 
 .. code:: sh
 


### PR DESCRIPTION

**Detailed description**

Older versions of CMake (prior to  v3.13) does not have support for the `-B` flag. Distributions as Ubunto 18 and 16 have older versions.

This PR will make the building instructions compatible with old versions of cmake, while still suggesting the cleaner and newer solution.

**Test plan (required)**


![image](https://user-images.githubusercontent.com/20182642/76628822-04bf8d80-6546-11ea-9646-6487a2c49111.png)


