### PR TITLE
Install ninja from backports on Ubuntu 16.04.

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -26,7 +26,14 @@ jobs:
         submodules: true # 'recursive' 'true' or 'false'
     - name: apt dependencies
       if: contains(matrix.os, 'ubuntu')
-      run: sudo apt-get install ninja-build libgraphviz-dev
+      run: |
+        sudo apt-get install libgraphviz-dev
+        if [[ "${{ matrix.os }}" = "ubuntu-16.04" ]]
+        then
+          sudo apt-get install ninja-build/xenial-backports
+        else
+          sudo apt-get install ninja-build
+        fi
     - name: homebrew dependencies
       if: contains(matrix.os, 'macos')
       run: |


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/developers-docs/first-time.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/developers-docs.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Latest meson version increased minimum ninja version to 1.7 https://github.com/mesonbuild/meson/commit/be486a2ec84f22052fba5ba16de136de00379966 . 

Alternative solution would be pinning meson version. Since this job is already using newer library versions from cutter-deps I chose updating ninja instead. Such approach would be more suited if all the dependencies were taken from system repository like it's done in Travis Ubuntu 16.04 build job.

**Test plan (required)**

*  CI tests are green.
* Log for Ubuntu 16.04 on github actions build indicates that ninja 1.7.1 was installed :heavy_check_mark: 



**Closing issues**
