### PR TITLE
Initial implementation of improved renaming dialog

### DIFF
--- a/src/common/CutterSeekable.cpp
+++ b/src/common/CutterSeekable.cpp
@@ -75,7 +75,8 @@ void CutterSeekable::seekToReference(RVA offset)
     
     if (refs.length()) {
         if (refs.length() > 1) {
-            qWarning() << "Too many references here. Weird behaviour expected.";
+            qWarning() << QString("Too many references here (%1). Weird behaviour expected.")
+                                        .arg(refs.length());
         }
         
         target = refs.at(0).to;

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -643,7 +643,12 @@ void CutterCore::renameFlag(QString old_name, QString new_name)
 
 void CutterCore::renameRealName(QString flagName, QString newRealName)
 {
-    cmdRaw("fN " + flagName + " " + newRealName);
+    CORE_LOCK();
+    RFlagItem *flag = r_flag_get (core->flags, flagName.toUtf8().constData());
+    if (!flag) {
+        return;
+    }
+    r_flag_item_set_realname (flag, newRealName.toUtf8().constData());
     emit flagsChanged();
 }
 
@@ -3488,8 +3493,10 @@ RFlagItem *CutterCore::getFlagByName(QString flagName) {
     return flag ? flag : nullptr;
 }
 
-QString CutterCore::getRealNameByFlagName(QString flagName) {
-    RFlagItem *flag = getFlagByName(flagName);
+QString CutterCore::getRealNameByFlagName(QString flagName)
+{
+    CORE_LOCK();
+    RFlagItem *flag = r_flag_get (core->flags, flagName.toUtf8().constData());
     if (flag) {
         return QString(flag->realname);
     } else {

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -3487,12 +3487,6 @@ QString CutterCore::nearestFlag(RVA offset, RVA *flagOffsetOut)
     return name;
 }
 
-RFlagItem *CutterCore::getFlagByName(QString flagName) {
-    CORE_LOCK();
-    RFlagItem *flag = r_flag_get (core->flags, qPrintable(flagName));
-    return flag ? flag : nullptr;
-}
-
 QString CutterCore::getRealNameByFlagName(QString flagName)
 {
     CORE_LOCK();

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -641,6 +641,12 @@ void CutterCore::renameFlag(QString old_name, QString new_name)
     emit flagsChanged();
 }
 
+void CutterCore::renameRealName(QString flagName, QString newRealName)
+{
+    cmdRaw("fN " + flagName + " " + newRealName);
+    emit flagsChanged();
+}
+
 void CutterCore::delFlag(RVA addr)
 {
     cmdRawAt("f-", addr);
@@ -3474,6 +3480,21 @@ QString CutterCore::nearestFlag(RVA offset, RVA *flagOffsetOut)
         *flagOffsetOut = offset  + static_cast<RVA>(-queryOffset);
     }
     return name;
+}
+
+RFlagItem *CutterCore::getFlagByName(QString flagName) {
+    CORE_LOCK();
+    RFlagItem *flag = r_flag_get (core->flags, qPrintable(flagName));
+    return flag ? flag : nullptr;
+}
+
+QString CutterCore::getRealNameByFlagName(QString flagName) {
+    RFlagItem *flag = getFlagByName(flagName);
+    if (flag) {
+        return QString(flag->realname);
+    } else {
+        return QString();
+    }
 }
 
 void CutterCore::handleREvent(int type, void *data)

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -145,6 +145,14 @@ public:
     void renameFlag(QString old_name, QString new_name);
 
     /**
+     * @brief Set the realname property of a \a flagName to \a newRealName
+     * 
+     * @param flagName The name of the flag that its realname property will change.
+     * @param newRealName The new value of the realname property of the flag
+     */
+    void renameRealName(QString flagName, QString newRealName);
+
+    /**
      * @param addr
      * @return a function that contains addr or nullptr
      */
@@ -176,6 +184,22 @@ public:
      * @return flag name
      */
     QString nearestFlag(RVA offset, RVA *flagOffsetOut);
+
+    /**
+     * @brief Get a pointer to RFlagItem that represents a flag with name \a flagName.
+     * 
+     * @param flagName The name of the requested flag.
+     * @return RFlagItem* that represents the requested flag.
+     */
+    RFlagItem *getFlagByName(QString flagName);
+
+    /**
+     * @brief Get the realname of a flag \a flagName.
+     * 
+     * @param flagName The name of the flag its realname will be returned.
+     * @return QString The realname of the flag \a flagName.
+     */
+    QString getRealNameByFlagName(QString flagName);
     void triggerFlagsChanged();
 
     /* Edition functions */

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -186,14 +186,6 @@ public:
     QString nearestFlag(RVA offset, RVA *flagOffsetOut);
 
     /**
-     * @brief Get a pointer to RFlagItem that represents a flag with name \a flagName.
-     * 
-     * @param flagName The name of the requested flag.
-     * @return RFlagItem* that represents the requested flag.
-     */
-    RFlagItem *getFlagByName(QString flagName);
-
-    /**
      * @brief Get the realname of a flag \a flagName.
      * 
      * @param flagName The name of the flag its realname will be returned.

--- a/src/dialogs/RenameDialog.cpp
+++ b/src/dialogs/RenameDialog.cpp
@@ -1,12 +1,18 @@
-#include "RenameDialog.h"
+﻿#include "RenameDialog.h"
 #include "ui_RenameDialog.h"
 
-RenameDialog::RenameDialog(QWidget *parent) :
+#include <QMessageBox>
+#include <QtDebug>
+
+RenameDialog::RenameDialog(QWidget *parent, Type type) :
     QDialog(parent),
     ui(new Ui::RenameDialog)
 {
     ui->setupUi(this);
+    this->type = type;
     setWindowFlags(windowFlags() & (~Qt::WindowContextHelpButtonHint));
+    connect(ui->autoRenameCheckBox, SIGNAL(stateChanged(int)), this, SLOT(autoRenameStateChanged(int)));
+    connect(ui->realnameLineEdit, SIGNAL(textEdited(QString)), this, SLOT(realnameTextEdited(QString)));
 }
 
 RenameDialog::~RenameDialog() {}
@@ -14,7 +20,7 @@ RenameDialog::~RenameDialog() {}
 void RenameDialog::on_buttonBox_accepted()
 {
     // Rename function and refresh widgets
-    QString name = ui->nameEdit->text();
+    QString name = ui->flagNameLineEdit->text();
 }
 
 void RenameDialog::on_buttonBox_rejected()
@@ -22,29 +28,159 @@ void RenameDialog::on_buttonBox_rejected()
     close();
 }
 
-void RenameDialog::setName(QString fcnName)
+void RenameDialog::setName(QString name)
 {
-    ui->nameEdit->setText(fcnName);
-    ui->nameEdit->selectAll();
+    ui->flagNameLineEdit->setText(name);
 }
 
 QString RenameDialog::getName() const
 {
-    return ui->nameEdit->text();
+    return ui->flagNameLineEdit->text();
+}
+
+void RenameDialog::setRealName(QString name)
+{
+    ui->realnameLineEdit->setText(name);
+    ui->realnameLineEdit->selectAll();
+}
+
+QString RenameDialog::getRealName() const
+{
+    return ui->realnameLineEdit->text();
+}
+
+void RenameDialog::setDialogType(Type type)
+{
+    this->type = type;
 }
 
 void RenameDialog::setPlaceholderText(const QString &text)
 {
-    ui->nameEdit->setPlaceholderText(text);
+    ui->realnameLineEdit->setPlaceholderText(text);
 }
 
-bool RenameDialog::showDialog(const QString &title, QString *name, const QString &placeholder, QWidget *parent)
+bool RenameDialog::showDialog(const QString &title, QString *name, const QString &placeholder,
+                              Type type, QWidget *parent)
 {
     RenameDialog dialog(parent);
+
+    dialog.type = type;
     dialog.setWindowTitle(title);
     dialog.setPlaceholderText(placeholder);
     dialog.setName(*name);
     int result = dialog.exec();
     *name = dialog.getName();
     return result == QDialog::DialogCode::Accepted;
+}
+
+
+void RenameDialog::autoRenameStateChanged(int state)
+{
+       switch (state) {
+       case Qt::Checked:
+           ui->flagNameLineEdit->setEnabled(false);
+           break;
+       case Qt::Unchecked:
+           ui->flagNameLineEdit->setEnabled(true);
+           break;
+       }
+}
+
+void RenameDialog::realnameTextEdited(QString text)
+{
+    if (ui->autoRenameCheckBox->isChecked()) {
+        // Don't duplicate flag prefixes
+        if (text.startsWith(flagPrefix)) {
+            setName(text + flagSuffix);
+        } else {
+            setName(flagPrefix + text + flagSuffix);
+        }
+    }
+}
+
+void RenameDialog::showEvent(QShowEvent* event)
+{
+    if (type == Type::Class) {
+        ui->realnameLabel->hide();
+        ui->realnameLineEdit->hide();
+        ui->autoRenameCheckBox->setChecked(false);
+        ui->autoRenameCheckBox->hide();
+        ui->flagNameLineEdit->setFocus();
+        ui->flagNameLineEdit->selectAll();
+        return;
+    }
+
+    // Disable auto-rename if realname is not a sub-string of the flagName
+    QString flagName = getName();
+    QString realname = getRealName();
+
+    if (realname.isEmpty()) {
+        setRealName(flagName);
+        realname = flagName;
+    }
+
+    bool sameNames = flagName.compare(realname) == 0;
+    bool realnameIsSubstring = flagName.contains(realname);
+
+    // We want realname to be a substring of name. but not an exact match.
+    // Otherwise, we'll try to handle the prefixes by ourselves
+    if (realnameIsSubstring && !sameNames) {
+
+        // Realname is a substring, we can enable auto-name
+        // and do auto-magic when renaming
+        ui->autoRenameCheckBox->setChecked(true);
+
+        // Grab the index of realname inside the flag name, usually
+        // it will be right after the prefix such as "imp.", "fcn.", "sym.", etc.
+        int indexOfSubstring = flagName.indexOf(realname);
+
+        // Grab the prefix, including the separating 'dot'. We'll use this prefix
+        // later to construct the new flag name.
+        // For the name "sym.helloworld" and realname "helloworld" the prefix
+        // will be "sym.".
+        flagPrefix = flagName.left(indexOfSubstring);
+
+        if (indexOfSubstring + realname.length() < flagName.length()) {
+
+            // When possible, we would also like to grab the suffix of the flag.
+            // For the name "sym.helloworld_2a" and realname "helloworld" the suffix
+            // Will be "_2a". Then. when the realname would change to something like
+            // "goodbye", the flag name would be "sym.goodbye_2a".
+            flagSuffix = flagName.right(indexOfSubstring + realname.length());
+        }
+    } else {
+        int indexOfDot = realname.indexOf('.');
+        if (indexOfDot == -1) {
+            // loc. is our generic prefix to mark a location.
+            // If more info provided to us we can use fcn.,
+            // str., etc.
+            switch (type) {
+            case Type::Function:
+                flagPrefix = "fcn.";
+                break;
+            case Type::String:
+                flagPrefix = "str.";
+                break;
+             default:
+                flagPrefix = "loc.";
+            }
+        } else {
+            flagPrefix = realname.left(indexOfDot+1);
+        }
+        // Enable or disable the auto-rename checkbox based on our
+        // confidence with having the prefix.
+        ui->autoRenameCheckBox->setChecked(indexOfDot != -1 || sameNames);
+    }
+
+    // Focus on realname and select the text to make it quick for the user to rename
+    ui->realnameLineEdit->setFocus();
+    ui->realnameLineEdit->selectAll();
+}
+
+void RenameDialog::accept()
+{
+    if (!getName().contains('.')) {
+        qDebug() << "Potential problematic UID Name for the flag. Flags are better to contain a dot ('.')";
+    }
+    QDialog::accept();
 }

--- a/src/dialogs/RenameDialog.cpp
+++ b/src/dialogs/RenameDialog.cpp
@@ -119,7 +119,7 @@ void RenameDialog::showEvent(QShowEvent* event)
         realname = flagName;
     }
 
-    bool sameNames = flagName.compare(realname) == 0;
+    bool sameNames = flagName == realname;
     bool realnameIsSubstring = flagName.contains(realname);
 
     // We want realname to be a substring of name. but not an exact match.

--- a/src/dialogs/RenameDialog.cpp
+++ b/src/dialogs/RenameDialog.cpp
@@ -20,7 +20,7 @@ RenameDialog::~RenameDialog() {}
 void RenameDialog::on_buttonBox_accepted()
 {
     // Rename function and refresh widgets
-    QString name = ui->flagNameLineEdit->text();
+    QString name = ui->nameLineEdit->text();
 }
 
 void RenameDialog::on_buttonBox_rejected()
@@ -30,12 +30,12 @@ void RenameDialog::on_buttonBox_rejected()
 
 void RenameDialog::setName(QString name)
 {
-    ui->flagNameLineEdit->setText(name);
+    ui->nameLineEdit->setText(name);
 }
 
 QString RenameDialog::getName() const
 {
-    return ui->flagNameLineEdit->text();
+    return ui->nameLineEdit->text();
 }
 
 void RenameDialog::setRealName(QString name)
@@ -78,10 +78,10 @@ void RenameDialog::autoRenameStateChanged(int state)
 {
        switch (state) {
        case Qt::Checked:
-           ui->flagNameLineEdit->setEnabled(false);
+           ui->nameLineEdit->setEnabled(false);
            break;
        case Qt::Unchecked:
-           ui->flagNameLineEdit->setEnabled(true);
+           ui->nameLineEdit->setEnabled(true);
            break;
        }
 }
@@ -105,8 +105,8 @@ void RenameDialog::showEvent(QShowEvent* event)
         ui->realnameLineEdit->hide();
         ui->autoRenameCheckBox->setChecked(false);
         ui->autoRenameCheckBox->hide();
-        ui->flagNameLineEdit->setFocus();
-        ui->flagNameLineEdit->selectAll();
+        ui->nameLineEdit->setFocus();
+        ui->nameLineEdit->selectAll();
         return;
     }
 

--- a/src/dialogs/RenameDialog.h
+++ b/src/dialogs/RenameDialog.h
@@ -16,12 +16,42 @@ class RenameDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit RenameDialog(QWidget *parent = nullptr);
+    enum Type {
+        Flag,
+        Function,
+        String,
+        Class
+    };
+
+    explicit RenameDialog(QWidget *parent = nullptr, Type type = Type::Flag);
     ~RenameDialog();
 
-    void setName(QString fcnName);
+    // Type that represents the object to be renamed
+    Type type;
+
+    /**
+     * @brief Set the value of the flag name Line Edit to \a name.
+     * 
+     * @param name The flag name to be filled in the Line Edit.
+     */
+    void setName(QString name);
     QString getName() const;
 
+    /**
+     * @brief Set the value of the realname Line Edit to \a name.
+     * 
+     * @param name The realname to be filled in the Line Edit.
+     */
+    void setRealName(QString name);
+
+    /**
+     * @brief Get the value of the realname Line Edit
+     * 
+     * @return QString
+     */
+    QString getRealName() const;
+
+    void setDialogType(Type type);
     void setPlaceholderText(const QString &text);
 
     /**
@@ -32,15 +62,24 @@ public:
      * @param placeholder placeholder text for the QLineEdit
      * @return whether the dialog was accepted by the user
      */
-    static bool showDialog(const QString &title, QString *name, const QString &placeholder, QWidget *parent = nullptr);
+    static bool showDialog(const QString &title, QString *name, const QString &placeholder,
+                           Type type = Type::Flag, QWidget *parent = nullptr);
+
+protected:
+    void showEvent(QShowEvent *event);
+    void accept();
 
 private slots:
     void on_buttonBox_accepted();
 
     void on_buttonBox_rejected();
 
+    void autoRenameStateChanged(int state);
+    void realnameTextEdited(QString text);
 private:
     std::unique_ptr<Ui::RenameDialog> ui;
+    QString flagPrefix = QString();
+    QString flagSuffix = QString();
 };
 
 #endif // RENAMEDIALOG_H

--- a/src/dialogs/RenameDialog.ui
+++ b/src/dialogs/RenameDialog.ui
@@ -40,7 +40,7 @@
       </widget>
      </item>
      <item row="1" column="1">
-      <widget class="QLineEdit" name="flagNameLineEdit">
+      <widget class="QLineEdit" name="nameLineEdit">
        <property name="enabled">
         <bool>false</bool>
        </property>

--- a/src/dialogs/RenameDialog.ui
+++ b/src/dialogs/RenameDialog.ui
@@ -9,28 +9,58 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>75</height>
+    <width>491</width>
+    <height>128</height>
    </rect>
   </property>
   <property name="windowTitle">
-   <string notr="true">Rename function</string>
+   <string notr="true">Rename</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <property name="spacing">
-      <number>5</number>
-     </property>
-     <item>
-      <widget class="QLabel" name="nameLabel">
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="realnameLabel">
+       <property name="toolTip">
+        <string>By default, this is the name that Cutter displays in the disassembly, graph, decompiler and across different widgets.</string>
+       </property>
        <property name="text">
-        <string>Name:</string>
+        <string>Display Name (realname):</string>
        </property>
       </widget>
      </item>
-     <item>
-      <widget class="QLineEdit" name="nameEdit">
+     <item row="1" column="0">
+      <widget class="QLabel" name="uidLabel">
+       <property name="toolTip">
+        <string>A unique identifier name that is used by radare2 to represent a flag. This name is not shown by default in Cutter.</string>
+       </property>
+       <property name="text">
+        <string>Unique Identifier (name):</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="flagNameLineEdit">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="QCheckBox" name="autoRenameCheckBox">
+       <property name="toolTip">
+        <string>Guesses the most suitable flag name and apllies it</string>
+       </property>
+       <property name="text">
+        <string>Auto-Rename</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1" colspan="2">
+      <widget class="QLineEdit" name="realnameLineEdit">
        <property name="inputMask">
         <string notr="true"/>
        </property>

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -33,7 +33,7 @@ DisassemblyContextMenu::DisassemblyContextMenu(QWidget *parent, MainWindow *main
         actionCopyAddr(this),
         actionAddComment(this),
         actionAddFlag(this),
-        actionDefineFunction(this),
+        actionAnalyzeFunction(this),
         actionEditFunction(this),
         actionRename(this),
         actionRenameUsedHere(this),
@@ -116,9 +116,9 @@ DisassemblyContextMenu::DisassemblyContextMenu(QWidget *parent, MainWindow *main
                SLOT(on_actionDeleteFunction_triggered()), getUndefineFunctionSequence());
     addAction(&actionDeleteFunction);
 
-    initAction(&actionDefineFunction, tr("Define function here"),
-               SLOT(on_actionDefineFunction_triggered()), getDefineNewFunctionSequence());
-    addAction(&actionDefineFunction);
+    initAction(&actionAnalyzeFunction, tr("Define function here"),
+               SLOT(on_actionAnalyzeFunction_triggered()), getDefineNewFunctionSequence());
+    addAction(&actionAnalyzeFunction);
 
     addSeparator();
 
@@ -462,7 +462,7 @@ void DisassemblyContextMenu::aboutToShowSlot()
         }
     }
 
