### PR TITLE
By default search r2 in /usr/local used by sys/install.sh.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,8 @@ include(CutterInstallDirs)
 set(CUTTER_PYTHON_MIN 3.5)
 
 option(CUTTER_USE_BUNDLED_RADARE2 "Use radare2 from src/radare2 submodule instead of searching for it on the system" OFF)
+option(CUTTER_USE_ADDITIONAL_RADARE2_PATHS "Search radare2 in additional paths which are not part of default system library paths.\
+ Disable this option if you are linking against radare2 pacakged as proper system library or in a custom path and additional are paths causing problems." ON)
 option(CUTTER_ENABLE_PYTHON "Enable Python integration. Requires Python >= ${CUTTER_PYTHON_MIN}." OFF)
 option(CUTTER_ENABLE_PYTHON_BINDINGS "Enable generating Python bindings with Shiboken2. Unused if CUTTER_ENABLE_PYTHON=OFF." OFF)
 option(CUTTER_ENABLE_CRASH_REPORTS "Enable crash report system. Unused if CUTTER_ENABLE_CRASH_REPORTS=OFF" OFF)

--- a/src/cmake/FindRadare2.cmake
+++ b/src/cmake/FindRadare2.cmake
@@ -72,9 +72,12 @@ if(WIN32)
 			INTERFACE_INCLUDE_DIRECTORIES "${Radare2_INCLUDE_DIRS}")
 	set(Radare2_TARGET Radare2::libr)
 else()
-	# support sys/user.sh install
-	set(Radare2_CMAKE_PREFIX_PATH_TEMP ${CMAKE_PREFIX_PATH})
-	list(APPEND CMAKE_PREFIX_PATH "$ENV{HOME}/bin/prefix/radare2")
+	# support installation locations used by r2 scripts like sys/user.sh and sys/install.sh
+	if(CUTTER_USE_ADDITIONAL_RADARE2_PATHS)
+		set(Radare2_CMAKE_PREFIX_PATH_TEMP ${CMAKE_PREFIX_PATH})
+		list(APPEND CMAKE_PREFIX_PATH "$ENV{HOME}/bin/prefix/radare2") # sys/user.sh
+		list(APPEND CMAKE_PREFIX_PATH "/usr/local") # sys/install.sh
+	endif()
 
 	find_package(PkgConfig REQUIRED)
 	if(CMAKE_VERSION VERSION_LESS "3.6")
@@ -84,7 +87,9 @@ else()
 	endif()
 
 	# reset CMAKE_PREFIX_PATH
-	set(CMAKE_PREFIX_PATH ${Radare2_CMAKE_PREFIX_PATH_TEMP})
+	if(CUTTER_USE_ADDITIONAL_RADARE2_PATHS)
+		set(CMAKE_PREFIX_PATH ${Radare2_CMAKE_PREFIX_PATH_TEMP})
+	endif()
 
 	if((TARGET PkgConfig::Radare2) AND (NOT CMAKE_VERSION VERSION_LESS "3.11.0"))
 		set_target_properties(PkgConfig::Radare2 PROPERTIES IMPORTED_GLOBAL ON)


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/developers-docs/first-time.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/developers-docs.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Recently  radare2 changed path used by sys/install.sh to /usr/local. By default pkg-config doesn't search libraries there. Add it to default search paths the same way as we do it for `~/bin/prefix/radare2` used by sys/usr.sh. Adds an option for not adding these extra paths in 

**Test plan (required)**

* Test that searching for r2 built using sys/user.sh works, `-DCUTTER_USE_BUNDLED_RADARE2=OFF` :heavy_check_mark: 
* Test that searching for r2 built using sys/install.sh works `-DCUTTER_USE_BUNDLED_RADARE2=OFF`
* Test that setting `-DCUTTER_USE_ADDITIONAL_RADARE2_PATHS=OFF` causes r2 in the previous locations not to be found :heavy_check_mark: 

<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
