### PR TITLE
Fix memory leak in listFlagsAsStringsAt.

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -3483,7 +3483,10 @@ void CutterCore::addFlag(RVA offset, QString name, RVA size)
 QString CutterCore::listFlagsAsStringAt(RVA addr)
 {
     CORE_LOCK();
-    return r_flag_get_liststr (core->flags, addr);
+    char *flagList = r_flag_get_liststr (core->flags, addr);
+    QString result(flagList);
+    r_mem_free(flagList);
+    return result;
 }
 
 QString CutterCore::nearestFlag(RVA offset, RVA *flagOffsetOut)


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/developers-docs/first-time.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/developers-docs.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Free the pointer obtained from r2.

**Test plan (required)**

* compare address sanitizer output before and after
* hover the mouse over flag marker in hexwidget, make sure tooltip with flag name is displayed

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
