### PR TITLE
Change include order to prevent warning from GNUInstallDirs

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,7 +7,6 @@ endif()
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(DisallowInSource)
 include(Utils)
-include(CutterInstallDirs)
 
 set(CUTTER_PYTHON_MIN 3.5)
 
@@ -53,6 +52,8 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
 find_package(Qt5 REQUIRED COMPONENTS Core Widgets Gui Svg Network)
+
+include(CutterInstallDirs)
 
 if(CUTTER_USE_BUNDLED_RADARE2)
     include(BundledRadare2)


### PR DESCRIPTION


<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/developers-docs/first-time.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/developers-docs.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)

**Detailed description**
CMake >= 3.17 warns that GNUInstallDirs might not work correctly if
included before some target details are known.

**Test plan (required)**

On system with cmake >= 3.17 run cmake configure. Make sure that warning described in #2122 doesn't appear.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
