### PR TITLE
Slight improvements to light theme

### DIFF
--- a/src/themes/lightstyle/light.qss
+++ b/src/themes/lightstyle/light.qss
@@ -132,6 +132,12 @@ QLineEdit
   padding:0 8px;
 }
 
+QLineEdit:disabled
+{
+  color: #919191;
+  background-color:#f1f1f1;
+}
+
 QLabel
 {
   color:#00162e;
@@ -199,6 +205,11 @@ QMenuBar::item:pressed
   padding-bottom:1px;
 }
 
+QMenuBar::item:disabled
+{
+  color: #a6a6a6;
+}
+
 QMenu
 {
   background-color:#fafcfe;
@@ -222,6 +233,11 @@ QMenu::item:selected
   border-left-width:2px;
   color:#039be5;
   background-color:#f4f9ff;
+}
+
+QMenu::item:disabled
+{
+  color: #a6a6a6;
 }
 
 QTabWidget
@@ -304,6 +320,11 @@ QCheckBox::indicator:unchecked
   border-color:#039be5;
   border-style:solid;
   border-width:1px;
+}
+
+QCheckBox::indicator:checked:disabled
+{
+  background-color:#d6d6d6;
 }
 
 QRadioButton
@@ -605,11 +626,13 @@ QLineEdit:hover,QLineEdit:focus
 
 QToolTip
 {
-  border-radius:4px;
+  border-radius:1px;
   opacity:200;
   border-style:solid;
+  border-color: white;
   border-width:2px;
   padding:5px;
+  background-color: #212121;
 }
 
 QFrame


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/developers-docs/first-time.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/developers-docs.html)

**Detailed description**
This pull-request add little improvements to the Light theme.

 - Hard-coded background color for tooltip (#2124)
![image](https://user-images.githubusercontent.com/20182642/79010370-7bae6d00-7b6a-11ea-82c9-42cd569f40ec.png)

- Add background color for disabled QLineEdit to indicate it is disabled
![image](https://user-images.githubusercontent.com/20182642/79010526-d2b44200-7b6a-11ea-9565-99be98d962ee.png)

- Different font color for a disabled menu item
![image](https://user-images.githubusercontent.com/20182642/79010649-0f803900-7b6b-11ea-80f4-ca9606beb74d.png)

- Filled+Disabled checkbox now have a different fill color than enabled
![image](https://user-images.githubusercontent.com/20182642/79010775-50784d80-7b6b-11ea-908a-9b67e0819d33.png)


**Test plan (required)**
- Follow the mentioned screenshots and check if it looks similar on your machine
- My OS theme is dark, so it would be nice to test on Light OS theme

**Closing issues**

closes #2124 
