### PR TITLE
Add tooltip for displaying flag and comment in hexdump (#1471)

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -3482,7 +3482,7 @@ void CutterCore::addFlag(RVA offset, QString name, RVA size)
  */
 QString CutterCore::listFlagsAsStringAt(RVA addr)
 {
-    RCore *core = Core()->core();
+    CORE_LOCK();
     return r_flag_get_liststr (core->flags, addr);
 }
 

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -775,6 +775,11 @@ void CutterCore::delComment(RVA addr)
     emit commentsChanged();
 }
 
+QString CutterCore::getCommentAt(RVA addr)
+{
+    return Core()->cmdRawAt("CC.", addr);
+}
+
 void CutterCore::setImmediateBase(const QString &r2BaseName, RVA offset)
 {
     if (offset == RVA_INVALID) {
@@ -3463,6 +3468,12 @@ void CutterCore::addFlag(RVA offset, QString name, RVA size)
     name = sanitizeStringForCommand(name);
     cmdRawAt(QString("f %1 %2").arg(name).arg(size), offset);
     emit flagsChanged();
+}
+
+QString CutterCore::listFlagsAsStringAt(RVA addr)
+{
+    RCore *core = Core()->core();
+    return r_flag_get_liststr (core->flags, addr);
 }
 
 QString CutterCore::nearestFlag(RVA offset, RVA *flagOffsetOut)

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -775,6 +775,11 @@ void CutterCore::delComment(RVA addr)
     emit commentsChanged();
 }
 
+/**
+ * @brief Gets the comment present at a specific address
+ * @param addr The address to be checked
+ * @return String containing comment
+ */
 QString CutterCore::getCommentAt(RVA addr)
 {
     return Core()->cmdRawAt("CC.", addr);

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -3470,6 +3470,11 @@ void CutterCore::addFlag(RVA offset, QString name, RVA size)
     emit flagsChanged();
 }
 
