### PR TITLE
fixed - a word not clearly was not clearly visible in preferences-debug

### DIFF
--- a/src/dialogs/preferences/DebugOptionsWidget.ui
+++ b/src/dialogs/preferences/DebugOptionsWidget.ui
@@ -1,98 +1,82 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
-    <class>DebugOptionsWidget</class>
-    <widget class="QWidget" name="DebugOptionsWidget">
-        <property name="geometry">
-            <rect>
-                <x>0</x>
-                <y>0</y>
-                <width>489</width>
-                <height>201</height>
-            </rect>
-        </property>
-        <property name="windowTitle">
-            <string>Debug</string>
-        </property>
-        <layout class="QVBoxLayout" name="verticalLayout">
-            <item>
-                <layout class="QFormLayout" name="formLayout">
-                    <property name="fieldGrowthPolicy">
-                        <enum>QFormLayout::ExpandingFieldsGrow</enum>
-                    </property>
-                    <property name="labelAlignment">
-                        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-                    </property>
-                    <item row="0" column="0">
-                        <widget class="QLabel" name="pluginLabel">
-                            <property name="text">
-                                <string>Debug Plugin:</string>
-                            </property>
-                        </widget>
-                    </item>
-                    <item row="0" column="1">
-                        <widget class="QComboBox" name="pluginComboBox"/>
-                    </item>
-                    <item row="1" column="0">
-                        <widget class="QLabel" name="esilstackAddr">
-                            <property name="text">
-                                <string>ESIL stack address:</string>
-                            </property>
-                        </widget>
-                    </item>
-                    <item row="1" column="1">
-                        <widget class="QLineEdit" name="stackAddr">
-                            <property name="sizePolicy">
-                                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                                    <horstretch>0</horstretch>
-                                    <verstretch>0</verstretch>
-                                </sizepolicy>
-                            </property>
-                        </widget>
-                    </item>
-                    <item row="2" column="0">
-                        <widget class="QLabel" name="esilStackSize">
-                            <property name="text">
-                                <string>ESIL stack size:</string>
-                            </property>
-                        </widget>
-                    </item>
-                    <item row="2" column="1">
-                        <widget class="QLineEdit" name="stackSize">
-                            <property name="sizePolicy">
-                                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                                    <horstretch>0</horstretch>
-                                    <verstretch>0</verstretch>
-                                </sizepolicy>
-                            </property>
-                        </widget>
-                    </item>
-                </layout>
-            </item>
-            <item>
-                <widget class="QWidget" name="widget_2" native="true">
-                    <property name="sizePolicy">
-                        <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-                            <horstretch>0</horstretch>
-                            <verstretch>0</verstretch>
-                        </sizepolicy>
-                    </property>
-                    <widget class="QCheckBox" name="esilBreakOnInvalid">
-                        <property name="geometry">
-                            <rect>
-                                <x>0</x>
-                                <y>0</y>
-                                <width>469</width>
-                                <height>24</height>
-                            </rect>
-                        </property>
-                        <property name="text">
-                            <string>Break esil execution when instruction is invalid (esil.breakoninvalid)</string>
-                        </property>
-                    </widget>
-                </widget>
-            </item>
-        </layout>
-    </widget>
-    <resources/>
-    <connections/>
+ <class>DebugOptionsWidget</class>
+ <widget class="QWidget" name="DebugOptionsWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>489</width>
+    <height>201</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Debug</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <property name="fieldGrowthPolicy">
+      <enum>QFormLayout::ExpandingFieldsGrow</enum>
+     </property>
+     <property name="labelAlignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+     </property>
+     <item row="0" column="0">
+      <widget class="QLabel" name="pluginLabel">
+       <property name="text">
+        <string>Debug Plugin:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QComboBox" name="pluginComboBox"/>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="esilstackAddr">
+       <property name="text">
+        <string>ESIL stack address:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="stackAddr">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="esilStackSize">
+       <property name="text">
+        <string>ESIL stack size:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QLineEdit" name="stackSize">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0" colspan="2">
+      <widget class="QCheckBox" name="esilBreakOnInvalid">
+       <property name="text">
+        <string>Break esil execution when instruction is invalid (esil.breakoninvalid)</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
 </ui>

