### PR TITLE
Add commandline option for disabling stdout redirection

### DIFF
--- a/docs/source/common-errors.rst
+++ b/docs/source/common-errors.rst
@@ -16,7 +16,7 @@ Compilation error
 -----------------
 
 r_core development package not found
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you installed radare2 and still encounter this error, it could be that your
 ``PATH`` environment variable is set improperly (doesn’t contain

--- a/docs/source/user-docs.rst
+++ b/docs/source/user-docs.rst
@@ -11,5 +11,6 @@ Cutter is an advanced reverse engineering platform that is powered by radare2. T
    :titlesonly:
    :glob:
 
+   user-docs/command-line
    user-docs/menus
 

--- a/docs/source/user-docs/command-line.rst
+++ b/docs/source/user-docs/command-line.rst
@@ -1,0 +1,63 @@
+Command line options
+====================
+
+Synopsis
+--------
+
+**Cutter** [*options*] [<*filename*>]
+
+
+Options
+-------
+
+.. option:: <filename>
+
+   Filename to open. If not specified file selection dialog will be shown.
+
+.. option:: -h, --help
+
+   Displays help on commandline options.
+
+.. option:: --help-all
+
+   Displays help including Qt specific options.
+
+.. option:: -v, --version
+
+   Displays version information.
+
+.. option:: -A, --anal <level>
+
+   When opening a file automatically perform analysis at given level. Requires
+   :option:`<filename>` to be specified. Following levels are available:
+
+   **0**
+     No analysis.
+
+   **1**
+     aaa
+
+   **2**
+     aaaa (experimental)
+
+.. option:: -F, --format <name>
+
+   Force using a specific file format (bin plugin)
+
+.. option:: -B, --base <base address>
+
+   Load binary at a specific base address
+
+.. option:: -i <file>
+
+   Run  script file
+
+.. option:: --pythonhome <PYTHONHOME>
+
+   PYTHONHOME to use for embedded python interpreter
+
+.. option:: --no-output-redirect
+
+   Disable output redirection. Some of the output in console widget will not
+   be visible. Use this option when debuging a crash or freeze and output
+   redirection is causing some messages to be lost.

--- a/src/CutterApplication.cpp
+++ b/src/CutterApplication.cpp
@@ -99,6 +99,13 @@ CutterApplication::CutterApplication(int &argc, char **argv) : QApplication(argc
                                         "PYTHONHOME");
     cmd_parser.addOption(pythonHomeOption);
 
+    QCommandLineOption disableRedirectOption("no-output-redirect",
+                                    QObject::tr("Disable output redirection."
+                                                " Some of the output in console widget will not be visible."
+                                                " Use this option when debuging a crash or freeze and output "
+                                                " redirection is causing some messages to be lost."));
+    cmd_parser.addOption(disableRedirectOption);
+
     cmd_parser.process(*this);
 
     QStringList args = cmd_parser.positionalArguments();
@@ -136,6 +143,10 @@ CutterApplication::CutterApplication(int &argc, char **argv) : QApplication(argc
     Core()->setSettings();
     Config()->loadInitial();
     Core()->loadCutterRC();
+
+    if (cmd_parser.isSet(disableRedirectOption)) {
+        Config()->setOutputRedirectionEnabled(false);
+    }
 
     if (R2DecDecompiler::isAvailable()) {
         Core()->registerDecompiler(new R2DecDecompiler(Core()));
@@ -367,4 +378,3 @@ void CutterProxyStyle::polish(QWidget *widget)
     }
 #endif // QT_VERSION_CHECK(5, 10, 0) < QT_VERSION
 }
-

--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -728,3 +728,13 @@ void Configuration::setBitmapExportScaleFactor(double inputValueGraph)
     s.setValue("bitmapGraphExportScale", inputValueGraph);
 }
 
+void Configuration::setOutputRedirectionEnabled(bool enabled)
+{
+    this->outputRedirectEnabled = enabled;
+}
+
+bool Configuration::getOutputRedirectionEnabled() const
+{
+    return outputRedirectEnabled;
+}
+

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -41,6 +41,7 @@ private:
 #ifdef CUTTER_ENABLE_KSYNTAXHIGHLIGHTING
     KSyntaxHighlighting::Repository *kSyntaxHighlightingRepository;
 #endif
+    bool outputRedirectEnabled = true;
 
     // Colors
     void loadBaseThemeNative();
@@ -180,6 +181,15 @@ public:
     double getBitmapExportScaleFactor();
     void setBitmapTransparentState(bool inputValueGraph);
     void setBitmapExportScaleFactor(double inputValueGraph);
+
+    /**
+     * @brief Enable or disable Cutter output redirection.
+     * Output redirection state can only be changed early during Cutter initalization.
+     * Changing it later will have no effect
+     * @param enabled set this to false for disabling output redirection
+     */
+    void setOutputRedirectionEnabled(bool enabled);
+    bool getOutputRedirectionEnabled() const;
 
 public slots:
     void refreshFont();

--- a/src/widgets/ConsoleWidget.cpp
+++ b/src/widgets/ConsoleWidget.cpp
@@ -128,7 +128,9 @@ ConsoleWidget::ConsoleWidget(MainWindow *main, QAction *action) :
 
     completer->popup()->installEventFilter(this);
 
-    redirectOutput();
+    if (Config()->getOutputRedirectionEnabled()) {
+        redirectOutput();
+    }
 }
 
 ConsoleWidget::~ConsoleWidget()


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/developers-docs/first-time.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/developers-docs.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Even though output redirection sends a copy of messages to original stdout and stderr it can do it only when everything is working correctly. Output redirection can cause some of the messages to get lost when Cutter crashes, freezes or during opening and closing. These are the moments when seeing output standard output is most important. For example today I wanted to run Cutter with sanitizers but some of the sanitizer messages during exit got lost.

PR adds a commandline option for disabling output redirection.

**Test plan (required)**

* run `Cutter --help`, make sure new option is displayed :heavy_check_mark: 
* run Cutter without specifying the option and check that messages are printed to console widget :heavy_check_mark: 
* run Cutter with `--no-output-redirect` option from terminal. Observe that some of the output that was previously seen in console widget  is now visible only in terminal. :heavy_check_mark: 

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
