### PR TITLE
Refactor radare2 commands usage in Cutter using cmdRaw and cmdRawAt

### DIFF
--- a/docs/source/developers-docs.rst
+++ b/docs/source/developers-docs.rst
@@ -29,10 +29,20 @@ Example:
 Calling a radare2 command
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-There are two ways to call a radare2 command: 
+There are multiple ways to call a radare2 command: 
 
-- ``CutterCore::cmd()`` *(Discouraged)* Only use it for commands which yells no output
-- ``CutterCore::cmdj()`` To be used with json commands like ``cmdj("agj")`` or ``cmdj("aflj")``.
+- ``CutterCore::cmdj(<command>)`` - To be used with json commands like ``cmdj("agj")`` or ``cmdj("aflj")``. 
+  This is the command we used to fetch structured data from radare2.
+  
+- ``CutterCore::cmdRaw(<command>)`` - Executes a single radare2 command 
+ without going through radare2 shell functionality like output redirects, grep, and multiple command parsing.
+The command then returns its output. This should be used when a command doesn't have output or the output should be handled as-is. If possible, using the json variation with ``cmdj`` is always preferred.
+  
+- ``CutterCore::cmdRawAt(<command>, <address>)`` - Executes a single radare2 command in a given address and returns the output. This helps avoiding weird strings concatenation like ``cmd("ph " + hash + " @ " + QString::num(address))``.
+  
+- ``CutterCore::cmd()`` - *(Discouraged)* Only use it when ``cmdj`` or ``cmdRaw`` cannot be used. This is used for complex commands using concatenation of several commands (``px 5; pd 7; afl;``), for grepping (``pd 5~call``). for commands inside commands (``?e `afn.```) and so on.
+  This is also used when the output is complex and does not parsed correctly in ``cmdRaw``.
+  Make sure to carefully sanitize user-controlled variables that are passed to the command, to avoid unexpected command injections. 
 
 Generally, if one needs to retrieve information from a radare2 command, it
 is preferred to use the json API.
@@ -56,6 +66,11 @@ Example:
 .. code:: cpp
 
    Core()->seek(0x00C0FFEE);
+
+.. note::
+
+ Cutter also supports a silent seek which doesn't trigger the ``seekChanged`` event and doesn't add new entries to the seek history.
+
 
 Creating a widget
 ~~~~~~~~~~~~~~~~~

--- a/src/common/AnalTask.cpp
+++ b/src/common/AnalTask.cpp
@@ -60,7 +60,7 @@ void AnalTask::runTask()
     }
 
     if (!options.os.isNull()) {
-        Core()->cmd("e asm.os=" + options.os);
+        Core()->cmdRaw("e asm.os=" + options.os);
     }
 
     if (!options.pdbFile.isNull()) {
@@ -74,14 +74,14 @@ void AnalTask::runTask()
 
     if (!options.shellcode.isNull() && options.shellcode.size() / 2 > 0) {
         log(tr("Loading shellcode..."));
-        Core()->cmd("wx " + options.shellcode);
+        Core()->cmdRaw("wx " + options.shellcode);
     }
 
     if (options.endian != InitialOptions::Endianness::Auto) {
         Core()->setEndianness(options.endian == InitialOptions::Endianness::Big);
     }
 
-    Core()->cmd("fs *");
+    Core()->cmdRaw("fs *");
 
     if (!options.script.isNull()) {
         log(tr("Executing script..."));
@@ -102,6 +102,7 @@ void AnalTask::runTask()
                 return;
             }
             log(cmd.description);
+            // use cmd instead of cmdRaw because commands can be unexpected
             Core()->cmd(cmd.command);
         }
         log(tr("Analysis complete!"));

--- a/src/common/ColorThemeWorker.cpp
+++ b/src/common/ColorThemeWorker.cpp
@@ -167,9 +167,9 @@ QJsonDocument ColorThemeWorker::getTheme(const QString& themeName) const
     QString curr = Config()->getColorTheme();
 
     if (themeName != curr) {
-        Core()->cmd(QString("eco %1").arg(themeName));
+        Core()->cmdRaw(QString("eco %1").arg(themeName));
         theme = Core()->cmdj("ecj").object().toVariantMap();
-        Core()->cmd(QString("eco %1").arg(curr));
+        Core()->cmdRaw(QString("eco %1").arg(curr));
     } else {
         theme = Core()->cmdj("ecj").object().toVariantMap();
     }

