### PR TITLE
Added function to load cutterrc from all standard paths along with home

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -233,11 +233,7 @@ QVector<QDir> CutterCore::getCutterRCDirectories() const
 {
     QVector<QDir> result;
     result.push_back(QDir::home());
-    QStringList locations = QStandardPaths::standardLocations(QStandardPaths::AppDataLocation);
-    for (auto &location : locations) { 
-        result.push_back(QDir(location)); 
-    }
-    locations = QStandardPaths::standardLocations(QStandardPaths::AppConfigLocation);
+    QStringList locations = QStandardPaths::standardLocations(QStandardPaths::AppConfigLocation);
     for (auto &location : locations) { 
         result.push_back(QDir(location)); 
     }

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -14,6 +14,7 @@
 #include <QJsonDocument>
 #include <QErrorMessage>
 #include <QMutex>
+#include <QDir>
 
 class AsyncTaskManager;
 class BasicInstructionHighlighter;
@@ -692,6 +693,8 @@ private:
 
     QSharedPointer<R2Task> debugTask;
     R2TaskDialog *debugTaskDialog;
+    
+    QVector<QDir> getCutterRCDirectories() const;
 };
 
 class RCoreLocked


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/developers-docs/first-time.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/developers-docs.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**
Issue is to a fully fledged reusable configuration editor for cutterrc. As the first part, I have made changes to the part where cutterrc is loaded. Now .cutterrc is loaded from all the standard locations (Qt). Earlier, .cutterrc was loaded from just home. Since home is not a standard location, this code handles home location explicitly.
<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

**Test plan (required)**

![Screenshot from 2020-03-22 18-52-01](https://user-images.githubusercontent.com/18501167/77250794-3afcbb80-6c70-11ea-94a3-51c270de92a6.png)
I have put .cutterrc files in two locations from which the files are loaded.
![Screenshot from 2020-03-22 18-52-30](https://user-images.githubusercontent.com/18501167/77250810-52d43f80-6c70-11ea-947c-13c20a4a2ec8.png)
So, the result gives us the following display.
![Screenshot from 2020-03-22 18-52-44](https://user-images.githubusercontent.com/18501167/77250817-65e70f80-6c70-11ea-81b3-581d41baa742.png)

Now, I have changed the secondly loaded file to this. (changed eco)
![Screenshot from 2020-03-22 19-09-07](https://user-images.githubusercontent.com/18501167/77250862-ba8a8a80-6c70-11ea-9fc8-f9cb17d1fc50.png)
now, the disassembly and graph widget display changes to this
![Screenshot from 2020-03-22 19-09-49](https://user-images.githubusercontent.com/18501167/77250868-c8401000-6c70-11ea-8e14-2559be1fcb21.png)


Now I have copied first cutterrc file to another location which is the third loaded one in this.
![Screenshot from 2020-03-22 19-17-46](https://user-images.githubusercontent.com/18501167/77251037-ef4b1180-6c71-11ea-932d-39d688972fae.png)
now, the output changes to this.
![Screenshot from 2020-03-22 19-17-53](https://user-images.githubusercontent.com/18501167/77251041-f83be300-6c71-11ea-9122-c1a048a4fafc.png)

I will do the testing in Windows. I need help from someone to test this in mac.
Checklist for testing**
- [ ] File is loading from home.
- [ ] File is loading from the standard locations.
- [ ] Newly loaded files supercede the commands in the previously loaded files.

**Update**:

I have **tested in windows**. It's working.

This is how cutter looked like before using .cutterrc
![3before-solarized](https://user-images.githubusercontent.com/18501167/77289812-b8700c80-6d00-11ea-93a4-7221acd406c2.PNG)

Initial cutterrc file which is at home location.
![first-file-in-home](https://user-images.githubusercontent.com/18501167/77289779-a2624c00-6d00-11ea-8e0b-e2f6d97a3a90.PNG)

After this, display changes to this.

![4after-solarized](https://user-images.githubusercontent.com/18501167/77289857-d2a9ea80-6d00-11ea-8586-6dad9ea5f6a7.PNG)

After this, I changed `eco ` and put in another .cutterrc in a `AppConfigLocation`  `C:\ProgramData\RadareOrg\Cutter`. 
![6secondfile-and-location](https://user-images.githubusercontent.com/18501167/77289910-f66d3080-6d00-11ea-9528-b5f5337fbf40.PNG)

Now the display changes to this.
![5after-consonance](https://user-images.githubusercontent.com/18501167/77289926-02f18900-6d01-11ea-8a76-572c55243201.PNG)


<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->


<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
Finishes a part of issue #1837 