+/**
+ * @brief Gets all the flags present at a specific address
+ * @param addr The address to be checked
+ * @return String containing all the flags which are comma-separated
+ */
 QString CutterCore::listFlagsAsStringAt(RVA addr)
 {
     RCore *core = Core()->core();

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -169,6 +169,7 @@ public:
     void delFlag(RVA addr);
     void delFlag(const QString &name);
     void addFlag(RVA offset, QString name, RVA size);
+    QString listFlagsAsStringAt(RVA addr);
     /**
      * @brief Get nearest flag at or before offset.
      * @param offset search position
@@ -217,6 +218,7 @@ public:
     /* Comments */
     void setComment(RVA addr, const QString &cmt);
     void delComment(RVA addr);
+    QString getCommentAt(RVA addr);
     void setImmediateBase(const QString &r2BaseName, RVA offset = RVA_INVALID);
     void setCurrentBits(int bits, RVA offset = RVA_INVALID);
 

--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -472,7 +472,7 @@ void HexWidget::mouseMoveEvent(QMouseEvent *event)
 
     QString metaData = getFlagAndComment(mouseAddr);
     if (!metaData.isEmpty() && itemArea.contains(pos)) {
-        QToolTip::showText(event->globalPos(), metaData, this);
+        QToolTip::showText(event->globalPos(), metaData.replace(",", ", "), this);
     } else {
         QToolTip::hideText();
     }
@@ -1479,13 +1479,10 @@ QChar HexWidget::renderAscii(int offset, QColor *color)
  */
 QString HexWidget::getFlagAndComment(uint64_t address)
 {
-    RCore *core = Core()->core();
-    QString flagName = r_flag_get_liststr (core->flags, address);
+    QString flagName = Core()->listFlagsAsStringAt(address);
+    QString metaData = flagName.isEmpty() ? "" : "Flags: " + flagName.trimmed();
 
-    QString metaData = flagName.isEmpty() ? "" : "Flag: " + flagName.trimmed();
-
-    QString comment = Core()->cmdRawAt("CC.", address);
-
+    QString comment = Core()->getCommentAt(address);
     if (!comment.isEmpty()) {
         if (!metaData.isEmpty()) {
             metaData.append("\n");

--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -470,7 +470,7 @@ void HexWidget::mouseMoveEvent(QMouseEvent *event)
 
     auto mouseAddr = mousePosToAddr(pos).address;
 
-    QString metaData = getFlagAndComment(mouseAddr);
+    QString metaData = getFlagsAndComment(mouseAddr);
     if (!metaData.isEmpty() && itemArea.contains(pos)) {
         QToolTip::showText(event->globalPos(), metaData.replace(",", ", "), this);
     } else {
@@ -1021,7 +1021,7 @@ void HexWidget::drawItemArea(QPainter &painter)
             for (int k = 0; k < itemGroupSize && itemAddr <= data->maxIndex(); ++k, itemAddr += itemByteLen) {
                 itemString = renderItem(itemAddr - startAddress, &itemColor);
 
-                if (!getFlagAndComment(itemAddr).isEmpty()) {
+                if (!getFlagsAndComment(itemAddr).isEmpty()) {
                     QColor markerColor(borderColor);
                     markerColor.setAlphaF(0.5);
                     const auto shape = rangePolygons(itemAddr, itemAddr, false)[0];
@@ -1477,10 +1477,10 @@ QChar HexWidget::renderAscii(int offset, QColor *color)
  * @param address Address of Item to be checked.
  * @return String containing the flags and comment available at the address.
  */
-QString HexWidget::getFlagAndComment(uint64_t address)
+QString HexWidget::getFlagsAndComment(uint64_t address)
 {
-    QString flagName = Core()->listFlagsAsStringAt(address);
-    QString metaData = flagName.isEmpty() ? "" : "Flags: " + flagName.trimmed();
+    QString flagNames = Core()->listFlagsAsStringAt(address);
+    QString metaData = flagNames.isEmpty() ? "" : "Flags: " + flagNames.trimmed();
 
     QString comment = Core()->getCommentAt(address);
     if (!comment.isEmpty()) {

--- a/src/widgets/HexWidget.h
+++ b/src/widgets/HexWidget.h
@@ -329,6 +329,7 @@ private:
     QVariant readItem(int offset, QColor *color = nullptr);
     QString renderItem(int offset, QColor *color = nullptr);
     QChar renderAscii(int offset, QColor *color = nullptr);
+    QString getFlagAndComment(uint64_t address);
     /**
      * @brief Get the location on which operations such as Writing should apply.
      * @return Start of selection if multiple bytes are selected. Otherwise, the curren seek of the widget.

--- a/src/widgets/HexWidget.h
+++ b/src/widgets/HexWidget.h
@@ -329,7 +329,7 @@ private:
     QVariant readItem(int offset, QColor *color = nullptr);
     QString renderItem(int offset, QColor *color = nullptr);
     QChar renderAscii(int offset, QColor *color = nullptr);
-    QString getFlagAndComment(uint64_t address);
+    QString getFlagsAndComment(uint64_t address);
     /**
      * @brief Get the location on which operations such as Writing should apply.
      * @return Start of selection if multiple bytes are selected. Otherwise, the curren seek of the widget.


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/developers-docs/first-time.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/developers-docs.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

**Functional Changes**
- Mark and show the available flags and comments in a tooltip in the hex dump.

**Code Changes**
_HexWidget.cpp_:
- Created a new function `getFlagAndComment(uint64_t address)` to retrieve the flag and comment for an address.
    - Fetched all the flags info for the address using `r_flag_get_liststr (core->flags, address)`
    - Fetched the comments for the address using `Core()->cmdRawAt("CC.", address)`
- Marked the address in the `drawItemArea(QPainter &painter)` function with available flag/comment.
- Added the tooltip in mouseMoveEvent(QMouseEvent *event) to display flag/comment on hover. 

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->
* Marked position of comment or flag using the borderColor with alpha 50% in the hex section
![hexdump](https://user-images.githubusercontent.com/7266024/78110000-94948100-73fa-11ea-8c5e-82d61cf9f77a.png)

* Both flag and comment are present:
![hexdump-final](https://user-images.githubusercontent.com/7266024/78221274-5f079a80-74c3-11ea-981d-5eae24649c45.png)

* Only the flag is present:
![hex-dump-final-2](https://user-images.githubusercontent.com/7266024/78221371-88c0c180-74c3-11ea-9e58-4da7e3f3693d.png)

* Only the Comment is present:
![hexdump-3](https://user-images.githubusercontent.com/7266024/78110103-be4da800-73fa-11ea-86f2-ece8f61d6876.png)

<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**
Closes #1471 
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