--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -208,7 +208,7 @@ int Configuration::getNewFileLastClicked()
 
 void Configuration::resetAll()
 {
-    Core()->cmd("e-");
+    Core()->cmdRaw("e-");
     Core()->setSettings();
     // Delete the file so no extra configuration is in it.
     QFile settingsFile(s.fileName());
@@ -524,10 +524,10 @@ const QColor Configuration::getColor(const QString &name) const
 void Configuration::setColorTheme(const QString &theme)
 {
     if (theme == "default") {
-        Core()->cmd("ecd");
+        Core()->cmdRaw("ecd");
         s.setValue("theme", "default");
     } else {
-        Core()->cmd(QStringLiteral("eco %1").arg(theme));
+        Core()->cmdRaw(QStringLiteral("eco %1").arg(theme));
         s.setValue("theme", theme);
     }
 

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -76,8 +76,7 @@ public:
     /**
      * @brief Execute a radare2 command \a cmd.  By nature, the API
      * is executing raw commands, and thus ignores multiple commands and overcome command injections.
-     * @param cmd - a raw command to execute. If multiple commands will be passed (e.g "px 5; pd 7 && pdf") then
-     * only the first command will be executed.
+     * @param cmd - a raw command to execute. Passing multiple commands (e.g "px 5; pd 7 && pdf") will result in them treated as arguments to first command.
      * @return the output of the command
      */
     QString cmdRaw(const char *cmd);
@@ -90,7 +89,8 @@ public:
     /**
      * @brief Execute a radare2 command \a cmd at \a address. The function will preform a silent seek to the address
      * without triggering the seekChanged event nor adding new entries to the seek history. By nature, the
-     * API is executing raw commands, and thus ignores multiple commands and overcome command injections.
+     * API is executing a single command without going through radare2 shell, and thus ignores multiple commands 
+     * and tries to overcome command injections.
      * @param cmd - a raw command to execute. If multiple commands will be passed (e.g "px 5; pd 7 && pdf") then
      * only the first command will be executed.
      * @param address - an address to which Cutter will temporarily seek.

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -72,10 +72,23 @@ public:
      */
     bool asyncCmd(const char *str, QSharedPointer<R2Task> &task);
     bool asyncCmd(const QString &str, QSharedPointer<R2Task> &task) { return asyncCmd(str.toUtf8().constData(), task); }
-    QString cmdRaw(const QString &str);
 
     /**
-     * @brief Execute a command \a cmd at \a address. The function will preform a silent seek to the address
+     * @brief Execute a radare2 command \a cmd.  By nature, the API
+     * is executing raw commands, and thus ignores multiple commands and overcome command injections.
+     * @param cmd - a raw command to execute. If multiple commands will be passed (e.g "px 5; pd 7 && pdf") then
+     * only the first command will be executed.
+     * @return the output of the command
+     */
+    QString cmdRaw(const char *cmd);
+
+    /**
+     * @brief a wrapper around cmdRaw(const char *cmd,).
+     */
+    QString cmdRaw(const QString &cmd) { return cmdRaw(cmd.toUtf8().constData()); };
+
+    /**
+     * @brief Execute a radare2 command \a cmd at \a address. The function will preform a silent seek to the address
      * without triggering the seekChanged event nor adding new entries to the seek history. By nature, the
      * API is executing raw commands, and thus ignores multiple commands and overcome command injections.
      * @param cmd - a raw command to execute. If multiple commands will be passed (e.g "px 5; pd 7 && pdf") then
@@ -89,6 +102,7 @@ public:
      * @brief a wrapper around cmdRawAt(const char *cmd, RVA address).
      */
     QString cmdRawAt(const QString &str, RVA address) { return cmdRawAt(str.toUtf8().constData(), address); }
+    
     QJsonDocument cmdj(const char *str);
     QJsonDocument cmdj(const QString &str) { return cmdj(str.toUtf8().constData()); }
     QStringList cmdList(const char *str) { return cmd(str).split(QLatin1Char('\n'), QString::SkipEmptyParts); }

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -532,7 +532,7 @@ void MainWindow::displayInitialOptionsDialog(const InitialOptions &options, bool
 
 void MainWindow::openProject(const QString &project_name)
 {
-    QString filename = core->cmd("Pi " + project_name);
+    QString filename = core->cmdRaw("Pi " + project_name);
     setFilename(filename.trimmed());
 
     core->openProject(project_name);
@@ -547,7 +547,7 @@ void MainWindow::finalizeOpen()
     refreshAll();
 
     // Add fortune message
-    core->message("\n" + core->cmd("fo"));
+    core->message("\n" + core->cmdRaw("fo"));
     showMaximized();
 
 
@@ -1551,6 +1551,8 @@ void MainWindow::on_actionExport_as_code_triggered()
     tempConfig.set("io.va", false);
     QTextStream fileOut(&file);
     QString &cmd = cmdMap[dialog.selectedNameFilter()];
+
+    // Use cmd because cmdRaw would not handle such input
     fileOut << Core()->cmd(cmd + " $s @ 0");
 }
 

--- a/src/dialogs/CommentsDialog.cpp
+++ b/src/dialogs/CommentsDialog.cpp
@@ -38,7 +38,7 @@ void CommentsDialog::setComment(const QString &comment)
 
 void CommentsDialog::addOrEditComment(RVA offset, QWidget *parent)
 {
-    QString oldComment = Core()->cmd("CC." + RAddressString(offset));
+    QString oldComment = Core()->cmdRawAt("CC.", offset);
     // Remove newline at the end added by cmd
     oldComment.remove(oldComment.length() - 1, 1);
     CommentsDialog c(parent);

--- a/src/dialogs/EditVariablesDialog.cpp
+++ b/src/dialogs/EditVariablesDialog.cpp
@@ -15,7 +15,7 @@ EditVariablesDialog::EditVariablesDialog(RVA offset, QString initialVar, QWidget
     connect(ui->buttonBox, SIGNAL(accepted()), this, SLOT(applyFields()));
     connect(ui->dropdownLocalVars, SIGNAL(currentIndexChanged(int)), SLOT(updateFields()));
 
-    QString fcnName = Core()->cmd(QString("afn @ %1").arg(offset)).trimmed();
+    QString fcnName = Core()->cmdRawAt("afn.", offset).trimmed();
     setWindowTitle(tr("Set Variable Types for Function: %1").arg(fcnName));
 
     variables = Core()->getVariables(offset);

--- a/src/dialogs/NewFileDialog.cpp
+++ b/src/dialogs/NewFileDialog.cpp
@@ -321,7 +321,7 @@ bool NewFileDialog::fillProjectsList()
 
     int i = 0;
     for (const QString &project : projects) {
-        QString info = QDir::toNativeSeparators(core->cmd("Pi " + project));
+        QString info = QDir::toNativeSeparators(core->cmdRaw("Pi " + project));
 
         QListWidgetItem *item = new QListWidgetItem(getIconFor(project, i++), project + "\n" + info);
 

--- a/src/dialogs/WriteCommandsDialogs.cpp
+++ b/src/dialogs/WriteCommandsDialogs.cpp
@@ -84,9 +84,9 @@ void DuplicateFromOffsetDialog::refresh()
 
     // Add space every two characters for word wrap in hex sequence
     QRegularExpression re{"(.{2})"};
-    QString bytes = Core()->cmd(QString("p8 %1 @ %2")
-    .arg(QString::number(getNBytes()))
-    .arg(QString::number(offestFrom)))
+    QString bytes = Core()->cmdRawAt(QString("p8 %1")
+    .arg(QString::number(getNBytes())),
+    offestFrom)
     .replace(re, "\\1 ");
 
     ui->bytesLabel->setText(bytes.trimmed());

--- a/src/dialogs/XrefsDialog.cpp
+++ b/src/dialogs/XrefsDialog.cpp
@@ -123,6 +123,7 @@ void XrefsDialog::updatePreview(RVA addr)
     tempConfig.set("asm.lines", false);
     tempConfig.set("asm.bytes", false);
 
+    // Use cmd because cmRaw cannot handle the output properly. Why?
     QString disas = Core()->cmd("pd--20 @ " + QString::number(addr));
     ui->previewTextEdit->document()->setHtml(disas);
 

--- a/src/dialogs/preferences/ColorThemeEditDialog.cpp
+++ b/src/dialogs/preferences/ColorThemeEditDialog.cpp
@@ -134,7 +134,7 @@ void ColorThemeEditDialog::colorOptionChanged(const QColor& newColor)
 
     Config()->setColor(currOption.optionName, currOption.color);
     if (!ColorThemeWorker::cutterSpecificOptions.contains(currOption.optionName)) {
-        Core()->cmd(QString("ec %1 %2").arg(currOption.optionName).arg(currOption.color.name()));
+        Core()->cmdRaw(QString("ec %1 %2").arg(currOption.optionName).arg(currOption.color.name()));
     }
     previewDisasmWidget->colorsUpdatedSlot();
 }

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -460,10 +460,11 @@ void DisassemblyContextMenu::aboutToShowSlot()
     actionAnalyzeFunction.setVisible(true);
 
     // Show the option to remove a defined string only if a string is defined in this address
-    QString stringDefinition = Core()->cmd("Cs. @ " + RAddressString(offset));
+    QString stringDefinition = Core()->cmdRawAt("Cs.", offset);
     actionSetAsStringRemove.setVisible(!stringDefinition.isEmpty());
 
-    QString comment = Core()->cmd("CC." + RAddressString(offset));
+    QString comment = Core()->cmdRawAt("CC.", offset);
+
     if (comment.isNull() || comment.isEmpty()) {
         actionDeleteComment.setVisible(false);
         actionAddComment.setText(tr("Add Comment"));
@@ -841,7 +842,7 @@ void DisassemblyContextMenu::on_actionRenameUsedHere_triggered()
     if (dialog.exec()) {
         QString newName = dialog.getName().trimmed();
         if (!newName.isEmpty()) {
-            Core()->cmd("an " + newName + " @ " + QString::number(offset));
+            Core()->cmdRawAt(QString("an %1").arg(newName), offset);
 
             if (type == ThingUsedHere::Type::Address || type == ThingUsedHere::Type::Flag) {
                 Core()->triggerFlagsChanged();
@@ -1006,7 +1007,7 @@ void DisassemblyContextMenu::on_actionEditFunction_triggered()
         stackSizeText.sprintf("%d", fcn->stack);
         dialog.setStackSizeText(stackSizeText);
 
-        QStringList callConList = Core()->cmd("afcl").split("\n");
+        QStringList callConList = Core()->cmdRaw("afcl").split("\n");
         callConList.removeLast();
         dialog.setCallConList(callConList);
         dialog.setCallConSelected(fcn->cc);
@@ -1019,7 +1020,7 @@ void DisassemblyContextMenu::on_actionEditFunction_triggered()
             fcn->addr = Core()->math(new_start_addr);
             QString new_stack_size = dialog.getStackSizeText();
             fcn->stack = int(Core()->math(new_stack_size));
-            Core()->cmd("afc " + dialog.getCallConSelected());
+            Core()->cmdRaw("afc " + dialog.getCallConSelected());
             emit Core()->functionsChanged();
         }
     }

--- a/src/plugins/sample-cpp/CutterSamplePlugin.cpp
+++ b/src/plugins/sample-cpp/CutterSamplePlugin.cpp
@@ -62,6 +62,8 @@ void CutterSamplePluginWidget::on_seekChanged(RVA addr)
 void CutterSamplePluginWidget::on_buttonClicked()
 {
     QString fortune = Core()->cmd("fo").replace("\n", "");
+    // cmdRaw can be used to execute single raw commands
+    // this is especially good for user-controlled input
     QString res = Core()->cmdRaw("?E " + fortune);
     text->setText(res);
 }

--- a/src/widgets/ColorThemeListView.cpp
+++ b/src/widgets/ColorThemeListView.cpp
@@ -241,7 +241,7 @@ void ColorThemeListView::currentChanged(const QModelIndex &current,
     ColorOption prev = previous.data(Qt::UserRole).value<ColorOption>();
     Config()->setColor(prev.optionName, prev.color);
     if (ThemeWorker().radare2SpecificOptions.contains(prev.optionName)) {
-        Core()->cmd(QString("ec %1 %2").arg(prev.optionName).arg(prev.color.name()));
+        Core()->cmdRaw(QString("ec %1 %2").arg(prev.optionName).arg(prev.color.name()));
     }
 
     QListView::currentChanged(current, previous);
@@ -302,7 +302,7 @@ void ColorThemeListView::blinkTimeout()
     auto updateColor = [](const QString &name, const QColor &color) {
         Config()->setColor(name, color);
         if (ThemeWorker().radare2SpecificOptions.contains(name)) {
-            Core()->cmd(QString("ec %1 %2").arg(name).arg(color.name()));
+            Core()->cmdRaw(QString("ec %1 %2").arg(name).arg(color.name()));
         }
     };
 

--- a/src/widgets/Dashboard.cpp
+++ b/src/widgets/Dashboard.cpp
@@ -105,7 +105,7 @@ void Dashboard::updateContents()
 
         // Calculate the Entropy of the entire binary from offset 0 to $s
         // where $s is the size of the entire file
-        QString entropy = Core()->cmd("ph entropy $s @ 0").trimmed();
+        QString entropy = Core()->cmdRawAt("ph entropy $s", 0).trimmed();
 
         // Define a Read-Only line edit to display the entropy value
         QLineEdit *entropyLineEdit = new QLineEdit();

--- a/src/widgets/DebugActions.cpp
+++ b/src/widgets/DebugActions.cpp
@@ -191,6 +191,7 @@ DebugActions::DebugActions(QToolBar *toolBar, MainWindow *main) :
 
 void DebugActions::setButtonVisibleIfMainExists()
 {
+    // Use cmd because cmdRaw would not handle multiple commands concatenated
     int mainExists = Core()->cmd("f?sym.main; ??").toInt();
     // if main is not a flag we hide the continue until main button
     if (!mainExists) {
@@ -213,7 +214,7 @@ void DebugActions::showDebugWarning()
 
 void DebugActions::continueUntilMain()
 {
-    QString mainAddr = Core()->cmd("?v sym.main");
+    QString mainAddr = Core()->cmdRaw("?v sym.main");
     Core()->continueUntilDebug(mainAddr);
 }
 

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -1177,7 +1177,7 @@ void DisassemblerGraphView::exportGraph(QString filePath, GraphExportType type)
             return;
         }
         QTextStream fileOut(&file);
-        fileOut << Core()->cmd(QString("agfd 0x%1").arg(currentFcnAddr, 0, 16));
+        fileOut << Core()->cmdRaw(QString("agfd 0x%1").arg(currentFcnAddr, 0, 16));
     }
     break;
 
@@ -1206,8 +1206,9 @@ void DisassemblerGraphView::exportR2GraphvizGraph(QString filePath, QString type
 {
     TempConfig tempConfig;
     tempConfig.set("graph.gv.format", type);
-    qWarning() << Core()->cmdRaw(QString("agfw \"%1\" @ 0x%2")
-                                 .arg(filePath).arg(currentFcnAddr, 0, 16));
+    qWarning() << Core()->cmdRawAt(QString("agfw \"%1\"")
+                                 .arg(filePath),
+                                 currentFcnAddr);
 }
 
 void DisassemblerGraphView::mousePressEvent(QMouseEvent *event)

--- a/src/widgets/GraphWidget.cpp
+++ b/src/widgets/GraphWidget.cpp
@@ -90,7 +90,7 @@ QString GraphWidget::getWidgetType()
 
 void GraphWidget::prepareHeader()
 {
-    QString afcf = Core()->cmd(QString("afcf @%1").arg(seekable->getOffset())).trimmed();
+    QString afcf = Core()->cmdRawAt("afcf", seekable->getOffset()).trimmed();
     if (afcf.isEmpty()) {
         header->hide();
         return;

--- a/src/widgets/HexdumpWidget.cpp
+++ b/src/widgets/HexdumpWidget.cpp
@@ -220,9 +220,6 @@ void HexdumpWidget::updateParseWindow(RVA start_address, int size)
         return;
     }
 
-    QString address = RAddressString(start_address);
-    QString argument = QString("%1@" + address).arg(size);
-
     if (ui->hexSideTab_2->currentIndex() == 0) {
         // scope for TempConfig
 
@@ -274,14 +271,17 @@ void HexdumpWidget::updateParseWindow(RVA start_address, int size)
             selectedCommand = "pcy";
             break;
         }
-        ui->hexDisasTextEdit->setPlainText(selectedCommand != "" ? Core()->cmd(selectedCommand + " " + argument) : "");
+        ui->hexDisasTextEdit->setPlainText(selectedCommand != "" ? Core()->cmdRawAt(QString("%1 %2")
+                                                                    .arg(selectedCommand)
+                                                                    .arg(size)
+                                                                    , start_address) : "");
     } else {
         // Fill the information tab hashes and entropy
-        ui->bytesMD5->setText(Core()->cmd("ph md5 " + argument).trimmed());
-        ui->bytesSHA1->setText(Core()->cmd("ph sha1 " + argument).trimmed());
-        ui->bytesSHA256->setText(Core()->cmd("ph sha256 " + argument).trimmed());
-        ui->bytesCRC32->setText(Core()->cmd("ph crc32 " + argument).trimmed());
-        ui->bytesEntropy->setText(Core()->cmd("ph entropy " + argument).trimmed());
+        ui->bytesMD5->setText(Core()->cmdRawAt(QString("ph md5 %1").arg(size), start_address).trimmed());
+        ui->bytesSHA1->setText(Core()->cmdRawAt(QString("ph sha1 %1").arg(size), start_address).trimmed());
+        ui->bytesSHA256->setText(Core()->cmdRawAt(QString("ph sha256 %1").arg(size), start_address).trimmed());
+        ui->bytesCRC32->setText(Core()->cmdRawAt(QString("ph crc32 %1").arg(size), start_address).trimmed());
+        ui->bytesEntropy->setText(Core()->cmdRawAt(QString("ph entropy %1").arg(size), start_address).trimmed());
         ui->bytesMD5->setCursorPosition(0);
         ui->bytesSHA1->setCursorPosition(0);
         ui->bytesSHA256->setCursorPosition(0);

--- a/src/widgets/TypesWidget.cpp
+++ b/src/widgets/TypesWidget.cpp
@@ -273,7 +273,7 @@ void TypesWidget::on_actionExport_Types_triggered()
         return;
     }
     QTextStream fileOut(&file);
-    fileOut << Core()->cmd("tc");
+    fileOut << Core()->cmdRaw("tc");
     file.close();
 }
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/developers-docs/first-time.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/developers-docs.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

This pull-request fixes the current implementation of `cmdRaw` and re-implements it properly. A POC for this was already merged in `cmdRawAt`. All the possible occurrences of `cmd()` usage were replaced with `cmdRaw()` and `cmdRawAt()` commands to ensure safety and simplicity. This also improves performance since Cutter would not execute command-parsing in radare2. This solution should solve the command injections problem, but this needed to check thoroughly.

To make regression resolution easier, changes to each file were created separately. I'd be happy if they'll merge as-is and won't be changed.

Documentation was expanded and improved.

Sometimes I improved existing code to use QString properly, but sometimes not.

**Test plan (required)**

The pull request made major changes across the entire code-base and thus need to be tested by you, the reviewers, very thoroughly. Please pay attention especially to changes in dialogs and features that execute user-input in the commands, such as renaming or setting new flags.
Especially, make sure to test special and risky chars such as: ` @ ! " > ; - <
I usually checking for command injection such as "! ping 8.8.8.8" because then Cutter is freezing and it is much visible :) 


**AnalTask.cpp**
- [x] Changing asm.os in the open dialog
- [x] Open a shellcode in Cutter
  
**ColorThemeWorker.cpp**
- [x] Duplicate existing theme
- [x] Check that selected theme is loaded when opening Cutter

**Configuration.cpp**
- [x] Reset settings
- [x] Check that setting new color theme works

**MainWindow.cpp**
- [x] Check that opening a project works


**CommentsDialog.cpp**
- [x] Check that adding comment work
- [x] Check that editing an existing comment work
- [x] Test for special value in the comments (e.g @ " ' ` ; )
  

**EditVariableDialog.cpp**
*In this one, a bug was fixed `afn` -> `afn.`*

- [x] Check that the title of the function variable editing dialog shows correctly


**NewFileDialog.cpp**

- [x] Check that recent projects list shows recent items correctly

**WriteCommandsDialog.cpp**

- [x] Check that the Duplicate from offset dialog shows preview correctly

**ColorThemeEditor.cpp**

- [x] Make sure that changing a color of a config works in editing mode


**DisassemblyContextMenu.cpp**
- [x] Check if Remove string is shown instead of "add" when string is defined
- [x] Check that Edit Comment is shown instead Add Comment
- [X] Check that exisiting comment is set in the comment box when editing
- [x] Check if renaming "used here" works properly. Test for special input
- [x] Check if a list of calling conventions is shown during function editing
- [x] Check that editing calling convention applied


**CutterSamplePlugin.cpp**
- [x] Check if cmdRaw works on button click

**ColorThemListView.cpp**
- [x] Check if choosing a value to edit causes blinking in preview
- [x] Make sure that changing color applies

**Dashboard.cpp**
- [x] Make sure that entropy is calculated and showed correctly

**DebugActions.cpp**
- [x] Check that Continue until Main works properly


**DisassemblerGraphView.cpp**
- [x] Check that exporting r2 graph to graphviz works
- [x] Check that exporting r2 graph to dot file works
- [x] Check hat graph name shows name and prototype correctly


**HexdumpWidget.cpp**
- [x] Check that hashes for selected bytes showed correctly in the sidebar


**TypesWidget.cpp**
- [x] Check that exporting types works correctly



**Cutter.cpp**

TODO


<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
