### PR TITLE
Add option for not loading plugins

### DIFF
--- a/docs/source/user-docs/command-line.rst
+++ b/docs/source/user-docs/command-line.rst
@@ -61,3 +61,15 @@ Options
    Disable output redirection. Some of the output in console widget will not
    be visible. Use this option when debuging a crash or freeze and output
    redirection is causing some messages to be lost.
+
+.. option:: --no-plugins
+
+   Start cutter with all plugins disabled. Implies :option:`--no-cutter-plugins` and :option:`--no-r2-plugins`.
+
+.. option:: --no-cutter-plugins
+
+   Start cutter with cutter plugins disabled.
+
+.. option:: --no-r2-plugins
+
+   Start cutter with r2 plugins disabled.

--- a/src/CutterApplication.cpp
+++ b/src/CutterApplication.cpp
@@ -205,7 +205,7 @@ void CutterApplication::launchNewInstance(const QStringList &args)
         allArgs.push_back("--no-cutter-plugins");
     }
     if (!clOptions.enableR2Plugins) {
-        allArgs.push_back("--no-cutter-plugins");
+        allArgs.push_back("--no-r2-plugins");
     }
     allArgs.append(args);
     process.startDetached(qApp->applicationFilePath(), allArgs);

--- a/src/CutterApplication.h
+++ b/src/CutterApplication.h
@@ -8,6 +8,17 @@
 
 #include "core/MainWindow.h"
 
+enum class AutomaticAnalysisLevel {
+    Ask, None, AAA, AAAA
+};
+
+struct CutterCommandLineOptions {
+    QStringList args;
+    AutomaticAnalysisLevel analLevel = AutomaticAnalysisLevel::Ask;
+    InitialOptions fileOpenOptions;
+    QString pythonHome;
+    bool outputRedirectionEnabled = true;
+};
 
 class CutterApplication : public QApplication
 {
@@ -31,10 +42,15 @@ private:
      * @return true on success
      */
     bool loadTranslations();
-
+    /**
+     * @brief Parse commandline options and store them in a structure.
+     * @return false if options have error
+     */
+    bool parseCommandLineOptions();
 private:
     bool m_FileAlreadyDropped;
     MainWindow *mainWindow;
+    CutterCommandLineOptions clOptions;
 };
 
 

--- a/src/CutterApplication.h
+++ b/src/CutterApplication.h
@@ -18,6 +18,8 @@ struct CutterCommandLineOptions {
     InitialOptions fileOpenOptions;
     QString pythonHome;
     bool outputRedirectionEnabled = true;
+    bool enableCutterPlugins = true;
+    bool enableR2Plugins = true;
 };
 
 class CutterApplication : public QApplication
@@ -33,6 +35,7 @@ public:
         return mainWindow;
     }
 
+    void launchNewInstance(const QStringList &args = {});
 protected:
     bool event(QEvent *e);
 

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -174,7 +174,7 @@ CutterCore *CutterCore::instance()
     return uniqueInstance;
 }
 
-void CutterCore::initialize()
+void CutterCore::initialize(bool loadPlugins)
 {
     r_cons_new();  // initialize console
     core_ = r_core_new();
@@ -208,7 +208,12 @@ void CutterCore::initialize()
     }
 #endif
 
-    r_core_loadlibs(this->core_, R_CORE_LOADLIBS_ALL, NULL);
+    if (!loadPlugins) {
+        setConfig("cfg.plugins", 0);
+    }
+    if (getConfigi("cfg.plugins")) {
+        r_core_loadlibs(this->core_, R_CORE_LOADLIBS_ALL, nullptr);
+    }
     // IMPLICIT r_bin_iobind (core_->bin, core_->io);
 
     // Otherwise r2 may ask the user for input and Cutter would freeze

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -44,7 +44,7 @@ public:
     ~CutterCore();
     static CutterCore *instance();
 
-    void initialize();
+    void initialize(bool loadPlugins = true);
     void loadCutterRC();
 
     AsyncTaskManager *getAsyncTaskManager() { return asyncTaskManager; }

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -13,6 +13,7 @@
 #include "common/PythonManager.h"
 #include "plugins/PluginManager.h"
 #include "CutterConfig.h"
+#include "CutterApplication.h"
 
 // Dialogs
 #include "dialogs/WelcomeDialog.h"
@@ -1349,9 +1350,7 @@ void MainWindow::on_actionDefault_triggered()
 void MainWindow::on_actionNew_triggered()
 {
     // Create a new Cutter process
-    QProcess process(this);
-    process.setEnvironment(QProcess::systemEnvironment());
-    process.startDetached(qApp->applicationFilePath());
+    static_cast<CutterApplication*>(qApp)->launchNewInstance();
 }
 
 void MainWindow::on_actionSave_triggered()

--- a/src/plugins/PluginManager.cpp
+++ b/src/plugins/PluginManager.cpp
@@ -31,9 +31,14 @@ PluginManager::~PluginManager()
 {
 }
 
-void PluginManager::loadPlugins()
+void PluginManager::loadPlugins(bool enablePlugins)
 {
     assert(plugins.empty());
+
+    if (!enablePlugins) {
+        // [#2159] list but don't enable the plugins
+        return;
+    }
 
     QString userPluginDir = getUserPluginsDirectory();
     if (!userPluginDir.isEmpty()) {

--- a/src/plugins/PluginManager.h
+++ b/src/plugins/PluginManager.h
@@ -28,8 +28,9 @@ public:
 
     /**
      * @brief Load all plugins, should be called once on application start
+     * @param enablePlugins set to false if plugin code shouldn't be started
      */
-    void loadPlugins();
+    void loadPlugins(bool enablePlugins = true);
 
     /**
      * @brief Destroy all loaded plugins, should be called once on application shutdown


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/developers-docs/first-time.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/developers-docs.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

**Test plan (required)**

* install example python plugin and make sure it starts :heavy_check_mark: 
* start cutter with `--no-plugins`, check that plugin isn't loaded :heavy_check_mark: 
* start cutter with `--no-cutter-plugins`, check that plugin isn't loaded :heavy_check_mark: 
* start cutter with `--no-r2-plugins`, check that plugin is loaded :heavy_check_mark: 
* start cutter with `--no-plugins`, create new window make sure plugins are still not loaded :heavy_check_mark:  
* test that `--no-r2-plugins` works :heavy_check_mark: 
* test that passing executable as argument and `-A` isn't broken by refactoring. :heavy_check_mark: 


**Closing issues**

Closes #2158 
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