-    actionDefineFunction.setVisible(true);
+    actionAnalyzeFunction.setVisible(true);
 
     // Show the option to remove a defined string only if a string is defined in this address
     QString stringDefinition = Core()->cmdRawAt("Cs.", offset);
@@ -491,7 +491,7 @@ void DisassemblyContextMenu::aboutToShowSlot()
     actionDeleteFunction.setVisible(fcn ? true : false);
 
     if (fcn) {
-        actionDefineFunction.setVisible(false);
+        actionAnalyzeFunction.setVisible(false);
         actionRename.setVisible(true);
         actionRename.setText(tr("Rename function \"%1\"").arg(fcn->name));
     } else if (f) {
@@ -773,7 +773,7 @@ void DisassemblyContextMenu::on_actionAddComment_triggered()
     CommentsDialog::addOrEditComment(offset, this);
 }
 
-void DisassemblyContextMenu::on_actionDefineFunction_triggered()
+void DisassemblyContextMenu::on_actionAnalyzeFunction_triggered()
 {
     RenameDialog dialog(mainWindow, RenameDialog::Type::Function);
     

--- a/src/menus/DisassemblyContextMenu.h
+++ b/src/menus/DisassemblyContextMenu.h
@@ -40,7 +40,7 @@ private slots:
     void on_actionCopy_triggered();
     void on_actionCopyAddr_triggered();
     void on_actionAddComment_triggered();
-    void on_actionAnalyzeFunction_triggered();
+    void on_actionDefineFunction_triggered();
     void on_actionAddFlag_triggered();
     void on_actionRename_triggered();
     void on_actionRenameUsedHere_triggered();
@@ -125,7 +125,7 @@ private:
 
     QAction actionAddComment;
     QAction actionAddFlag;
-    QAction actionAnalyzeFunction;
+    QAction actionDefineFunction;
     QAction actionEditFunction;
     QAction actionRename;
     QAction actionRenameUsedHere;
@@ -205,6 +205,7 @@ private:
 
     struct ThingUsedHere {
         QString name;
+        QString realname;
         RVA offset;
         enum class Type {
             Var,

--- a/src/menus/DisassemblyContextMenu.h
+++ b/src/menus/DisassemblyContextMenu.h
@@ -40,7 +40,7 @@ private slots:
     void on_actionCopy_triggered();
     void on_actionCopyAddr_triggered();
     void on_actionAddComment_triggered();
-    void on_actionDefineFunction_triggered();
+    void on_actionAnalyzeFunction_triggered();
     void on_actionAddFlag_triggered();
     void on_actionRename_triggered();
     void on_actionRenameUsedHere_triggered();
@@ -125,7 +125,7 @@ private:
 
     QAction actionAddComment;
     QAction actionAddFlag;
-    QAction actionDefineFunction;
+    QAction actionAnalyzeFunction;
     QAction actionEditFunction;
     QAction actionRename;
     QAction actionRenameUsedHere;

--- a/src/widgets/ClassesWidget.cpp
+++ b/src/widgets/ClassesWidget.cpp
@@ -744,7 +744,8 @@ void ClassesWidget::on_editMethodAction_triggered()
 void ClassesWidget::on_newClassAction_triggered()
 {
     QString name;
-    if (!RenameDialog::showDialog(tr("Create new Class"), &name, tr("Class Name"), this) || name.isEmpty()) {
+    if (!RenameDialog::showDialog(tr("Create new Class"), &name, tr("Class Name"),
+                                  RenameDialog::Type::Class, this) || name.isEmpty()) {
         return;
     }
     Core()->createNewClass(name);
@@ -771,7 +772,8 @@ void ClassesWidget::on_renameClassAction_triggered()
     }
     QString oldName = index.data(ClassesModel::NameRole).toString();
     QString newName = oldName;
-    if (!RenameDialog::showDialog(tr("Rename Class %1").arg(oldName), &newName, tr("Class Name"), this) || newName.isEmpty()) {
+    if (!RenameDialog::showDialog(tr("Rename Class %1").arg(oldName), &newName, tr("Class Name"),
+                                  RenameDialog::Type::Class, this) || newName.isEmpty()) {
         return;
     }
     Core()->renameClass(oldName, newName);

--- a/src/widgets/FlagsWidget.cpp
+++ b/src/widgets/FlagsWidget.cpp
@@ -87,6 +87,12 @@ QString FlagsModel::name(const QModelIndex &index) const
     return flag.name;
 }
 
+QString FlagsModel::realname(const QModelIndex &index) const
+{
+    const FlagDescription &flag = flags->at(index.row());
+    return flag.realname;
+}
+
 const FlagDescription *FlagsModel::description(QModelIndex index) const
 {
     if (index.row() < flags->size()) {
@@ -205,6 +211,7 @@ void FlagsWidget::on_actionRename_triggered()
                                FlagsModel::FlagDescriptionRole).value<FlagDescription>();
 
     RenameDialog r(this);
+    r.setRealName(flag.realname);
     r.setName(flag.name);
     if (r.exec()) {
         QString new_name = r.getName();

--- a/src/widgets/FlagsWidget.h
+++ b/src/widgets/FlagsWidget.h
@@ -40,6 +40,7 @@ public:
 
     RVA address(const QModelIndex &index) const override;
     QString name(const QModelIndex &index) const override;
+    QString realname(const QModelIndex &index) const;
 
     const FlagDescription *description(QModelIndex index) const;
 };

--- a/src/widgets/FunctionsWidget.cpp
+++ b/src/widgets/FunctionsWidget.cpp
@@ -527,10 +527,11 @@ void FunctionsWidget::onActionFunctionsRenameTriggered()
                                        FunctionModel::FunctionDescriptionRole).value<FunctionDescription>();
 
     // Create dialog
-    RenameDialog r(this);
+    RenameDialog r(this, RenameDialog::Type::Function);
 
     // Set function name in dialog
     r.setName(function.name);
+    r.setRealName(Core()->getRealNameByFlagName(function.name));
     // If user accepted
     if (r.exec()) {
         // Get new function name


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/developers-docs/first-time.html) to this repository
- [ ] I made sure to follow the project's [coding style](https://cutter.re/docs/developers-docs.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)

**Detailed description**

Currently, when renaming a flag or a function when realname is set to on, the change would not be visible since only the flag was changed but not its relanmae. 
This pull-request tries to apply magic renaming to flags and functions. 

To tell the truth, there is a lot of mess in r2 regarding the connection between flags, symbol names and function names. This is a nightmare (see radareorg/radare2#16519 for example).

In addition, the renaming feature is not implemented ideally. When implementing Classes, @thestr4ng3r added some nice function to handle renaming (in the same rename dialog), and it can be nice overall. I also added some variation here, but in general, this need to be unified and maybe refactored. That's another discussion.



![Peek 2020-04-10 19-57](https://user-images.githubusercontent.com/20182642/79007981-13a95800-7b65-11ea-8cea-4ff0c560dbe4.gif)
![Peek 2020-04-10 20-00](https://user-images.githubusercontent.com/20182642/79008248-9af6cb80-7b65-11ea-8b69-fbcc138ffbd6.gif)

![Peek 2020-04-10 19-58](https://user-images.githubusercontent.com/20182642/79008117-579c5d00-7b65-11ea-973b-339e1f7def17.gif)


**Test plan (required)**
1. Rename flags
2. Rename function
3. Add functions
4. Rename imported functions
5. Add flags
6. Rename from the functions widget
7. Rename from the flags widget
8. Rename classes
9. Add new class


**Closing issues**

closes #2119 
