### PR TITLE
Fix errors reported by UB sanitizer

### DIFF
--- a/src/widgets/ConsoleWidget.cpp
+++ b/src/widgets/ConsoleWidget.cpp
@@ -133,8 +133,6 @@ ConsoleWidget::ConsoleWidget(MainWindow *main, QAction *action) :
 
 ConsoleWidget::~ConsoleWidget()
 {
-    delete completer;
-
 #ifndef Q_OS_WIN
     ::close(stdinFile);
     remove(stdinFifoPath.toStdString().c_str());

--- a/src/widgets/HexWidget.h
+++ b/src/widgets/HexWidget.h
@@ -75,7 +75,7 @@ class AbstractData
 public:
     virtual ~AbstractData() {}
     virtual void fetch(uint64_t addr, int len) = 0;
-    virtual const void *dataPtr(uint64_t addr) = 0;
+    virtual bool copy(void *out, uint64_t adr, size_t len) = 0;
     virtual uint64_t maxIndex() = 0;
     virtual uint64_t minIndex() = 0;
 };
@@ -101,9 +101,12 @@ public:
 
     void fetch(uint64_t, int) override { }
 
-    const void *dataPtr(uint64_t addr) override
-    {
-        return m_buffer.constData() + addr;
+    bool copy(void *out, uint64_t addr, size_t len) override {
+        if (addr < static_cast<uint64_t>(m_buffer.size()) && (static_cast<uint64_t>(m_buffer.size()) - addr) < len) {
+            memcpy(out, m_buffer.constData() + addr, len);
+            return true;
+        }
+        return false;
     }
 
     uint64_t maxIndex() override
@@ -120,6 +123,7 @@ class MemoryData : public AbstractData
 public:
     MemoryData() {}
     ~MemoryData() override {}
+    static constexpr size_t BLOCK_SIZE = 4096;
 
     void fetch(uint64_t address, int length) override
     {
@@ -141,12 +145,23 @@ public:
         }
     }
 
-    const void *dataPtr(uint64_t addr) override
-    {
+    bool copy(void *out, uint64_t addr, size_t len) override {
+        if (addr < m_firstBlockAddr || addr > m_lastValidAddr ||
+                (m_lastValidAddr - addr + 1) < len /* do not merge with last check to handle overflows */) {
+            return false;
+        }
+
         int totalOffset = addr - m_firstBlockAddr;
-        int blockId = totalOffset / 4096;
-        int blockOffset = totalOffset % 4096;
-        return static_cast<const void *>(m_blocks.at(blockId).constData() + blockOffset);
+        int blockId = totalOffset / BLOCK_SIZE;
+        int blockOffset = totalOffset % BLOCK_SIZE;
+        size_t first_part = BLOCK_SIZE - blockOffset;
+        if (first_part >= len) {
+            memcpy(out, m_blocks.at(blockId).constData() + blockOffset, len);
+        } else {
+            memcpy(out, m_blocks.at(blockId).constData() + blockOffset, first_part);
+            memcpy(static_cast<char*>(out) + first_part, m_blocks.at(blockId + 1).constData(), len - first_part);
+        }
+        return true;
     }
 
     virtual uint64_t maxIndex() override
@@ -353,13 +368,13 @@ private:
      * @param offset relative to first byte on screen
      * @return
      */
-    QRectF itemRectangle(uint offset);
+    QRectF itemRectangle(int offset);
     /**
      * @brief Rectangle for single item in ascii area.
      * @param offset relative to first byte on screen
      * @return
      */
-    QRectF asciiRectangle(uint offset);
+    QRectF asciiRectangle(int offset);
     QVector<QPolygonF> rangePolygons(RVA start, RVA last, bool ascii);
     void updateWidth();
 
@@ -450,12 +465,12 @@ private:
     QRectF itemArea;
     QRectF asciiArea;
 
-    int itemByteLen;
-    int itemGroupSize; ///< Items per group (default: 1), 2 in case of hexpair mode
-    int rowSizeBytes; ///< Line size in bytes
-    int itemColumns; ///< Number of columns, single column consists of itemGroupSize items
-    int itemCharLen;
-    int itemPrefixLen;
+    int itemByteLen = 1;
+    int itemGroupSize = 1; ///< Items per group (default: 1), 2 in case of hexpair mode
+    int rowSizeBytes = 16; ///< Line size in bytes
+    int itemColumns = 16; ///< Number of columns, single column consists of itemGroupSize items
+    int itemCharLen = 2;
+    int itemPrefixLen = 0;
     ColumnMode columnMode;
 
     ItemFormat itemFormat;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/developers-docs/first-time.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/developers-docs.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

* Use qt parent for deleting complete - Manualy deleting causes some UAF due to it being isntalled as event filter. Qt seems to destroy things in correct order. Sanitizer doesn't report completer as being leaked.
* Fix sanitizer problems in HexWidget
  * Initialize size properties to somewhat sane values to avoid unitialized variable use when calculating them first time.
  * Change AbstractData interface. Old one returned pointer to unknwon sized block of data which was difficult to use correctly. Adjust bound checking to avoid out of bounds access when comparing  it with oldData and scrolling.

**Test plan (required)**

* run with sanitizer, make sure it doesn't complain about completer getting leaked :heavy_check_mark: 
* open disasembly widget next to hexdump, test that changed bytes highlighted still works by noping an instruction :heavy_check_mark: 

<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