--- a/src/dialogs/preferences/DebugOptionsWidget.ui
+++ b/src/dialogs/preferences/DebugOptionsWidget.ui
@@ -1,98 +1,98 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>DebugOptionsWidget</class>
- <widget class="QWidget" name="DebugOptionsWidget">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>501</width>
-    <height>207</height>
-   </rect>
-  </property>
-  <property name="windowTitle">
-   <string>Debug</string>
-  </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
-    <layout class="QFormLayout" name="formLayout">
-     <property name="fieldGrowthPolicy">
-      <enum>QFormLayout::ExpandingFieldsGrow</enum>
-     </property>
-     <property name="labelAlignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-     </property>
-     <item row="0" column="0">
-      <widget class="QLabel" name="pluginLabel">
-       <property name="text">
-        <string>Debug Plugin:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QComboBox" name="pluginComboBox"/>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="esilstackAddr">
-       <property name="text">
-        <string>ESIL stack address:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QLineEdit" name="stackAddr">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="esilStackSize">
-       <property name="text">
-        <string>ESIL stack size:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QLineEdit" name="stackSize">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="QWidget" name="widget_2" native="true">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <widget class="QCheckBox" name="esilBreakOnInvalid">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>481</width>
-        <height>24</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Break esil execution when instruction is invalid (esil.breakoninvalid)</string>
-      </property>
-     </widget>
+    <class>DebugOptionsWidget</class>
+    <widget class="QWidget" name="DebugOptionsWidget">
+        <property name="geometry">
+            <rect>
+                <x>0</x>
+                <y>0</y>
+                <width>489</width>
+                <height>201</height>
+            </rect>
+        </property>
+        <property name="windowTitle">
+            <string>Debug</string>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout">
+            <item>
+                <layout class="QFormLayout" name="formLayout">
+                    <property name="fieldGrowthPolicy">
+                        <enum>QFormLayout::ExpandingFieldsGrow</enum>
+                    </property>
+                    <property name="labelAlignment">
+                        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+                    </property>
+                    <item row="0" column="0">
+                        <widget class="QLabel" name="pluginLabel">
+                            <property name="text">
+                                <string>Debug Plugin:</string>
+                            </property>
+                        </widget>
+                    </item>
+                    <item row="0" column="1">
+                        <widget class="QComboBox" name="pluginComboBox"/>
+                    </item>
+                    <item row="1" column="0">
+                        <widget class="QLabel" name="esilstackAddr">
+                            <property name="text">
+                                <string>ESIL stack address:</string>
+                            </property>
+                        </widget>
+                    </item>
+                    <item row="1" column="1">
+                        <widget class="QLineEdit" name="stackAddr">
+                            <property name="sizePolicy">
+                                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                                    <horstretch>0</horstretch>
+                                    <verstretch>0</verstretch>
+                                </sizepolicy>
+                            </property>
+                        </widget>
+                    </item>
+                    <item row="2" column="0">
+                        <widget class="QLabel" name="esilStackSize">
+                            <property name="text">
+                                <string>ESIL stack size:</string>
+                            </property>
+                        </widget>
+                    </item>
+                    <item row="2" column="1">
+                        <widget class="QLineEdit" name="stackSize">
+                            <property name="sizePolicy">
+                                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                                    <horstretch>0</horstretch>
+                                    <verstretch>0</verstretch>
+                                </sizepolicy>
+                            </property>
+                        </widget>
+                    </item>
+                </layout>
+            </item>
+            <item>
+                <widget class="QWidget" name="widget_2" native="true">
+                    <property name="sizePolicy">
+                        <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                        </sizepolicy>
+                    </property>
+                    <widget class="QCheckBox" name="esilBreakOnInvalid">
+                        <property name="geometry">
+                            <rect>
+                                <x>0</x>
+                                <y>0</y>
+                                <width>469</width>
+                                <height>24</height>
+                            </rect>
+                        </property>
+                        <property name="text">
+                            <string>Break esil execution when instruction is invalid (esil.breakoninvalid)</string>
+                        </property>
+                    </widget>
+                </widget>
+            </item>
+        </layout>
     </widget>
-   </item>
-  </layout>
- </widget>
- <resources/>
- <connections/>
+    <resources/>
+    <connections/>
 </ui>

