### PR TITLE
Use drrj in register widget

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1494,22 +1494,22 @@ QList<VariableDescription> CutterCore::getVariables(RVA at)
     return ret;
 }
 
-QJsonObject CutterCore::getRegisterJson()
+QVector<RegisterRefValueDescription> CutterCore::getRegisterRefValues()
 {
     QJsonArray registerRefArray = cmdj("drrj").array();
-    QJsonObject registerJson;
+    QVector<RegisterRefValueDescription> result;
 
-    for (const QJsonValue &value : registerRefArray) {
+    for (const QJsonValue value : registerRefArray) {
         QJsonObject regRefObject = value.toObject();
 
-        QJsonObject registers;
+        RegisterRefValueDescription desc;
+        desc.name = regRefObject[RJsonKey::reg].toString();
+        desc.value = regRefObject[RJsonKey::value].toString();
+        desc.ref = regRefObject[RJsonKey::ref].toString();
 
-        registers.insert(RJsonKey::value, regRefObject[RJsonKey::value]);
-        registers.insert(RJsonKey::ref, regRefObject[RJsonKey::ref]);
-
-        registerJson.insert(regRefObject[RJsonKey::reg].toString(), registers);
+        result.push_back(desc);
     }
-    return registerJson;
+    return result;
 }
 
 QString CutterCore::getRegisterName(QString registerRole)

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -560,7 +560,7 @@ public:
      * @param depth telescoping depth
      */
     QList<QJsonObject> getRegisterRefs(int depth = 6);
-    QJsonObject getRegisterJson();
+    QVector<RegisterRefValueDescription> getRegisterRefValues();
     QList<VariableDescription> getVariables(RVA at);
 
     QList<XrefDescription> getXRefs(RVA addr, bool to, bool whole_function,

--- a/src/core/CutterDescriptions.h
+++ b/src/core/CutterDescriptions.h
@@ -321,6 +321,12 @@ struct VariableDescription {
     QString type;
 };
 
+struct RegisterRefValueDescription {
+    QString name;
+    QString value;
+    QString ref;
+};
+
 Q_DECLARE_METATYPE(FunctionDescription)
 Q_DECLARE_METATYPE(ImportDescription)
 Q_DECLARE_METATYPE(ExportDescription)

--- a/src/widgets/RegistersWidget.cpp
+++ b/src/widgets/RegistersWidget.cpp
@@ -51,17 +51,11 @@ void RegistersWidget::setRegisterGrid()
     QString regValue;
     QLabel *registerLabel;
     QLineEdit *registerEditValue;
-    QJsonObject registerValues = Core()->getRegisterValues().object();
-    QJsonObject registerRefs = Core()->getRegisterJson();
-    QStringList registerNames = registerValues.keys();
+    const auto registerRefs = Core()->getRegisterRefValues();
 
-    QCollator collator;
-    collator.setNumericMode(true);
-    std::sort(registerNames.begin(), registerNames.end(), collator);
-
-    registerLen = registerValues.size();
-    for (const QString &key : registerNames) {
-        regValue = RAddressString(registerValues[key].toVariant().toULongLong());
+    registerLen = registerRefs.size();
+    for (auto &reg : registerRefs) {
+        regValue = "0x" + reg.value;
         // check if we already filled this grid space with label/value
         if (!registerLayout->itemAtPosition(i, col)) {
             registerLabel = new QLabel;
@@ -87,8 +81,6 @@ void RegistersWidget::setRegisterGrid()
                 QString regNameString = registerLabel->text();
                 QString regValueString = registerEditValue->text();
                 Core()->setRegister(regNameString, regValueString);
-                printf("dr %s %s\n", regNameString.toLocal8Bit().constData(),
-                       regValueString.toLocal8Bit().constData());
             });
         } else {
             QWidget *regNameWidget = registerLayout->itemAtPosition(i, col)->widget();
@@ -104,13 +96,11 @@ void RegistersWidget::setRegisterGrid()
             registerEditValue->setStyleSheet("");
         }
         // define register label and value
-        registerLabel->setText(key);
-        if (registerRefs.contains(key)) {
-            // add register references to tooltips
-            QString reference = registerRefs[key].toObject()["ref"].toString();
-            registerLabel->setToolTip(reference);
-            registerEditValue->setToolTip(reference);
-        }
+        registerLabel->setText(reg.name);
+
+        registerLabel->setToolTip(reg.ref);
+        registerEditValue->setToolTip(reg.ref);
+
         registerEditValue->setPlaceholderText(regValue);
         registerEditValue->setText(regValue);
         i++;


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/developers-docs/first-time.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/developers-docs.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)

**Detailed description**

Use drrj to read values for register widget. 

It returns values as strings instead of numbers thus avoiding json 64bit number parsing problem. There can be registers wider than 64 bits so even if changed JSON parser it wouldn't solve the problem of parsing those.

`drrj` also returns the values as array instead of dictionary so it is possible to preserve the order.  It is assumed that order returned by r2 could be closer to what user expects than sorting alphabetically.

Note to anyone testing this: r2 submodule update is required. Without it register name and value may contain partial terminal color codes which will cause problems.

Having two register ref methods in CutterCore is a bit ugly but they where there before and cleaning that up would require more refactoring in Cutter and r2.

**Test plan (required)**

* perform the steps from #2108 bug report
* try editing a register and verify changes using drrj in console

![registers](https://user-images.githubusercontent.com/7101031/79063917-7d347e00-7cad-11ea-9d31-a665d9edfe52.png)

**Closing issues**

closes #2139 , closes #2108 
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
