### PR TITLE
Fix redundent word in the user docs

### DIFF
--- a/docs/source/user-docs.rst
+++ b/docs/source/user-docs.rst
@@ -1,7 +1,7 @@
 User documentation
 =======================
 
-This page shows contains information about the different menus in Cutter.
+This page contains information about the different menus in Cutter.
 
 Cutter is an advanced reverse engineering platform that is powered by radare2. This user's guide provides detailed information on how to use Cutter. The documentation for users is still on its early stages and will be improved over time.
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Detailed description**

Simply remove a redundant word in the user docs