### PR TITLE
add astyle backup .orig extension in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,6 @@ src/out
 /cutter-deps
 
 /breakpad
+
+# astyle backup .orig files
+*.orig


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Add `orig` extension in .gitignore. `orig` is a backup generated by astyle.