--- a/src/dialogs/preferences/DebugOptionsWidget.ui
+++ b/src/dialogs/preferences/DebugOptionsWidget.ui
@@ -1,98 +1,98 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
-    <class>DebugOptionsWidget</class>
-    <widget class="QWidget" name="DebugOptionsWidget">
-        <property name="geometry">
-            <rect>
-                <x>0</x>
-                <y>0</y>
-                <width>489</width>
-                <height>201</height>
-            </rect>
-        </property>
-        <property name="windowTitle">
-            <string>Debug</string>
-        </property>
-        <layout class="QVBoxLayout" name="verticalLayout">
-            <item>
-                <layout class="QFormLayout" name="formLayout">
-                    <property name="fieldGrowthPolicy">
-                        <enum>QFormLayout::ExpandingFieldsGrow</enum>
-                    </property>
-                    <property name="labelAlignment">
-                        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-                    </property>
-                    <item row="0" column="0">
-                        <widget class="QLabel" name="pluginLabel">
-                            <property name="text">
-                                <string>Debug Plugin:</string>
-                            </property>
-                        </widget>
-                    </item>
-                    <item row="0" column="1">
-                        <widget class="QComboBox" name="pluginComboBox"/>
-                    </item>
-                    <item row="1" column="0">
-                        <widget class="QLabel" name="esilstackAddr">
-                            <property name="text">
-                                <string>ESIL stack address:</string>
-                            </property>
-                        </widget>
-                    </item>
-                    <item row="1" column="1">
-                        <widget class="QLineEdit" name="stackAddr">
-                            <property name="sizePolicy">
-                                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                                    <horstretch>0</horstretch>
-                                    <verstretch>0</verstretch>
-                                </sizepolicy>
-                            </property>
-                        </widget>
-                    </item>
-                    <item row="2" column="0">
-                        <widget class="QLabel" name="esilStackSize">
-                            <property name="text">
-                                <string>ESIL stack size:</string>
-                            </property>
-                        </widget>
-                    </item>
-                    <item row="2" column="1">
-                        <widget class="QLineEdit" name="stackSize">
-                            <property name="sizePolicy">
-                                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                                    <horstretch>0</horstretch>
-                                    <verstretch>0</verstretch>
-                                </sizepolicy>
-                            </property>
-                        </widget>
-                    </item>
-                </layout>
-            </item>
-            <item>
-                <widget class="QWidget" name="widget_2" native="true">
-                    <property name="sizePolicy">
-                        <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-                            <horstretch>0</horstretch>
-                            <verstretch>0</verstretch>
-                        </sizepolicy>
-                    </property>
-                    <widget class="QCheckBox" name="esilBreakOnInvalid">
-                        <property name="geometry">
-                            <rect>
-                                <x>0</x>
-                                <y>0</y>
-                                <width>469</width>
-                                <height>24</height>
-                            </rect>
-                        </property>
-                        <property name="text">
-                            <string>Break esil execution when instruction is invalid (esil.breakoninvalid)</string>
-                        </property>
-                    </widget>
-                </widget>
-            </item>
-        </layout>
+ <class>DebugOptionsWidget</class>
+ <widget class="QWidget" name="DebugOptionsWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>501</width>
+    <height>207</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Debug</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <property name="fieldGrowthPolicy">
+      <enum>QFormLayout::ExpandingFieldsGrow</enum>
+     </property>
+     <property name="labelAlignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+     </property>
+     <item row="0" column="0">
+      <widget class="QLabel" name="pluginLabel">
+       <property name="text">
+        <string>Debug Plugin:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QComboBox" name="pluginComboBox"/>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="esilstackAddr">
+       <property name="text">
+        <string>ESIL stack address:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="stackAddr">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="esilStackSize">
+       <property name="text">
+        <string>ESIL stack size:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLineEdit" name="stackSize">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QWidget" name="widget_2" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <widget class="QCheckBox" name="esilBreakOnInvalid">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>481</width>
+        <height>24</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Break esil execution when instruction is invalid (esil.breakoninvalid)</string>
+      </property>
+     </widget>
     </widget>
-    <resources/>
-    <connections/>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
 </ui>


### PR DESCRIPTION
![Screenshot from 2020-03-21 11-38-16](https://user-images.githubusercontent.com/18501167/77220884-95135900-6b6a-11ea-8474-3af7807532e6.png)

(esil.breakoninvalid) was not clearly visible. Changed the dimension by a bit to make it clearly visible. That's the only part changed. I didn't change the indentation, I wonder if Qt changed it automatically. (it shows 94 additions and 94 deletions).

![Screenshot from 2020-03-21 11-49-31](https://user-images.githubusercontent.com/18501167/77220939-1ff45380-6b6b-11ea-9634-4af42a3adb27.png)

