### PR TITLE
Show available flags and comments in hexdump (#1471)

### DIFF
--- a/src/widgets/HexdumpWidget.cpp
+++ b/src/widgets/HexdumpWidget.cpp
@@ -62,6 +62,11 @@ HexdumpWidget::HexdumpWidget(MainWindow *main, QAction *action) :
     ui->bytesCRC32->setPlaceholderText(placeholder);
     ui->hexDisasTextEdit->setPlaceholderText(placeholder);
 
+    // Set placeholders for the flag and comment components
+    QString placeholder_2 = tr("Select address to display information");
+    ui->addressFlag->setPlaceholderText(placeholder_2);
+    ui->addressComment->setPlaceholderText(placeholder_2);
+
     setupFonts();
 
     ui->openSideViewB->setStyleSheet(""
@@ -97,6 +102,7 @@ HexdumpWidget::HexdumpWidget(MainWindow *main, QAction *action) :
             seekable->seek(addr);
             sent_seek = false;
         }
+        showMetaInfo(addr);
     });
     connect(ui->hexTextView, &HexWidget::selectionChanged, this, &HexdumpWidget::selectionChanged);
     connect(ui->hexSideTab_2, &QTabWidget::currentChanged, this, &HexdumpWidget::refreshSelectionInfo);
@@ -287,6 +293,29 @@ void HexdumpWidget::updateParseWindow(RVA start_address, int size)
         ui->bytesSHA256->setCursorPosition(0);
         ui->bytesCRC32->setCursorPosition(0);
     }
+}
+
+void HexdumpWidget::showMetaInfo(RVA address)
+{
+    QString flagName = "";
+
+    RCore *core = Core()->core();
+    RFlagItem *f = r_flag_get_i (core->flags, address);
+
+    if (f) {
+        // Check if Realname is enabled. If yes, show it instead of the full flag-name.
+        if (Config()->getConfigBool("asm.flags.real") && f->realname) {
+            flagName = f->realname;
+        } else {
+            flagName = f->name;
+        }
+    }
+
+    // Fill the information for flag and comment
+    ui->addressFlag->setText(flagName.trimmed());
+    ui->addressComment->setText(Core()->cmd("CC." + RAddressString(address).trimmed()));
+    ui->addressFlag->setCursorPosition(0);
+    ui->addressComment->setCursorPosition(0);
 }
 
 void HexdumpWidget::on_parseTypeComboBox_currentTextChanged(const QString &)

--- a/src/widgets/HexdumpWidget.h
+++ b/src/widgets/HexdumpWidget.h
@@ -58,6 +58,7 @@ private:
     void setupFonts();
 
     void refreshSelectionInfo();
+    void showMetaInfo(RVA address);
     void updateParseWindow(RVA start_address, int size);
     void clearParseWindow();
     void showSidePanel(bool show);

--- a/src/widgets/HexdumpWidget.ui
+++ b/src/widgets/HexdumpWidget.ui
@@ -490,6 +490,70 @@
              </property>
             </widget>
            </item>
+           <item row="6" column="1" colspan="2">
+            <widget class="QLineEdit" name="addressFlag">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="frame">
+              <bool>true</bool>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignJustify|Qt::AlignVCenter</set>
+             </property>
+             <property name="readOnly">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="6" column="0" alignment="Qt::AlignLeft">
+            <widget class="QLabel" name="labelFlag">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Flag:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="7" column="1" colspan="2">
+            <widget class="QLineEdit" name="addressComment">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="frame">
+              <bool>true</bool>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignJustify|Qt::AlignVCenter</set>
+             </property>
+             <property name="readOnly">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="7" column="0" alignment="Qt::AlignLeft">
+            <widget class="QLabel" name="labelComment">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Comment:</string>
+             </property>
+            </widget>
+           </item>
            <item row="2" column="1">
             <widget class="QLineEdit" name="bytesSHA1">
              <property name="sizePolicy">


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/developers-docs/first-time.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/developers-docs.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

**Functional Changes**
- Displays the flags and comments in the Information tab of the hexdump sidebar for the current address.

**Code Changes**
_HexdumpWidget.ui_:
- Added ui item elements under `hexSideTab_2` for displaying flags and comments.

_HexdumpWidget.cpp_:
- Set the placeholder text for the flag and comment elements using `setPlaceholderText`.
- Created a new function `showMetaInfo(RVA address)`:
    - Fetched the flags info for the address using `r_flag_get_i (core->flags, address)`
    - Fetched the comments for the address using `Core()->cmd("CC." + RAddressString(address)`
    - Set the fetched values for the UI elements using `setText`.
- Invoked `showMetaInfo` whenever `positionChanged` signal is emitted.

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->
* Both flag and comment are present:
![Case-1](https://user-images.githubusercontent.com/7266024/77314014-2fa79f80-6d05-11ea-81bf-dbebf367b2ef.png)

* Only the flag is present:
![Case-2](https://user-images.githubusercontent.com/7266024/77314017-30d8cc80-6d05-11ea-967d-ebf843d3aca7.png)

* Only the Comment is present:
![hexdump-4](https://user-images.githubusercontent.com/7266024/77314591-3da9f000-6d06-11ea-8949-797105186c67.png)

* Both flag and comment are not present:
![Case-4](https://user-images.githubusercontent.com/7266024/77314016-30d8cc80-6d05-11ea-8eb0-54b10187ba8d.png)





<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**
Closes #1471 
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
