### PR TITLE
Resource names are strings

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -3121,7 +3121,7 @@ QList<ResourcesDescription> CutterCore::getAllResources()
 
         ResourcesDescription res;
 
-        res.name = resourceObject[RJsonKey::name].toInt();
+        res.name = resourceObject[RJsonKey::name].toString();
         res.vaddr = resourceObject[RJsonKey::vaddr].toVariant().toULongLong();
         res.index = resourceObject[RJsonKey::index].toVariant().toULongLong();
         res.type = resourceObject[RJsonKey::type].toString();

--- a/src/core/CutterDescriptions.h
+++ b/src/core/CutterDescriptions.h
@@ -239,7 +239,7 @@ struct AnalVTableDescription {
 };
 
 struct ResourcesDescription {
-    int name;
+    QString name;
     RVA vaddr;
     ut64 index;
     QString type;

--- a/src/widgets/ResourcesWidget.cpp
+++ b/src/widgets/ResourcesWidget.cpp
@@ -27,7 +27,7 @@ QVariant ResourcesModel::data(const QModelIndex &index, int role) const
     case Qt::DisplayRole:
         switch (index.column()) {
         case NAME:
-            return QString::number(res.name);
+            return res.name;
         case VADDR:
             return RAddressString(res.vaddr);
         case INDEX:


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/developers-docs/first-time.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/developers-docs.html)


**Detailed description**
Resources names are provided by radare2 as Strings while Cutter treats them as integers and shows them as 0.

This PR make sure Cutter treats them as strings and not as integers. 

![image](https://user-images.githubusercontent.com/20182642/79348676-fc3fe580-7f3d-11ea-9c84-7b31dc667467.png)

**Test plan (required)**

- Open a PE with resources in Cutter
- See that the names are shown correctly


**Closing issues**

closes #2149 
