### PR TITLE
Rewrite layout management code

### DIFF
--- a/docs/source/user-docs/menus/menu-bar/view-menu.rst
+++ b/docs/source/user-docs/menus/menu-bar/view-menu.rst
@@ -69,12 +69,12 @@ Reset Zoom
 
 Save layout
 ----------------------------------------
-**Description:** Save current layout with given name. Layout includes the set of currently opened widgets, their position and some properties.
+**Description:** Save the current layout with a given name. A layout includes the set of currently opened widgets, their position, and some properties.
 
-**Steps:** View -> Save Layout , enter layout name in the dialog.
+**Steps:** View -> Save Layout , enter a layout name in the dialog.
 
 Layouts
 ----------------------------------------
-**Description:** Load the settings from selected layout into current layout. Loading a layout will not cause it to automatically be modifed. To do that you must use `Save layout`_ command. 
+**Description:** Load the settings from the selected layout into the current layout. Loading a layout will not cause it to automatically be modified. To do that you must use the `Save layout`_ command. 
 
 **Steps:** View -> Layouts ->  layout name

--- a/docs/source/user-docs/menus/menu-bar/view-menu.rst
+++ b/docs/source/user-docs/menus/menu-bar/view-menu.rst
@@ -1,6 +1,7 @@
 View Menu
 ==============================
 
+
 Refresh contents
 ----------------------------------------
 **Description:** In some cases, not all the displayed information on Cutter's widgets will be up-to-date, for example - after defining a new function from the integrated radare2 console. By refreshing the contents, Cutter will fetch the most up to date information from the session and will update the different views.
@@ -12,7 +13,7 @@ Refresh contents
 
 Reset to default layout
 ----------------------------------------
-**Description:** Reset the current layout to the default layout provided by Cutter. Future additions will include custom and user-defined layouts to which you'll be able to reset.
+**Description:** Reset the current layout to the default layout provided by Cutter.
 
 **Steps:** View -> Reset Layout  
 
@@ -24,7 +25,7 @@ Reset to default settings
 
 Lock and Unlock panels
 ----------------------------------------
-**Description:** Allow or disable locking the different widgets.  
+**Description:** Allow or disable moving and closing of different widgets. Uncheck this option to prevent accidentally modifying current layout.
 
 **Steps:** View -> Unlock Panels  
 
@@ -64,3 +65,16 @@ Reset Zoom
 **Steps:** View -> Zoom -> Reset  
 
 **Shortcut:** :kbd:`Ctrl` + :kbd:`=`
+
+
+Save layout
+----------------------------------------
+**Description:** Save current layout with given name. Layout includes the set of currently opened widgets, their position and some properties.
+
+**Steps:** View -> Save Layout , enter layout name in the dialog.
+
+Layouts
+----------------------------------------
+**Description:** Load the settings from selected layout into current layout. Loading a layout will not cause it to automatically be modifed. To do that you must use `Save layout`_ command. 
+
+**Steps:** View -> Layouts ->  layout name

--- a/docs/source/user-docs/menus/menu-bar/view-menu.rst
+++ b/docs/source/user-docs/menus/menu-bar/view-menu.rst
@@ -15,7 +15,7 @@ Reset to default layout
 ----------------------------------------
 **Description:** Reset the current layout to the default layout provided by Cutter.
 
-**Steps:** View -> Reset Layout  
+**Steps:** View -> Reset to default layout
 
 Reset to default settings
 ----------------------------------------

--- a/src/Cutter.pro
+++ b/src/Cutter.pro
@@ -420,7 +420,8 @@ SOURCES += \
     widgets/ListDockWidget.cpp \
     dialogs/MultitypeFileSaveDialog.cpp \
     widgets/BoolToggleDelegate.cpp \
-    common/IOModesController.cpp
+    common/IOModesController.cpp \
+    common/SettingsUpgrade.cpp
 
 GRAPHVIZ_SOURCES = \
     widgets/GraphvizLayout.cpp
@@ -566,7 +567,8 @@ HEADERS  += \
     widgets/AddressableItemList.h \
     dialogs/MultitypeFileSaveDialog.h \
     widgets/BoolToggleDelegate.h \
-    common/IOModesController.h
+    common/IOModesController.h \
+    common/SettingsUpgrade.h
 
 GRAPHVIZ_HEADERS = widgets/GraphGridLayout.h
 

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -2,124 +2,13 @@
 #include "CutterApplication.h"
 #include "core/MainWindow.h"
 #include "common/UpdateWorker.h"
-#include "common/ColorThemeWorker.h"
 #include "CutterConfig.h"
 #include "common/CrashHandler.h"
+#include "common/SettingsUpgrade.h"
 
 #include <QJsonObject>
 #include <QJsonArray>
 
-/**
- * @brief Migrate Settings used before Cutter 1.8
- *
- * @return whether any settings have been migrated
- */
-static bool migrateSettingsPre18(QSettings &newSettings)
-{
-    if(newSettings.value("settings_migrated", false).toBool()) {
-        return false;
-    }
-    QSettings oldSettings(QSettings::NativeFormat, QSettings::Scope::UserScope, "Cutter", "Cutter");
-    QStringList allKeys = oldSettings.allKeys();
-    if (allKeys.isEmpty()) {
-        return false;
-    }
-    qInfo() << "Migrating Settings from pre-1.8";
-    for (const QString &key : allKeys) {
-        newSettings.setValue(key, oldSettings.value(key));
-    }
-    oldSettings.clear();
-    QFile settingsFile(oldSettings.fileName());
-    settingsFile.remove();
-    newSettings.setValue("settings_migrated", true);
-    return true;
-}
-
-#define CUTTER_SETTINGS_VERSION_CURRENT 2
-#define CUTTER_SETTINGS_VERSION_KEY     "version"
-
-/*
- * How Settings migrations work:
- *
- * Every time settings are changed in a way that needs migration,
- * CUTTER_SETTINGS_VERSION_CURRENT is raised by 1 and a function migrateSettingsToX
- * is implemented and added to initializeSettings().
- * This function takes care of migrating from EXACTLY version X-1 to X.
- */
-
-static void migrateSettingsTo1(QSettings &settings) {
-    settings.remove("settings_migrated"); // now handled by version
-    settings.remove("updated_custom_themes"); // now handled by theme_version
-}
-
-static void migrateSettingsTo2(QSettings &settings) {
-    QStringList docks = settings.value("docks").toStringList(); // get current list of docks
-    // replace occurences of "PseudocodeWidget" with "DecompilerWidget"
-    settings.setValue("docks", docks.replaceInStrings("PseudocodeWidget", "DecompilerWidget"));
-}
-
-static void initializeSettings()
-{
-    QSettings::setDefaultFormat(QSettings::IniFormat);
-    QSettings settings;
-
-    int settingsVersion = settings.value(CUTTER_SETTINGS_VERSION_KEY, 0).toInt();
-    if(settingsVersion == 0) {
-        migrateSettingsPre18(settings);
-    }
-
-    if(settings.allKeys().length() > 0) {
-        if (settingsVersion > CUTTER_SETTINGS_VERSION_CURRENT) {
-            qWarning() << "Settings have a higher version than current! Skipping migration.";
-        } else if(settingsVersion >= 0) {
-            for (int v = settingsVersion + 1; v <= CUTTER_SETTINGS_VERSION_CURRENT; v++) {
-                qInfo() << "Migrating Settings to Version" << v;
-                switch (v) {
-                case 1:
-                    migrateSettingsTo1(settings); break;
-                case 2:
-                    migrateSettingsTo2(settings);
-                default:
-                    break;
-                }
-            }
-        }
-    }
-    settings.setValue(CUTTER_SETTINGS_VERSION_KEY, CUTTER_SETTINGS_VERSION_CURRENT);
-}
-
-
-#define THEME_VERSION_CURRENT   1
-#define THEME_VERSION_KEY       "theme_version"
-
-static void removeObsoleteOptionsFromCustomThemes() {
-    const QStringList options = Core()->cmdj("ecj").object().keys()
-        << ColorThemeWorker::cutterSpecificOptions;
-    for (auto theme : Core()->cmdList("eco*")) {
-        theme = theme.trimmed();
-        if (!ThemeWorker().isCustomTheme(theme)) {
-            continue;
-        }
-        QJsonObject updatedTheme;
-        auto sch = ThemeWorker().getTheme(theme).object();
-        for (const auto& key : sch.keys()) {
-            if (options.contains(key)) {
-                updatedTheme.insert(key, sch[key]);
-            }
-        }
-        ThemeWorker().save(QJsonDocument(updatedTheme), theme);
-    }
-}
-
-static void migrateThemes()
-{
-    QSettings settings;
-    int themeVersion = settings.value(THEME_VERSION_KEY, 0).toInt();
-    if (themeVersion != THEME_VERSION_CURRENT) {
-        removeObsoleteOptionsFromCustomThemes();
-        settings.setValue(THEME_VERSION_KEY, THEME_VERSION_CURRENT);
-    }
-}
 
 /**
  * @brief Attempt to connect to a parent console and configure outputs.
@@ -183,7 +72,7 @@ int main(int argc, char *argv[])
     QCoreApplication::setOrganizationName("RadareOrg");
     QCoreApplication::setApplicationName("Cutter");
 
-    initializeSettings();
+    Cutter::initializeSettings();
 
     QCoreApplication::setAttribute(Qt::AA_ShareOpenGLContexts); // needed for QtWebEngine inside Plugins
 #ifdef Q_OS_WIN
@@ -195,7 +84,7 @@ int main(int argc, char *argv[])
 
     CutterApplication a(argc, argv);
 
-    migrateThemes();
+    Cutter::migrateThemes();
 
     if (Config()->getAutoUpdateEnabled()) {
 #if CUTTER_UPDATE_WORKER_AVAILABLE

--- a/src/common/Helpers.cpp
+++ b/src/common/Helpers.cpp
@@ -145,14 +145,14 @@ SizePolicyMinMax forceHeight(QWidget *widget, int height)
 
 void SizePolicyMinMax::restoreWidth(QWidget *widget)
 {
-    widget->setSizePolicy(sizePolicy);
+    widget->setSizePolicy(sizePolicy.horizontalPolicy(), widget->sizePolicy().verticalPolicy());
     widget->setMinimumWidth(min);
     widget->setMaximumWidth(max);
 }
 
 void SizePolicyMinMax::restoreHeight(QWidget *widget)
 {
-    widget->setSizePolicy(sizePolicy);
+    widget->setSizePolicy(widget->sizePolicy().horizontalPolicy(), sizePolicy.verticalPolicy());
     widget->setMinimumHeight(min);
     widget->setMaximumHeight(max);
 }

--- a/src/common/SettingsUpgrade.cpp
+++ b/src/common/SettingsUpgrade.cpp
@@ -61,13 +61,17 @@ static void migrateSettingsTo3(QSettings &settings) {
 
     const auto docks = settings.value("docks", QStringList()).toStringList();
     auto unsyncList = settings.value("unsync", QStringList()).toStringList();
+#if QT_VERSION < QT_VERSION_CHECK(5,14,0)
+    QSet<QString> unsyncDocks = unsyncList.toSet();
+#else
     QSet<QString> unsyncDocks(unsyncList.begin(), unsyncList.end());
+#endif
 
     QVariantMap viewProperties;
     for (auto &dock : docks) {
         QVariantMap properties;
         bool synchronized = true;
-        if (unsyncList.contains(dock)) {
+        if (unsyncDocks.contains(dock)) {
             synchronized = false;
         }
         properties.insert("synchronized", synchronized);

--- a/src/common/SettingsUpgrade.cpp
+++ b/src/common/SettingsUpgrade.cpp
@@ -1,0 +1,162 @@
+#include "SettingsUpgrade.h"
+
+#include "common/ColorThemeWorker.h"
+
+/**
+ * @brief Migrate Settings used before Cutter 1.8
+ *
+ * @return whether any settings have been migrated
+ */
+static bool migrateSettingsPre18(QSettings &newSettings)
+{
+    if(newSettings.value("settings_migrated", false).toBool()) {
+        return false;
+    }
+    QSettings oldSettings(QSettings::NativeFormat, QSettings::Scope::UserScope, "Cutter", "Cutter");
+    QStringList allKeys = oldSettings.allKeys();
+    if (allKeys.isEmpty()) {
+        return false;
+    }
+    qInfo() << "Migrating Settings from pre-1.8";
+    for (const QString &key : allKeys) {
+        newSettings.setValue(key, oldSettings.value(key));
+    }
+    oldSettings.clear();
+    QFile settingsFile(oldSettings.fileName());
+    settingsFile.remove();
+    newSettings.setValue("settings_migrated", true);
+    return true;
+}
+
+#define CUTTER_SETTINGS_VERSION_CURRENT 3
+#define CUTTER_SETTINGS_VERSION_KEY     "version"
+
+/*
+ * How Settings migrations work:
+ *
+ * Every time settings are changed in a way that needs migration,
+ * CUTTER_SETTINGS_VERSION_CURRENT is raised by 1 and a function migrateSettingsToX
+ * is implemented and added to initializeSettings().
+ * This function takes care of migrating from EXACTLY version X-1 to X.
+ */
+
+static void migrateSettingsTo1(QSettings &settings) {
+    settings.remove("settings_migrated"); // now handled by version
+    settings.remove("updated_custom_themes"); // now handled by theme_version
+}
+
+static void migrateSettingsTo2(QSettings &settings) {
+    QStringList docks = settings.value("docks").toStringList(); // get current list of docks
+    // replace occurences of "PseudocodeWidget" with "DecompilerWidget"
+    settings.setValue("docks", docks.replaceInStrings("PseudocodeWidget", "DecompilerWidget"));
+}
+
+static void migrateSettingsTo3(QSettings &settings) {
+    auto defaultGeometry = settings.value("geometry").toByteArray();
+    auto defaultState = settings.value("state").toByteArray();
+
+    auto debugGeometry = settings.value("debug.geometry").toByteArray();
+    auto debugState = settings.value("debug.state").toByteArray();
+
+
+    const auto docks = settings.value("docks", QStringList()).toStringList();
+    auto unsyncList = settings.value("unsync", QStringList()).toStringList();
+    QSet<QString> unsyncDocks(unsyncList.begin(), unsyncList.end());
+
+    QVariantMap viewProperties;
+    for (auto &dock : docks) {
+        QVariantMap properties;
+        bool synchronized = true;
+        if (unsyncList.contains(dock)) {
+            synchronized = false;
+        }
+        properties.insert("synchronized", synchronized);
+        viewProperties.insert(dock, properties);
+    }
+
+    settings.beginWriteArray("layouts", 2);
+    settings.setArrayIndex(0);
+    settings.setValue("name", "Default");
+    settings.setValue("geometry", defaultGeometry);
+    settings.setValue("state", defaultState);
+    settings.setValue("docks", viewProperties);
+
+    settings.setArrayIndex(1);
+    settings.setValue("name", "Debug");
+    settings.setValue("geometry", debugGeometry);
+    settings.setValue("state", debugState);
+    settings.setValue("docks", viewProperties);
+
+    settings.endArray();
+
+    settings.remove("geometry");
+    settings.remove("state");
+    settings.remove("debug.geometry");
+    settings.remove("debug.state");
+    settings.remove("docks");
+    settings.remove("unsync");
+}
+
+void Cutter::initializeSettings()
+{
+    QSettings::setDefaultFormat(QSettings::IniFormat);
+    QSettings settings;
+
+    int settingsVersion = settings.value(CUTTER_SETTINGS_VERSION_KEY, 0).toInt();
+    if(settingsVersion == 0) {
+        migrateSettingsPre18(settings);
+    }
+
+    if(settings.allKeys().length() > 0) {
+        if (settingsVersion > CUTTER_SETTINGS_VERSION_CURRENT) {
+            qWarning() << "Settings have a higher version than current! Skipping migration.";
+        } else if(settingsVersion >= 0) {
+            for (int v = settingsVersion + 1; v <= CUTTER_SETTINGS_VERSION_CURRENT; v++) {
+                qInfo() << "Migrating Settings to Version" << v;
+                switch (v) {
+                case 1:
+                    migrateSettingsTo1(settings); break;
+                case 2:
+                    migrateSettingsTo2(settings); break;
+                case 3:
+                    migrateSettingsTo3(settings); break;
+                default:
+                    break;
+                }
+            }
+        }
+    }
+    settings.setValue(CUTTER_SETTINGS_VERSION_KEY, CUTTER_SETTINGS_VERSION_CURRENT);
+}
+
+#define THEME_VERSION_CURRENT   1
+#define THEME_VERSION_KEY       "theme_version"
+
+static void removeObsoleteOptionsFromCustomThemes() {
+    const QStringList options = Core()->cmdj("ecj").object().keys()
+        << ColorThemeWorker::cutterSpecificOptions;
+    for (auto theme : Core()->cmdList("eco*")) {
+        theme = theme.trimmed();
+        if (!ThemeWorker().isCustomTheme(theme)) {
+            continue;
+        }
+        QJsonObject updatedTheme;
+        auto sch = ThemeWorker().getTheme(theme).object();
+        for (const auto& key : sch.keys()) {
+            if (options.contains(key)) {
+                updatedTheme.insert(key, sch[key]);
+            }
+        }
+        ThemeWorker().save(QJsonDocument(updatedTheme), theme);
+    }
+}
+
+void Cutter::migrateThemes()
+{
+    QSettings settings;
+    int themeVersion = settings.value(THEME_VERSION_KEY, 0).toInt();
+    if (themeVersion != THEME_VERSION_CURRENT) {
+        removeObsoleteOptionsFromCustomThemes();
+        settings.setValue(THEME_VERSION_KEY, THEME_VERSION_CURRENT);
+    }
+}

--- a/src/common/SettingsUpgrade.cpp
+++ b/src/common/SettingsUpgrade.cpp
@@ -89,7 +89,9 @@ static void migrateSettingsTo3(QSettings &settings) {
 
     settings.endArray();
 
-    settings.remove("geometry");
+    settings.remove("pos"); // Pos and size already stored within geometry
+    settings.remove("size");
+    // keep geometry but with slightly different usecase
     settings.remove("state");
     settings.remove("debug.geometry");
     settings.remove("debug.state");

--- a/src/common/SettingsUpgrade.h
+++ b/src/common/SettingsUpgrade.h
@@ -1,0 +1,12 @@
+#ifndef COMMON_SETTINGS_UPGRADE_H
+#define COMMON_SETTINGS_UPGRADE_H
+
+#include <QSettings>
+#include <core/Cutter.h>
+
+namespace Cutter {
+    void initializeSettings();
+    void migrateThemes();
+}
+
+#endif // COMMON_SETTINGS_UPGRADE_H

--- a/src/core/CutterCommon.h
+++ b/src/core/CutterCommon.h
@@ -61,5 +61,12 @@ inline QString RHexString(RVA size)
 #define CUTTER_EXPORT Q_DECL_IMPORT
 #endif
 
+
+#if defined(__has_cpp_attribute) && __has_cpp_attribute(deprecated)
+#define CUTTER_DEPRECATED(msg) [[deprecated(msg)]]
+#else
+#define CUTTER_DEPRECATED(msg)
+#endif
+
 #endif // CUTTERCORE_H
 

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -1195,7 +1195,9 @@ void MainWindow::dockOnMainArea(QDockWidget *widget)
     float bestScore = 1;
     // choose best existing area for placing the new widget
     for (auto dock : dockWidgets) {
-        if (dock->isHidden() || dock == widget) {
+        if (dock->isHidden() || dock == widget ||
+            dock->isFloating() || // tabifying onto floating dock using code doesn't work well
+            dock->parentWidget() != this) { // floating group isn't considered floating
             continue;
         }
         float newScore = 0;

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -219,8 +219,7 @@ void MainWindow::initUI()
 
     enableDebugWidgetsMenu(false);
     readSettings();
-    //initCorners();
-    setViewLayout(getViewLayout(LAYOUT_DEFAULT));
+    initCorners();
 }
 
 void MainWindow::initToolBar()
@@ -527,8 +526,10 @@ void MainWindow::finalizeOpen()
 
     // Add fortune message
     core->message("\n" + core->cmdRaw("fo"));
+
     showMaximized();
     Config()->adjustColorThemeDarkness();
+    setViewLayout(getViewLayout(LAYOUT_DEFAULT));
 
     // Set focus to disasm or graph widget
 

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -693,12 +693,12 @@ void MainWindow::paintEvent(QPaintEvent *event)
     QMainWindow::paintEvent(event);
     /*
      * Dirty hack
-     * Just to adjust the width of Functions Widget to fixed size
-     * After everything is drawn, safely make it Preferred size policy
-     * So that user can change the widget size with the mouse
+     * Just to adjust the width of Functions Widget to fixed size.
+     * After everything is drawn, restore the max width limit.
      */
-    if (functionsDock) {
-        functionsDock->changeSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
+    if (functionsDock && functionDockWidthToRestore) {
+        functionsDock->setMaximumWidth(functionDockWidthToRestore);
+        functionDockWidthToRestore = 0;
     }
 }
 
@@ -1145,7 +1145,7 @@ void MainWindow::showZenDocks()
                                             searchDock,
                                             importsDock
                                           };
-    int width = functionsDock->maximumWidth();
+    functionDockWidthToRestore = functionsDock->maximumWidth();
     functionsDock->setMaximumWidth(200);
     for (auto w : dockWidgets) {
         if (zenDocks.contains(w) ||
@@ -1153,7 +1153,6 @@ void MainWindow::showZenDocks()
             w->show();
         }
     }
-    functionsDock->setMaximumWidth(width);
     dashboardDock->raise();
 }
 
@@ -1169,7 +1168,7 @@ void MainWindow::showDebugDocks()
                                               memoryMapDock,
                                               breakpointDock
                                             };
-    int width = functionsDock->maximumWidth();
+    functionDockWidthToRestore = functionsDock->maximumWidth();
     functionsDock->setMaximumWidth(200);
     auto registerWidth = qhelpers::forceWidth(registersDock, std::min(500, this->width() / 4));
     auto registerHeight = qhelpers::forceHeight(registersDock, std::max(100, height() / 2));
@@ -1185,7 +1184,6 @@ void MainWindow::showDebugDocks()
     }
     registerHeight.restoreHeight(registersDock);
     registerWidth.restoreWidth(registersDock);
-    functionsDock->setMaximumWidth(width);
     if (widgetToFocus) {
         widgetToFocus->raise();
     }

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -1273,7 +1273,7 @@ void MainWindow::loadLayouts()
         layout.geometry = settings.value("geometry").toByteArray();
         layout.state = settings.value("state").toByteArray();
 
-        auto docks = settings.value("docks", QHash<QString, QVariant>()).toHash();
+        auto docks = settings.value("docks").toMap();
         for (auto it = docks.begin(), end = docks.end(); it != end; it++) {
             layout.viewProperties.insert(it.key(), it.value().toMap());
         }
@@ -1294,7 +1294,7 @@ void MainWindow::saveLayouts(QSettings &settings)
         auto &layout = it.value();
         settings.setValue("state", layout.state);
         settings.setValue("geometry", layout.geometry);
-        QHash<QString, QVariant> properties;
+        QVariantMap properties;
         for (auto it = layout.viewProperties.begin(), end = layout.viewProperties.end(); it != end; ++it) {
             properties.insert(it.key(), it.value());
         }

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -1641,11 +1641,11 @@ void MainWindow::toggleDebugView()
 {
     MemoryWidgetType memType = getMemoryWidgetTypeToRestore();
     if (Core()->currentlyDebugging) {
-        layouts[LAYOUT_DEFAULT] = getViewLayout(); //TODO:#694 consider if should be saved to file
+        layouts[LAYOUT_DEFAULT] = getViewLayout();
         setViewLayout(getViewLayout(LAYOUT_DEBUG));
         enableDebugWidgetsMenu(true);
     } else {
-        layouts[LAYOUT_DEBUG] = getViewLayout(); //TODO:#694 consider if should be saved to file
+        layouts[LAYOUT_DEBUG] = getViewLayout();
         setViewLayout(getViewLayout(LAYOUT_DEFAULT));
         enableDebugWidgetsMenu(false);
     }

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -723,7 +723,7 @@ void MainWindow::saveSettings()
     settings.setValue("docksGroupedDragging", ui->actionGrouped_dock_dragging->isChecked());
     settings.setValue("geometry", saveGeometry());
 
-    layouts[Core()->isDebugTaskInProgress() ? LAYOUT_DEBUG : LAYOUT_DEFAULT] = getViewLayout();
+    layouts[Core()->currentlyDebugging ? LAYOUT_DEBUG : LAYOUT_DEFAULT] = getViewLayout();
     saveLayouts(settings);
 }
 

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -94,19 +94,18 @@ public:
     void paintEvent(QPaintEvent *event) override;
     void readSettings();
     void saveSettings();
-    void readDebugSettings();
-    void saveDebugSettings();
     void setFilename(const QString &fn);
     void refreshOmniBar(const QStringList &flags);
 
-    void addWidget(QDockWidget *widget);
+    void addWidget(CutterDockWidget *widget);
     void addMemoryDockWidget(MemoryDockWidget *widget);
-    void removeWidget(QDockWidget *widget);
+    void removeWidget(CutterDockWidget *widget);
     void addExtraWidget(CutterDockWidget *extraDock);
     MemoryDockWidget *addNewMemoryWidget(MemoryWidgetType type, RVA address, bool synchronized = true);
 
 
-    void addPluginDockWidget(QDockWidget *dockWidget, QAction *action);
+    //void addPluginDockWidget(QDockWidget *dockWidget, QAction *action); // TODO:[#694] mark as deprecated
+    void addPluginDockWidget(CutterDockWidget *dockWidget);
     enum class MenuType { File, Edit, View, Windows, Debug, Help, Plugins };
     /**
      * @brief Getter for MainWindow's different menus
@@ -115,8 +114,6 @@ public:
      */
     QMenu *getMenuByType(MenuType type);
     void addMenuFileAction(QAction *action);
-
-    void updateDockActionChecked(QAction * action);
 
     QString getFilename() const
     {
@@ -240,10 +237,10 @@ private:
 
     Configuration *configuration;
 
-    QList<QDockWidget *> dockWidgets;
-    QMultiMap<QAction *, QDockWidget *> dockWidgetsOfAction;
+    QList<CutterDockWidget *> dockWidgets;
     DecompilerWidget   *decompilerDock = nullptr;
     OverviewWidget     *overviewDock = nullptr;
+    QAction *actionOverview = nullptr;
     EntrypointWidget   *entrypointDock = nullptr;
     FunctionsWidget    *functionsDock = nullptr;
     ImportsWidget      *importsDock = nullptr;
@@ -265,15 +262,15 @@ private:
     ClassesWidget      *classesDock = nullptr;
     ResourcesWidget    *resourcesDock = nullptr;
     VTablesWidget      *vTablesDock = nullptr;
-    QDockWidget        *stackDock = nullptr;
-    QDockWidget        *threadsDock = nullptr;
-    QDockWidget        *processesDock = nullptr;
-    QDockWidget        *registersDock = nullptr;
-    QDockWidget        *backtraceDock = nullptr;
-    QDockWidget        *memoryMapDock = nullptr;
+    CutterDockWidget        *stackDock = nullptr;
+    CutterDockWidget        *threadsDock = nullptr;
+    CutterDockWidget        *processesDock = nullptr;
+    CutterDockWidget        *registersDock = nullptr;
+    CutterDockWidget        *backtraceDock = nullptr;
+    CutterDockWidget        *memoryMapDock = nullptr;
     NewFileDialog      *newFileDialog = nullptr;
-    QDockWidget        *breakpointDock = nullptr;
-    QDockWidget        *registerRefsDock = nullptr;
+    CutterDockWidget        *breakpointDock = nullptr;
+    CutterDockWidget        *registerRefsDock = nullptr;
 
     QMenu *disassemblyContextMenuExtensions = nullptr;
     QMenu *addressableContextMenuExtensions = nullptr;
@@ -310,7 +307,6 @@ private:
 
     void toggleDockWidget(QDockWidget *dock_widget, bool show);
 
-    void updateDockActionsChecked();
     void setOverviewData();
     bool isOverviewActive();
     /**
@@ -325,7 +321,7 @@ private:
     /**
      * @brief Map from a widget type (e.g. DisassemblyWidget::getWidgetType()) to the respective contructor of the widget
      */
-    QMap<QString, std::function<CutterDockWidget*(MainWindow*, QAction*)>> widgetTypeToConstructorMap;
+    QMap<QString, std::function<CutterDockWidget*(MainWindow*)>> widgetTypeToConstructorMap;
 
     MemoryDockWidget* lastSyncMemoryWidget = nullptr;
     MemoryDockWidget* lastMemoryWidget = nullptr;

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -59,7 +59,7 @@ struct CutterLayout
 {
     QByteArray geometry;
     QByteArray state;
-    QHash<QString, QVariantMap> viewProperties;
+    QMap<QString, QVariantMap> viewProperties;
 };
 
 class MainWindow : public QMainWindow

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -330,6 +330,7 @@ private:
 
     MemoryDockWidget* lastSyncMemoryWidget = nullptr;
     MemoryDockWidget* lastMemoryWidget = nullptr;
+    int functionDockWidthToRestore = 0;
 };
 
 #endif // MAINWINDOW_H

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -103,8 +103,8 @@ public:
     void addExtraWidget(CutterDockWidget *extraDock);
     MemoryDockWidget *addNewMemoryWidget(MemoryWidgetType type, RVA address, bool synchronized = true);
 
-
-    //void addPluginDockWidget(QDockWidget *dockWidget, QAction *action); // TODO:[#694] mark as deprecated
+    CUTTER_DEPRECATED("Action will be ignored. Use addPluginDockWidget(CutterDockWidget*) instead.")
+    void addPluginDockWidget(CutterDockWidget *dockWidget, QAction *) { addPluginDockWidget(dockWidget); }
     void addPluginDockWidget(CutterDockWidget *dockWidget);
     enum class MenuType { File, Edit, View, Windows, Debug, Help, Plugins };
     /**

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -238,6 +238,7 @@ private:
     Configuration *configuration;
 
     QList<CutterDockWidget *> dockWidgets;
+    QList<CutterDockWidget *> pluginDocks;
     DecompilerWidget   *decompilerDock = nullptr;
     OverviewWidget     *overviewDock = nullptr;
     QAction *actionOverview = nullptr;
@@ -295,6 +296,11 @@ private:
     void restoreDocks();
     void showZenDocks();
     void showDebugDocks();
+    /**
+     * @brief Try to guess which is the "main" section of layout and dock there.
+     * @param widget that needs to be docked
+     */
+    void dockOnMainArea(QDockWidget *widget);
     void enableDebugWidgetsMenu(bool enable);
     /**
      * @brief Fill menu with seek history entries.
@@ -305,8 +311,6 @@ private:
     void updateLayoutsMenu();
     void saveNamedLayout();
 
-    void toggleDockWidget(QDockWidget *dock_widget, bool show);
-
     void setOverviewData();
     bool isOverviewActive();
     /**
@@ -315,6 +319,7 @@ private:
      * @return true for debug specific widgets, false for all other including common dock widgets.
      */
     bool isDebugWidget(QDockWidget *dock) const;
+    bool isExtraMemoryWidget(QDockWidget *dock) const;
 
     MemoryWidgetType getMemoryWidgetTypeToRestore();
 

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -283,7 +283,6 @@ private:
     void initUI();
     void initToolBar();
     void initDocks();
-    void initCorners();
     void initBackForwardMenu();
     void displayInitialOptionsDialog(const InitialOptions &options = InitialOptions(), bool skipOptionsDialog = false);
 

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -55,6 +55,13 @@ namespace Ui {
 class MainWindow;
 }
 
+struct CutterLayout
+{
+    QByteArray geometry;
+    QByteArray state;
+    QHash<QString, QVariantMap> viewProperties;
+};
+
 class MainWindow : public QMainWindow
 {
     Q_OBJECT
@@ -85,7 +92,7 @@ public:
 
     void closeEvent(QCloseEvent *event) override;
     void paintEvent(QPaintEvent *event) override;
-    void readSettingsOrDefault();
+    void readSettings();
     void saveSettings();
     void readDebugSettings();
     void saveDebugSettings();
@@ -250,7 +257,6 @@ private:
     StringsWidget      *stringsDock = nullptr;
     FlagsWidget        *flagsDock = nullptr;
     Dashboard          *dashboardDock = nullptr;
-    QLineEdit          *gotoEntry = nullptr;
     SdbWidget          *sdbDock = nullptr;
     SectionsWidget     *sectionsDock = nullptr;
     SegmentsWidget     *segmentsDock = nullptr;
@@ -259,9 +265,6 @@ private:
     ClassesWidget      *classesDock = nullptr;
     ResourcesWidget    *resourcesDock = nullptr;
     VTablesWidget      *vTablesDock = nullptr;
-    DisassemblerGraphView *graphView = nullptr;
-    QDockWidget        *asmDock = nullptr;
-    QDockWidget        *calcDock = nullptr;
     QDockWidget        *stackDock = nullptr;
     QDockWidget        *threadsDock = nullptr;
     QDockWidget        *processesDock = nullptr;
@@ -275,22 +278,25 @@ private:
     QMenu *disassemblyContextMenuExtensions = nullptr;
     QMenu *addressableContextMenuExtensions = nullptr;
 
+    QMap<QString, CutterLayout> layouts;
+
     void initUI();
     void initToolBar();
     void initDocks();
-    void initLayout();
     void initCorners();
     void initBackForwardMenu();
     void displayInitialOptionsDialog(const InitialOptions &options = InitialOptions(), bool skipOptionsDialog = false);
 
-    void resetToDefaultLayout();
-    void resetToDebugLayout();
-    void restoreDebugLayout();
+    CutterLayout getViewLayout();
+    CutterLayout getViewLayout(const QString &name);
+
+    void setViewLayout(const CutterLayout &layout);
+    void loadLayouts();
+    void saveLayouts(QSettings &settings);
+
 
     void updateMemberPointers();
-    void resetDockWidgetList();
     void restoreDocks();
-    void hideAllDocks();
     void showZenDocks();
     void showDebugDocks();
     void enableDebugWidgetsMenu(bool enable);
@@ -300,6 +306,8 @@ private:
      * @param redo set to false for undo history, true for redo.
      */
     void updateHistoryMenu(QMenu *menu, bool redo = false);
+    void updateLayoutsMenu();
+    void saveNamedLayout();
 
     void toggleDockWidget(QDockWidget *dock_widget, bool show);
 

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -291,7 +291,7 @@ private:
     CutterLayout getViewLayout(const QString &name);
 
     void setViewLayout(const CutterLayout &layout);
-    void loadLayouts();
+    void loadLayouts(QSettings &settings);
     void saveLayouts(QSettings &settings);
 
 

--- a/src/core/MainWindow.ui
+++ b/src/core/MainWindow.ui
@@ -102,6 +102,13 @@
     <addaction name="actionGrouped_dock_dragging"/>
     <addaction name="separator"/>
     <addaction name="menuZoom"/>
+    <addaction name="actionSaveLayout"/>
+    <widget class="QMenu" name="menuLayouts">
+     <property name="title">
+      <string>Layouts</string>
+     </property>
+    </widget>
+    <addaction name="menuLayouts"/>
    </widget>
    <widget class="QMenu" name="menuHelp">
     <property name="title">
@@ -1124,6 +1131,11 @@
   <action name="actionCommitChanges">
    <property name="text">
     <string>Commit changes</string>
+   </property>
+  </action>
+  <action name="actionSaveLayout">
+   <property name="text">
+    <string>Save layout</string>
    </property>
   </action>
  </widget>

--- a/src/core/MainWindow.ui
+++ b/src/core/MainWindow.ui
@@ -140,55 +140,20 @@
      <property name="title">
       <string>Info...</string>
      </property>
-     <addaction name="actionClasses"/>
-     <addaction name="actionEntrypoints"/>
-     <addaction name="actionExports"/>
-     <addaction name="actionFlags"/>
-     <addaction name="actionHeaders"/>
-     <addaction name="actionImports"/>
-     <addaction name="actionRelocs"/>
-     <addaction name="actionResources"/>
-     <addaction name="actionSDBBrowser"/>
-     <addaction name="actionSections"/>
-     <addaction name="actionSegments"/>
-     <addaction name="actionSymbols"/>
-     <addaction name="actionVTables"/>
-     <addaction name="actionZignatures"/>
     </widget>
     <widget class="QMenu" name="menuAddDebugWidgets">
      <property name="title">
       <string>Debug...</string>
      </property>
-     <addaction name="actionBacktrace"/>
-     <addaction name="actionBreakpoint"/>
-     <addaction name="actionThreads"/>
-     <addaction name="actionProcesses"/>
-     <addaction name="actionMemoryMap"/>
-     <addaction name="actionRegisters"/>
-     <addaction name="actionRegisterRefs"/>
-     <addaction name="actionStack"/>
     </widget>
-    <addaction name="actionDashboard"/>
-    <addaction name="separator"/>
-    <addaction name="actionFunctions"/>
-    <addaction name="actionDecompiler"/>
-    <addaction name="actionOverview"/>
-    <addaction name="separator"/>
-    <addaction name="actionSearch"/>
-    <addaction name="actionStrings"/>
-    <addaction name="actionTypes"/>
-    <addaction name="separator"/>
     <addaction name="actionExtraDisassembly"/>
     <addaction name="actionExtraGraph"/>
     <addaction name="actionExtraHexdump"/>
     <addaction name="separator"/>
     <addaction name="menuAddInfoWidgets"/>
     <addaction name="menuAddDebugWidgets"/>
-    <addaction name="separator"/>
-    <addaction name="actionComments"/>
-    <addaction name="actionConsole"/>
-    <addaction name="separator"/>
     <addaction name="menuPlugins"/>
+    <addaction name="separator"/>
    </widget>
    <widget class="QMenu" name="menuDebug">
     <property name="title">
@@ -406,105 +371,6 @@
     <string>Lock/Unlock</string>
    </property>
   </action>
-  <action name="actionStrings">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Strings</string>
-   </property>
-   <property name="toolTip">
-    <string>Show/Hide Strings panel</string>
-   </property>
-  </action>
-  <action name="actionSections">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Sections</string>
-   </property>
-   <property name="toolTip">
-    <string>Show/Hide Sections panel</string>
-   </property>
-  </action>
-  <action name="actionSegments">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Segments</string>
-   </property>
-   <property name="toolTip">
-    <string>Show/Hide Segments panel</string>
-   </property>
-  </action>
-  <action name="actionFunctions">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Functions</string>
-   </property>
-   <property name="toolTip">
-    <string>Show/Hide Functions panel</string>
-   </property>
-  </action>
-  <action name="actionImports">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Imports</string>
-   </property>
-   <property name="toolTip">
-    <string>Show/Hide Imports panel</string>
-   </property>
-  </action>
-  <action name="actionSymbols">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Symbols</string>
-   </property>
-   <property name="toolTip">
-    <string>Show/Hide Symbols panel</string>
-   </property>
-  </action>
-  <action name="actionRelocs">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Relocs</string>
-   </property>
-   <property name="toolTip">
-    <string>Show/Hide Relocs panel</string>
-   </property>
-  </action>
-  <action name="actionFlags">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Flags</string>
-   </property>
-   <property name="toolTip">
-    <string>Show/Hide Flags panel</string>
-   </property>
-  </action>
-  <action name="actionMem">
-   <property name="checkable">
-    <bool>false</bool>
-   </property>
-   <property name="text">
-    <string>Memory</string>
-   </property>
-   <property name="toolTip">
-    <string>Show/Hide Memory panel</string>
-   </property>
-  </action>
   <action name="actionTheme">
    <property name="checkable">
     <bool>false</bool>
@@ -542,17 +408,6 @@
    </property>
    <property name="text">
     <string>Refresh</string>
-   </property>
-  </action>
-  <action name="actionComments">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Comments</string>
-   </property>
-   <property name="toolTip">
-    <string>Show/Hide comments</string>
    </property>
   </action>
   <action name="actionTabs_on_Top">
@@ -783,28 +638,9 @@
     <string>Show/Hide bottom pannel</string>
    </property>
   </action>
-  <action name="actionSDBBrowser">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>SDB Browser</string>
-   </property>
-  </action>
   <action name="actionRun_Script">
    <property name="text">
     <string>Run Script</string>
-   </property>
-  </action>
-  <action name="actionDashboard">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Dashboard</string>
-   </property>
-   <property name="toolTip">
-    <string>Show/Hide Dashboard panel</string>
    </property>
   </action>
   <action name="actionReset_settings">
@@ -858,14 +694,6 @@
     <string>Show pseudocode rather than assembly</string>
    </property>
   </action>
-  <action name="actionEntrypoints">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Entry Points</string>
-   </property>
-  </action>
   <action name="actionDisplay_Offsets">
    <property name="checkable">
     <bool>true</bool>
@@ -895,102 +723,6 @@
     <string>Graph</string>
    </property>
   </action>
-  <action name="actionOverview">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Graph Overview</string>
-   </property>
-  </action>
-  <action name="actionDecompiler">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Decompiler</string>
-   </property>
-  </action>
-  <action name="actionConsole">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Console</string>
-   </property>
-  </action>
-  <action name="actionStack">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Stack</string>
-   </property>
-  </action>
-  <action name="actionRegisters">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Registers</string>
-   </property>
-  </action>
-  <action name="actionBacktrace">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Backtrace</string>
-   </property>
-  </action>
-  <action name="actionThreads">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Threads</string>
-   </property>
-  </action>
-  <action name="actionProcesses">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Processes</string>
-   </property>
-  </action>
-  <action name="actionMemoryMap">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Memory map</string>
-   </property>
-  </action>
-  <action name="actionBreakpoint">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Breakpoints</string>
-   </property>
-  </action>
-  <action name="actionRegisterRefs">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Register References</string>
-   </property>
-  </action>
-  <action name="actionClasses">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Classes</string>
-   </property>
-  </action>
   <action name="actionImportPDB">
    <property name="text">
     <string>Import PDB</string>
@@ -999,69 +731,6 @@
   <action name="actionAnalyze">
    <property name="text">
     <string>Analyze</string>
-   </property>
-  </action>
-  <action name="actionResources">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Resources</string>
-   </property>
-  </action>
-  <action name="actionVTables">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>VTables</string>
-   </property>
-   <property name="toolTip">
-    <string>Show/Hide VTables panel</string>
-   </property>
-  </action>
-  <action name="actionTypes">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Types</string>
-   </property>
-   <property name="toolTip">
-    <string>Show/Hide Types panel</string>
-   </property>
-  </action>
-  <action name="actionSearch">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Search</string>
-   </property>
-   <property name="toolTip">
-    <string>Show/Hide Search panel</string>
-   </property>
-  </action>
-  <action name="actionHeaders">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Headers</string>
-   </property>
-   <property name="toolTip">
-    <string>Show/Hide Headers panel</string>
-   </property>
-  </action>
-  <action name="actionZignatures">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Zignatures</string>
-   </property>
-   <property name="toolTip">
-    <string>Show/Hide Zignatures panel</string>
    </property>
   </action>
   <action name="actionExport_as_code">

--- a/src/core/MainWindow.ui
+++ b/src/core/MainWindow.ui
@@ -203,10 +203,7 @@
   </widget>
   <action name="actionDefault">
    <property name="text">
-    <string>Reset Layout</string>
-   </property>
-   <property name="toolTip">
-    <string>Reset layout</string>
+    <string>Reset to default layout</string>
    </property>
   </action>
   <action name="actionZen">

--- a/src/plugins/sample-cpp/CutterSamplePlugin.cpp
+++ b/src/plugins/sample-cpp/CutterSamplePlugin.cpp
@@ -14,14 +14,12 @@ void CutterSamplePlugin::setupPlugin()
 
 void CutterSamplePlugin::setupInterface(MainWindow *main)
 {
-    QAction *action = new QAction("Sample C++ Plugin", main);
-    action->setCheckable(true);
-    CutterSamplePluginWidget *widget = new CutterSamplePluginWidget(main, action);
-    main->addPluginDockWidget(widget, action);
+    CutterSamplePluginWidget *widget = new CutterSamplePluginWidget(main);
+    main->addPluginDockWidget(widget);
 }
 
-CutterSamplePluginWidget::CutterSamplePluginWidget(MainWindow *main, QAction *action) :
-    CutterDockWidget(main, action)
+CutterSamplePluginWidget::CutterSamplePluginWidget(MainWindow *main) :
+    CutterDockWidget(main)
 {
     this->setObjectName("CutterSamplePluginWidget");
     this->setWindowTitle("Sample C++ Plugin");

--- a/src/plugins/sample-python/sample_python.py
+++ b/src/plugins/sample-python/sample_python.py
@@ -2,7 +2,7 @@
 import cutter
 
 from PySide2.QtCore import Qt
-from PySide2.QtWidgets import QAction, QVBoxLayout, QLabel, QWidget, QSizePolicy, QPushButton
+from PySide2.QtWidgets import QVBoxLayout, QLabel, QWidget, QSizePolicy, QPushButton
 
 
 class FortuneWidget(cutter.CutterDockWidget):

--- a/src/plugins/sample-python/sample_python.py
+++ b/src/plugins/sample-python/sample_python.py
@@ -6,8 +6,8 @@ from PySide2.QtWidgets import QAction, QVBoxLayout, QLabel, QWidget, QSizePolicy
 
 
 class FortuneWidget(cutter.CutterDockWidget):
-    def __init__(self, parent, action):
-        super(FortuneWidget, self).__init__(parent, action)
+    def __init__(self, parent):
+        super(FortuneWidget, self).__init__(parent)
         self.setObjectName("FancyDockWidgetFromCoolPlugin")
         self.setWindowTitle("Sample Python Plugin")
 
@@ -62,10 +62,8 @@ class CutterSamplePlugin(cutter.CutterPlugin):
 
     def setupInterface(self, main):
         # Dock widget
-        action = QAction("Sample Python Plugin", main)
-        action.setCheckable(True)
-        widget = FortuneWidget(main, action)
-        main.addPluginDockWidget(widget, action)
+        widget = FortuneWidget(main)
+        main.addPluginDockWidget(widget)
 
         # Dissassembly context menu
         menu = main.getContextMenuExtensions(cutter.MainWindow.ContextMenuType.Disassembly)

--- a/src/widgets/BacktraceWidget.cpp
+++ b/src/widgets/BacktraceWidget.cpp
@@ -5,8 +5,8 @@
 
 #include "core/MainWindow.h"
 
-BacktraceWidget::BacktraceWidget(MainWindow *main, QAction *action) :
-    CutterDockWidget(main, action),
+BacktraceWidget::BacktraceWidget(MainWindow *main) :
+    CutterDockWidget(main),
     ui(new Ui::BacktraceWidget)
 {
     ui->setupUi(this);

--- a/src/widgets/BacktraceWidget.h
+++ b/src/widgets/BacktraceWidget.h
@@ -19,7 +19,7 @@ class BacktraceWidget : public CutterDockWidget
     Q_OBJECT
 
 public:
-    explicit BacktraceWidget(MainWindow *main, QAction *action = nullptr);
+    explicit BacktraceWidget(MainWindow *main);
     ~BacktraceWidget();
 
 private slots:

--- a/src/widgets/BreakpointWidget.cpp
+++ b/src/widgets/BreakpointWidget.cpp
@@ -173,8 +173,8 @@ BreakpointProxyModel::BreakpointProxyModel(BreakpointModel *sourceModel, QObject
     this->setSortRole(Qt::EditRole);
 }
 
-BreakpointWidget::BreakpointWidget(MainWindow *main, QAction *action) :
-    CutterDockWidget(main, action),
+BreakpointWidget::BreakpointWidget(MainWindow *main) :
+    CutterDockWidget(main),
     ui(new Ui::BreakpointWidget)
 {
     ui->setupUi(this);

--- a/src/widgets/BreakpointWidget.h
+++ b/src/widgets/BreakpointWidget.h
@@ -69,7 +69,7 @@ class BreakpointWidget : public CutterDockWidget
     Q_OBJECT
 
 public:
-    explicit BreakpointWidget(MainWindow *main, QAction *action = nullptr);
+    explicit BreakpointWidget(MainWindow *main);
     ~BreakpointWidget();
 
 private slots:

--- a/src/widgets/ClassesWidget.cpp
+++ b/src/widgets/ClassesWidget.cpp
@@ -575,8 +575,8 @@ bool ClassesSortFilterProxyModel::hasChildren(const QModelIndex &parent) const
 
 
 
-ClassesWidget::ClassesWidget(MainWindow *main, QAction *action) :
-    CutterDockWidget(main, action),
+ClassesWidget::ClassesWidget(MainWindow *main) :
+    CutterDockWidget(main),
     ui(new Ui::ClassesWidget)
 {
     ui->setupUi(this);

--- a/src/widgets/ClassesWidget.h
+++ b/src/widgets/ClassesWidget.h
@@ -175,7 +175,7 @@ class ClassesWidget : public CutterDockWidget
     Q_OBJECT
 
 public:
-    explicit ClassesWidget(MainWindow *main, QAction *action = nullptr);
+    explicit ClassesWidget(MainWindow *main);
     ~ClassesWidget();
 
 private slots:

--- a/src/widgets/CommentsWidget.cpp
+++ b/src/widgets/CommentsWidget.cpp
@@ -229,8 +229,8 @@ bool CommentsProxyModel::lessThan(const QModelIndex &left, const QModelIndex &ri
     return false;
 }
 
-CommentsWidget::CommentsWidget(MainWindow *main, QAction *action) :
-    ListDockWidget(main, action),
+CommentsWidget::CommentsWidget(MainWindow *main) :
+    ListDockWidget(main),
     actionHorizontal(tr("Horizontal"), this),
     actionVertical(tr("Vertical"), this)
 {

--- a/src/widgets/CommentsWidget.h
+++ b/src/widgets/CommentsWidget.h
@@ -75,7 +75,7 @@ class CommentsWidget : public ListDockWidget
     Q_OBJECT
 
 public:
-    explicit CommentsWidget(MainWindow *main, QAction *action = nullptr);
+    explicit CommentsWidget(MainWindow *main);
     ~CommentsWidget() override;
 
 private slots:

--- a/src/widgets/ConsoleWidget.cpp
+++ b/src/widgets/ConsoleWidget.cpp
@@ -37,8 +37,8 @@ static const int invalidHistoryPos = -1;
 
 static const char *consoleWrapSettingsKey = "console.wrap";
 
-ConsoleWidget::ConsoleWidget(MainWindow *main, QAction *action) :
-    CutterDockWidget(main, action),
+ConsoleWidget::ConsoleWidget(MainWindow *main) :
+    CutterDockWidget(main),
     ui(new Ui::ConsoleWidget),
     debugOutputEnabled(true),
     maxHistoryEntries(100),

--- a/src/widgets/ConsoleWidget.h
+++ b/src/widgets/ConsoleWidget.h
@@ -24,7 +24,7 @@ class ConsoleWidget : public CutterDockWidget
     Q_OBJECT
 
 public:
-    explicit ConsoleWidget(MainWindow *main, QAction *action = nullptr);
+    explicit ConsoleWidget(MainWindow *main);
 
     ~ConsoleWidget();
 

--- a/src/widgets/CutterDockWidget.cpp
+++ b/src/widgets/CutterDockWidget.cpp
@@ -85,6 +85,10 @@ void CutterDockWidget::closeEvent(QCloseEvent *event)
         if (mainWindow) {
             mainWindow->removeWidget(this);
         }
+
+        // remove parent, otherwise dock layout may still decide to use this widget which is about to be deleted
+        setParent(nullptr);
+
         deleteLater();
     }
 

--- a/src/widgets/CutterDockWidget.cpp
+++ b/src/widgets/CutterDockWidget.cpp
@@ -1,26 +1,17 @@
 #include "CutterDockWidget.h"
 #include "core/MainWindow.h"
 
-#include <QAction>
 #include <QEvent>
 #include <QtWidgets/QShortcut>
 
-CutterDockWidget::CutterDockWidget(MainWindow *parent, QAction *action) :
+CutterDockWidget::CutterDockWidget(MainWindow *parent) :
     QDockWidget(parent),
-    mainWindow(parent),
-    action(action)
+    mainWindow(parent)
 {
-    if (action) {
-        addAction(action);
-        connect(action, &QAction::triggered, this, &CutterDockWidget::toggleDockWidget);
-    }
-    if (parent) {
-        parent->addWidget(this);
-    }
-
     // Install event filter to catch redraw widgets when needed
     installEventFilter(this);
     updateIsVisibleToUser();
+    connect(toggleViewAction(), &QAction::triggered, this, &QWidget::raise);
 }
 
 CutterDockWidget::~CutterDockWidget() = default;
@@ -77,9 +68,6 @@ void CutterDockWidget::updateIsVisibleToUser()
 
 void CutterDockWidget::closeEvent(QCloseEvent *event)
 {
-    if (action) {
-        this->action->setChecked(false);
-    }
     QDockWidget::closeEvent(event);
     if (isTransient) {
         if (mainWindow) {
@@ -93,11 +81,6 @@ void CutterDockWidget::closeEvent(QCloseEvent *event)
     }
 
     emit closed();
-}
-
-QAction *CutterDockWidget::getBoundAction() const
-{
-    return action;
 }
 
 QString CutterDockWidget::getDockNumber()

--- a/src/widgets/CutterDockWidget.cpp
+++ b/src/widgets/CutterDockWidget.cpp
@@ -4,6 +4,11 @@
 #include <QEvent>
 #include <QtWidgets/QShortcut>
 
+CutterDockWidget::CutterDockWidget(MainWindow *parent, QAction *)
+    : CutterDockWidget(parent)
+{
+}
+
 CutterDockWidget::CutterDockWidget(MainWindow *parent) :
     QDockWidget(parent),
     mainWindow(parent)

--- a/src/widgets/CutterDockWidget.cpp
+++ b/src/widgets/CutterDockWidget.cpp
@@ -38,6 +38,15 @@ bool CutterDockWidget::eventFilter(QObject *object, QEvent *event)
     return QDockWidget::eventFilter(object, event);
 }
 
+QVariantMap CutterDockWidget::serializeViewProprties()
+{
+    return {};
+}
+
+void CutterDockWidget::deserializeViewProperties(const QVariantMap &)
+{
+}
+
 void CutterDockWidget::toggleDockWidget(bool show)
 {
     if (!show) {

--- a/src/widgets/CutterDockWidget.h
+++ b/src/widgets/CutterDockWidget.h
@@ -12,7 +12,8 @@ class CutterDockWidget : public QDockWidget
     Q_OBJECT
 
 public:
-    explicit CutterDockWidget(MainWindow *parent, QAction *action = nullptr);
+    //CutterDockWidget(MainWindow *parent, QAction *); // TODO:[#694] mark as deprecated
+    explicit CutterDockWidget(MainWindow *parent);
     ~CutterDockWidget() override;
     bool eventFilter(QObject *object, QEvent *event) override;
     bool isVisibleToUser()      { return isVisibleToUserCurrent; }
@@ -56,8 +57,6 @@ public:
     }
     virtual QVariantMap serializeViewProprties();
     virtual void deserializeViewProperties(const QVariantMap &properties);
-
-    bool isTransient = false; //TODO:#694 hack, move this back as private
 signals:
     void becameVisibleToUser();
     void closed();
@@ -69,14 +68,12 @@ protected:
     virtual QWidget* widgetToFocusOnRaise();
 
     void closeEvent(QCloseEvent *event) override;
-    QAction *getBoundAction() const;
     QString getDockNumber();
 
     MainWindow *mainWindow;
 
 private:
-    QAction *action;
-
+    bool isTransient = false;
 
     bool isVisibleToUserCurrent = false;
     void updateIsVisibleToUser();

--- a/src/widgets/CutterDockWidget.h
+++ b/src/widgets/CutterDockWidget.h
@@ -1,9 +1,10 @@
 #ifndef CUTTERWIDGET_H
 #define CUTTERWIDGET_H
 
-#include <QDockWidget>
-
+#include "CutterCommon.h"
 #include "common/RefreshDeferrer.h"
+
+#include <QDockWidget>
 
 class MainWindow;
 
@@ -12,7 +13,9 @@ class CutterDockWidget : public QDockWidget
     Q_OBJECT
 
 public:
-    //CutterDockWidget(MainWindow *parent, QAction *); // TODO:[#694] mark as deprecated
+    CUTTER_DEPRECATED("Action will be ignored. Use CutterDockWidget(MainWindow*) instead.")
+    CutterDockWidget(MainWindow *parent, QAction *action);
+
     explicit CutterDockWidget(MainWindow *parent);
     ~CutterDockWidget() override;
     bool eventFilter(QObject *object, QEvent *event) override;

--- a/src/widgets/CutterDockWidget.h
+++ b/src/widgets/CutterDockWidget.h
@@ -54,7 +54,10 @@ public:
         });
         return deferrer;
     }
+    virtual QVariantMap serializeViewProprties();
+    virtual void deserializeViewProperties(const QVariantMap &properties);
 
+    bool isTransient = false; //TODO:#694 hack, move this back as private
 signals:
     void becameVisibleToUser();
     void closed();
@@ -74,7 +77,6 @@ protected:
 private:
     QAction *action;
 
-    bool isTransient = false;
 
     bool isVisibleToUserCurrent = false;
     void updateIsVisibleToUser();

--- a/src/widgets/CutterDockWidget.h
+++ b/src/widgets/CutterDockWidget.h
@@ -58,7 +58,33 @@ public:
         });
         return deferrer;
     }
+    /**
+     * @brief Serialize dock properties for saving as part of layout.
+     *
+     * Override this function for saving dock specific view properties. Use
+     * in situations where it makes sense to have different properties for
+     * multiple instances of widget. Don't use for options that are more suitable
+     * as global settings and should be applied equally to all widgets or all
+     * widgets of this kind.
+     *
+     * Keep synchrononized with deserializeViewProperties. When modifying add
+     * project upgrade step in SettingsUpgrade.cpp if necessary.
+     *
+     * @return Dictionary of current dock properties.
+     * @see CutterDockWidget#deserializeViewProperties
+     */
     virtual QVariantMap serializeViewProprties();
+    /**
+     * @brief Deserialization half of serialize view properties.
+     *
+     * When a property is not specified in property map dock should reset it
+     * to default value instead of leaving it umodified. Empty map should reset
+     * all properties controlled by serializeViewProprties/deserializeViewProperties
+     * mechanism.
+     *
+     * @param properties to modify for current widget
+     * @see CutterDockWidget#serializeViewProprties
+     */
     virtual void deserializeViewProperties(const QVariantMap &properties);
 signals:
     void becameVisibleToUser();

--- a/src/widgets/Dashboard.cpp
+++ b/src/widgets/Dashboard.cpp
@@ -21,8 +21,8 @@
 #include <QDialog>
 #include <QTreeWidget>
 
-Dashboard::Dashboard(MainWindow *main, QAction *action) :
-    CutterDockWidget(main, action),
+Dashboard::Dashboard(MainWindow *main) :
+    CutterDockWidget(main),
     ui(new Ui::Dashboard)
 {
     ui->setupUi(this);

--- a/src/widgets/Dashboard.h
+++ b/src/widgets/Dashboard.h
@@ -21,7 +21,7 @@ class Dashboard : public CutterDockWidget
     Q_OBJECT
 
 public:
-    explicit Dashboard(MainWindow *main, QAction *action = nullptr);
+    explicit Dashboard(MainWindow *main);
     ~Dashboard();
 
 private slots:

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -15,8 +15,8 @@
 #include <QObject>
 #include <QTextBlockUserData>
 
-DecompilerWidget::DecompilerWidget(MainWindow *main, QAction *action) :
-    MemoryDockWidget(MemoryWidgetType::Decompiler, main, action),
+DecompilerWidget::DecompilerWidget(MainWindow *main) :
+    MemoryDockWidget(MemoryWidgetType::Decompiler, main),
     mCtxMenu(new DisassemblyContextMenu(this, main)),
     ui(new Ui::DecompilerWidget)
 {

--- a/src/widgets/DecompilerWidget.h
+++ b/src/widgets/DecompilerWidget.h
@@ -25,7 +25,7 @@ protected:
     DisassemblyContextMenu *mCtxMenu;
 
 public:
-    explicit DecompilerWidget(MainWindow *main, QAction *action = nullptr);
+    explicit DecompilerWidget(MainWindow *main);
     ~DecompilerWidget();
 public slots:
     void showDisasContextMenu(const QPoint &pt);

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -38,8 +38,8 @@ static DisassemblyTextBlockUserData *getUserData(const QTextBlock &block)
     return static_cast<DisassemblyTextBlockUserData *>(userData);
 }
 
-DisassemblyWidget::DisassemblyWidget(MainWindow *main, QAction *action)
-    :   MemoryDockWidget(MemoryWidgetType::Disassembly, main, action)
+DisassemblyWidget::DisassemblyWidget(MainWindow *main)
+    :   MemoryDockWidget(MemoryWidgetType::Disassembly, main)
     ,   mCtxMenu(new DisassemblyContextMenu(this, main))
     ,   mDisasScrollArea(new DisassemblyScrollArea(this))
     ,   mDisasTextEdit(new DisassemblyTextEdit(this))

--- a/src/widgets/DisassemblyWidget.h
+++ b/src/widgets/DisassemblyWidget.h
@@ -22,7 +22,7 @@ class DisassemblyWidget : public MemoryDockWidget
 {
     Q_OBJECT
 public:
-    explicit DisassemblyWidget(MainWindow *main, QAction *action = nullptr);
+    explicit DisassemblyWidget(MainWindow *main);
     QWidget *getTextWidget();
 
     static QString getWidgetType();

--- a/src/widgets/EntrypointWidget.cpp
+++ b/src/widgets/EntrypointWidget.cpp
@@ -12,8 +12,8 @@
  * Entrypoint Widget
  */
 
-EntrypointWidget::EntrypointWidget(MainWindow *main, QAction *action) :
-    CutterDockWidget(main, action),
+EntrypointWidget::EntrypointWidget(MainWindow *main) :
+    CutterDockWidget(main),
     ui(new Ui::EntrypointWidget)
 {
     ui->setupUi(this);

--- a/src/widgets/EntrypointWidget.h
+++ b/src/widgets/EntrypointWidget.h
@@ -19,7 +19,7 @@ class EntrypointWidget : public CutterDockWidget
     Q_OBJECT
 
 public:
-    explicit EntrypointWidget(MainWindow *main, QAction *action = nullptr);
+    explicit EntrypointWidget(MainWindow *main);
     ~EntrypointWidget();
 
 private slots:

--- a/src/widgets/ExportsWidget.cpp
+++ b/src/widgets/ExportsWidget.cpp
@@ -125,8 +125,8 @@ bool ExportsProxyModel::lessThan(const QModelIndex &left, const QModelIndex &rig
     return leftExp.vaddr < rightExp.vaddr;
 }
 
-ExportsWidget::ExportsWidget(MainWindow *main, QAction *action) :
-    ListDockWidget(main, action)
+ExportsWidget::ExportsWidget(MainWindow *main) :
+    ListDockWidget(main)
 {
     setWindowTitle(tr("Exports"));
     setObjectName("ExportsWidget");
@@ -138,8 +138,7 @@ ExportsWidget::ExportsWidget(MainWindow *main, QAction *action) :
 
     QShortcut *toggle_shortcut = new QShortcut(widgetShortcuts["ExportsWidget"], main);
     connect(toggle_shortcut, &QShortcut::activated, this, [=] (){ 
-            toggleDockWidget(true); 
-            main->updateDockActionChecked(action);
+            toggleDockWidget(true);
             } );
 
     connect(Core(), &CutterCore::codeRebased, this, &ExportsWidget::refreshExports);

--- a/src/widgets/ExportsWidget.h
+++ b/src/widgets/ExportsWidget.h
@@ -60,7 +60,7 @@ class ExportsWidget : public ListDockWidget
     Q_OBJECT
 
 public:
-    explicit ExportsWidget(MainWindow *main, QAction *action = nullptr);
+    explicit ExportsWidget(MainWindow *main);
     ~ExportsWidget();
 
 private slots:

--- a/src/widgets/FlagsWidget.cpp
+++ b/src/widgets/FlagsWidget.cpp
@@ -137,8 +137,8 @@ bool FlagsSortFilterProxyModel::lessThan(const QModelIndex &left, const QModelIn
 }
 
 
-FlagsWidget::FlagsWidget(MainWindow *main, QAction *action) :
-    CutterDockWidget(main, action),
+FlagsWidget::FlagsWidget(MainWindow *main) :
+    CutterDockWidget(main),
     ui(new Ui::FlagsWidget),
     main(main),
     tree(new CutterTreeWidget(this))

--- a/src/widgets/FlagsWidget.h
+++ b/src/widgets/FlagsWidget.h
@@ -69,7 +69,7 @@ class FlagsWidget : public CutterDockWidget
     Q_OBJECT
 
 public:
-    explicit FlagsWidget(MainWindow *main, QAction *action = nullptr);
+    explicit FlagsWidget(MainWindow *main);
     ~FlagsWidget();
 
 private slots:

--- a/src/widgets/FunctionsWidget.cpp
+++ b/src/widgets/FunctionsWidget.cpp
@@ -424,8 +424,8 @@ bool FunctionSortFilterProxyModel::lessThan(const QModelIndex &left, const QMode
     }
 }
 
-FunctionsWidget::FunctionsWidget(MainWindow *main, QAction *action) :
-    ListDockWidget(main, action),
+FunctionsWidget::FunctionsWidget(MainWindow *main) :
+    ListDockWidget(main),
     actionRename(tr("Rename"), this),
     actionUndefine(tr("Undefine"), this),
     actionHorizontal(tr("Horizontal"), this),

--- a/src/widgets/FunctionsWidget.h
+++ b/src/widgets/FunctionsWidget.h
@@ -92,7 +92,7 @@ class FunctionsWidget : public ListDockWidget
     Q_OBJECT
 
 public:
-    explicit FunctionsWidget(MainWindow *main, QAction *action = nullptr);
+    explicit FunctionsWidget(MainWindow *main);
     ~FunctionsWidget() override;
     void changeSizePolicy(QSizePolicy::Policy hor, QSizePolicy::Policy ver);
 

--- a/src/widgets/GraphWidget.cpp
+++ b/src/widgets/GraphWidget.cpp
@@ -4,8 +4,8 @@
 #include "WidgetShortcuts.h"
 #include <QVBoxLayout>
 
-GraphWidget::GraphWidget(MainWindow *main, QAction *action) :
-    MemoryDockWidget(MemoryWidgetType::Graph, main, action)
+GraphWidget::GraphWidget(MainWindow *main) :
+    MemoryDockWidget(MemoryWidgetType::Graph, main)
 {
     setObjectName(main
                   ? main->getUniqueObjectName(getWidgetType())

--- a/src/widgets/GraphWidget.h
+++ b/src/widgets/GraphWidget.h
@@ -12,7 +12,7 @@ class GraphWidget : public MemoryDockWidget
     Q_OBJECT
 
 public:
-    explicit GraphWidget(MainWindow *main, QAction *action = nullptr);
+    explicit GraphWidget(MainWindow *main);
     ~GraphWidget() override {}
 
     DisassemblerGraphView *getGraphView() const;

--- a/src/widgets/HeadersWidget.cpp
+++ b/src/widgets/HeadersWidget.cpp
@@ -109,8 +109,8 @@ bool HeadersProxyModel::lessThan(const QModelIndex &left, const QModelIndex &rig
     return leftHeader.vaddr < rightHeader.vaddr;
 }
 
-HeadersWidget::HeadersWidget(MainWindow *main, QAction *action) :
-    ListDockWidget(main, action)
+HeadersWidget::HeadersWidget(MainWindow *main) :
+    ListDockWidget(main)
 {
     setWindowTitle(tr("Headers"));
     setObjectName("HeadersWidget");

--- a/src/widgets/HeadersWidget.h
+++ b/src/widgets/HeadersWidget.h
@@ -68,7 +68,7 @@ class HeadersWidget : public ListDockWidget
     Q_OBJECT
 
 public:
-    explicit HeadersWidget(MainWindow *main, QAction *action = nullptr);
+    explicit HeadersWidget(MainWindow *main);
     ~HeadersWidget();
 
 private slots:

--- a/src/widgets/HexWidget.h
+++ b/src/widgets/HexWidget.h
@@ -147,7 +147,7 @@ public:
 
     bool copy(void *out, uint64_t addr, size_t len) override {
         if (addr < m_firstBlockAddr || addr > m_lastValidAddr ||
-                (m_lastValidAddr - addr + 1) < len /* do not merge with last check to handle overflows */) {
+                (m_lastValidAddr - addr + 1) < len /* do not merge with last check to handle overflows */ || m_blocks.isEmpty()) {
             return false;
         }
 

--- a/src/widgets/HexdumpWidget.cpp
+++ b/src/widgets/HexdumpWidget.cpp
@@ -17,8 +17,8 @@
 #include <QInputDialog>
 #include <QShortcut>
 
-HexdumpWidget::HexdumpWidget(MainWindow *main, QAction *action) :
-    MemoryDockWidget(MemoryWidgetType::Hexdump, main, action),
+HexdumpWidget::HexdumpWidget(MainWindow *main) :
+    MemoryDockWidget(MemoryWidgetType::Hexdump, main),
     ui(new Ui::HexdumpWidget)
 {
     ui->setupUi(this);

--- a/src/widgets/HexdumpWidget.h
+++ b/src/widgets/HexdumpWidget.h
@@ -31,7 +31,7 @@ class HexdumpWidget : public MemoryDockWidget
 {
     Q_OBJECT
 public:
-    explicit HexdumpWidget(MainWindow *main, QAction *action = nullptr);
+    explicit HexdumpWidget(MainWindow *main);
     ~HexdumpWidget() override;
     Highlighter *highlighter;
 

--- a/src/widgets/ImportsWidget.cpp
+++ b/src/widgets/ImportsWidget.cpp
@@ -154,8 +154,8 @@ bool ImportsProxyModel::lessThan(const QModelIndex &left, const QModelIndex &rig
  * Imports Widget
  */
 
-ImportsWidget::ImportsWidget(MainWindow *main, QAction *action) :
-    ListDockWidget(main, action),
+ImportsWidget::ImportsWidget(MainWindow *main) :
+    ListDockWidget(main),
     importsModel(new ImportsModel(&imports, this)),
     importsProxyModel(new ImportsProxyModel(importsModel, this))
 {
@@ -167,8 +167,7 @@ ImportsWidget::ImportsWidget(MainWindow *main, QAction *action) :
     ui->treeView->sortByColumn(ImportsModel::LibraryColumn, Qt::AscendingOrder);
     QShortcut *toggle_shortcut = new QShortcut(widgetShortcuts["ImportsWidget"], main);
     connect(toggle_shortcut, &QShortcut::activated, this, [=] (){ 
-            toggleDockWidget(true); 
-            main->updateDockActionChecked(action);
+            toggleDockWidget(true);
             } );
 
     connect(Core(), &CutterCore::codeRebased, this, &ImportsWidget::refreshImports);

--- a/src/widgets/ImportsWidget.h
+++ b/src/widgets/ImportsWidget.h
@@ -77,7 +77,7 @@ class ImportsWidget : public ListDockWidget
     Q_OBJECT
 
 public:
-    explicit ImportsWidget(MainWindow *main, QAction *action);
+    explicit ImportsWidget(MainWindow *main);
     ~ImportsWidget();
 
 private slots:

--- a/src/widgets/ListDockWidget.cpp
+++ b/src/widgets/ListDockWidget.cpp
@@ -8,8 +8,8 @@
 #include <QResizeEvent>
 #include <QShortcut>
 
-ListDockWidget::ListDockWidget(MainWindow *main, QAction *action, SearchBarPolicy searchBarPolicy) :
-    CutterDockWidget(main, action),
+ListDockWidget::ListDockWidget(MainWindow *main, SearchBarPolicy searchBarPolicy) :
+    CutterDockWidget(main),
     ui(new Ui::ListDockWidget),
     tree(new CutterTreeWidget(this)),
     searchBarPolicy(searchBarPolicy)

--- a/src/widgets/ListDockWidget.h
+++ b/src/widgets/ListDockWidget.h
@@ -32,7 +32,7 @@ public:
         Hide,
     };
 
-    explicit ListDockWidget(MainWindow *main, QAction *action = nullptr, SearchBarPolicy searchBarPolicy = SearchBarPolicy::ShowByDefault);
+    explicit ListDockWidget(MainWindow *main, SearchBarPolicy searchBarPolicy = SearchBarPolicy::ShowByDefault);
     ~ListDockWidget() override;
 
     void showCount(bool show);

--- a/src/widgets/MemoryDockWidget.cpp
+++ b/src/widgets/MemoryDockWidget.cpp
@@ -58,6 +58,19 @@ bool MemoryDockWidget::eventFilter(QObject *object, QEvent *event)
     return CutterDockWidget::eventFilter(object, event);
 }
 
+QVariantMap MemoryDockWidget::serializeViewProprties()
+{
+    auto result = CutterDockWidget::serializeViewProprties();
+    result["synchronized"] = seekable->isSynchronized();
+    return result;
+}
+
+void MemoryDockWidget::deserializeViewProperties(const QVariantMap &properties)
+{
+    QVariant synchronized = properties.value("synchronized", true);
+    seekable->setSynchronization(synchronized.toBool());
+}
+
 void MemoryDockWidget::updateWindowTitle()
 {
     QString name = getWindowTitle();

--- a/src/widgets/MemoryDockWidget.cpp
+++ b/src/widgets/MemoryDockWidget.cpp
@@ -6,8 +6,8 @@
 #include <QMenu>
 #include <QContextMenuEvent>
 
-MemoryDockWidget::MemoryDockWidget(MemoryWidgetType type, MainWindow *parent, QAction *action)
-    : CutterDockWidget(parent, action)
+MemoryDockWidget::MemoryDockWidget(MemoryWidgetType type, MainWindow *parent)
+    : CutterDockWidget(parent)
     , mType(type)
     , seekable(new CutterSeekable(this))
     , syncAction(tr("Sync/unsync offset"), this)
@@ -40,11 +40,6 @@ bool MemoryDockWidget::tryRaiseMemoryWidget()
 
 void MemoryDockWidget::raiseMemoryWidget()
 {
-
-    if (getBoundAction()) {
-        getBoundAction()->setChecked(true);
-    }
-
     show();
     raise();
     widgetToFocusOnRaise()->setFocus(Qt::FocusReason::TabFocusReason);

--- a/src/widgets/MemoryDockWidget.h
+++ b/src/widgets/MemoryDockWidget.h
@@ -15,7 +15,7 @@ class MemoryDockWidget : public CutterDockWidget
 {
     Q_OBJECT
 public:
-    MemoryDockWidget(MemoryWidgetType type, MainWindow *parent, QAction *action = nullptr);
+    MemoryDockWidget(MemoryWidgetType type, MainWindow *parent);
     ~MemoryDockWidget() override {}
 
     CutterSeekable *getSeekable() const;

--- a/src/widgets/MemoryDockWidget.h
+++ b/src/widgets/MemoryDockWidget.h
@@ -27,6 +27,9 @@ public:
         return mType;
     }
     bool eventFilter(QObject *object, QEvent *event) override;
+
+    QVariantMap serializeViewProprties() override;
+    void deserializeViewProperties(const QVariantMap &properties) override;
 private:
 
     MemoryWidgetType mType;

--- a/src/widgets/MemoryMapWidget.cpp
+++ b/src/widgets/MemoryMapWidget.cpp
@@ -111,8 +111,8 @@ bool MemoryProxyModel::lessThan(const QModelIndex &left, const QModelIndex &righ
     return leftMemMap.addrStart < rightMemMap.addrStart;
 }
 
-MemoryMapWidget::MemoryMapWidget(MainWindow *main, QAction *action) :
-    ListDockWidget(main, action, ListDockWidget::SearchBarPolicy::HideByDefault)
+MemoryMapWidget::MemoryMapWidget(MainWindow *main) :
+    ListDockWidget(main, ListDockWidget::SearchBarPolicy::HideByDefault)
 {
     setWindowTitle(tr("Memory Map"));
     setObjectName("MemoryMapWidget");

--- a/src/widgets/MemoryMapWidget.h
+++ b/src/widgets/MemoryMapWidget.h
@@ -67,7 +67,7 @@ class MemoryMapWidget : public ListDockWidget
     Q_OBJECT
 
 public:
-    explicit MemoryMapWidget(MainWindow *main, QAction *action = nullptr);
+    explicit MemoryMapWidget(MainWindow *main);
     ~MemoryMapWidget();
 
 private slots:

--- a/src/widgets/OverviewWidget.cpp
+++ b/src/widgets/OverviewWidget.cpp
@@ -3,8 +3,8 @@
 #include "GraphWidget.h"
 #include "OverviewView.h"
 
-OverviewWidget::OverviewWidget(MainWindow *main, QAction *action) :
-    CutterDockWidget(main, action)
+OverviewWidget::OverviewWidget(MainWindow *main) :
+    CutterDockWidget(main)
 {
     setWindowTitle("Graph Overview");
     setObjectName("Graph Overview");

--- a/src/widgets/OverviewWidget.h
+++ b/src/widgets/OverviewWidget.h
@@ -12,7 +12,7 @@ class OverviewWidget : public CutterDockWidget
     Q_OBJECT
 
 public:
-    explicit OverviewWidget(MainWindow *main, QAction *action = nullptr);
+    explicit OverviewWidget(MainWindow *main);
     ~OverviewWidget();
 
 private:

--- a/src/widgets/ProcessesWidget.cpp
+++ b/src/widgets/ProcessesWidget.cpp
@@ -16,8 +16,8 @@ enum ColumnIndex {
     COLUMN_PATH,
 };
 
-ProcessesWidget::ProcessesWidget(MainWindow *main, QAction *action) :
-    CutterDockWidget(main, action),
+ProcessesWidget::ProcessesWidget(MainWindow *main) :
+    CutterDockWidget(main),
     ui(new Ui::ProcessesWidget)
 {
     ui->setupUi(this);

--- a/src/widgets/ProcessesWidget.h
+++ b/src/widgets/ProcessesWidget.h
@@ -31,7 +31,7 @@ class ProcessesWidget : public CutterDockWidget
     Q_OBJECT
 
 public:
-    explicit ProcessesWidget(MainWindow *main, QAction *action = nullptr);
+    explicit ProcessesWidget(MainWindow *main);
     ~ProcessesWidget();
 
 private slots:

--- a/src/widgets/RegisterRefsWidget.cpp
+++ b/src/widgets/RegisterRefsWidget.cpp
@@ -111,8 +111,8 @@ bool RegisterRefProxyModel::lessThan(const QModelIndex &left, const QModelIndex 
     return leftRegRef.reg < rightRegRef.reg;
 }
 
-RegisterRefsWidget::RegisterRefsWidget(MainWindow *main, QAction *action) :
-    CutterDockWidget(main, action),
+RegisterRefsWidget::RegisterRefsWidget(MainWindow *main) :
+    CutterDockWidget(main),
     ui(new Ui::RegisterRefsWidget),
     tree(new CutterTreeWidget(this)),
     addressableItemContextMenu(this, main)

--- a/src/widgets/RegisterRefsWidget.h
+++ b/src/widgets/RegisterRefsWidget.h
@@ -69,7 +69,7 @@ class RegisterRefsWidget : public CutterDockWidget
     Q_OBJECT
 
 public:
-    explicit RegisterRefsWidget(MainWindow *main, QAction *action = nullptr);
+    explicit RegisterRefsWidget(MainWindow *main);
     ~RegisterRefsWidget();
 
 private slots:

--- a/src/widgets/RegistersWidget.cpp
+++ b/src/widgets/RegistersWidget.cpp
@@ -8,8 +8,8 @@
 #include <QLabel>
 #include <QLineEdit>
 
-RegistersWidget::RegistersWidget(MainWindow *main, QAction *action) :
-    CutterDockWidget(main, action),
+RegistersWidget::RegistersWidget(MainWindow *main) :
+    CutterDockWidget(main),
     ui(new Ui::RegistersWidget),
     addressContextMenu(this, main)
 {

--- a/src/widgets/RegistersWidget.h
+++ b/src/widgets/RegistersWidget.h
@@ -21,7 +21,7 @@ class RegistersWidget : public CutterDockWidget
     Q_OBJECT
 
 public:
-    explicit RegistersWidget(MainWindow *main, QAction *action = nullptr);
+    explicit RegistersWidget(MainWindow *main);
     ~RegistersWidget();
 
 private slots:

--- a/src/widgets/RelocsWidget.cpp
+++ b/src/widgets/RelocsWidget.cpp
@@ -113,8 +113,8 @@ bool RelocsProxyModel::lessThan(const QModelIndex &left, const QModelIndex &righ
     return false;
 }
 
-RelocsWidget::RelocsWidget(MainWindow *main, QAction *action) :
-    ListDockWidget(main, action),
+RelocsWidget::RelocsWidget(MainWindow *main) :
+    ListDockWidget(main),
     relocsModel(new RelocsModel(&relocs, this)),
     relocsProxyModel(new RelocsProxyModel(relocsModel, this))
 {

--- a/src/widgets/RelocsWidget.h
+++ b/src/widgets/RelocsWidget.h
@@ -54,7 +54,7 @@ class RelocsWidget : public ListDockWidget
     Q_OBJECT
 
 public:
-    explicit RelocsWidget(MainWindow *main, QAction *action = nullptr);
+    explicit RelocsWidget(MainWindow *main);
     ~RelocsWidget();
 
 private slots:

--- a/src/widgets/ResourcesWidget.cpp
+++ b/src/widgets/ResourcesWidget.cpp
@@ -79,8 +79,8 @@ RVA ResourcesModel::address(const QModelIndex &index) const
     return res.vaddr;
 }
 
-ResourcesWidget::ResourcesWidget(MainWindow *main, QAction *action) :
-    ListDockWidget(main, action, ListDockWidget::SearchBarPolicy::HideByDefault)
+ResourcesWidget::ResourcesWidget(MainWindow *main) :
+    ListDockWidget(main, ListDockWidget::SearchBarPolicy::HideByDefault)
 {
     setObjectName("ResourcesWidget");
 

--- a/src/widgets/ResourcesWidget.h
+++ b/src/widgets/ResourcesWidget.h
@@ -45,7 +45,7 @@ private:
     QList<ResourcesDescription> resources;
 
 public:
-    explicit ResourcesWidget(MainWindow *main, QAction *action = nullptr);
+    explicit ResourcesWidget(MainWindow *main);
 
 private slots:
     void refreshResources();

--- a/src/widgets/SdbWidget.cpp
+++ b/src/widgets/SdbWidget.cpp
@@ -8,8 +8,8 @@
 #include <QTreeWidget>
 
 
-SdbWidget::SdbWidget(MainWindow *main, QAction *action) :
-    CutterDockWidget(main, action),
+SdbWidget::SdbWidget(MainWindow *main) :
+    CutterDockWidget(main),
     ui(new Ui::SdbWidget)
 {
     ui->setupUi(this);

--- a/src/widgets/SdbWidget.h
+++ b/src/widgets/SdbWidget.h
@@ -17,7 +17,7 @@ class SdbWidget : public CutterDockWidget
     Q_OBJECT
 
 public:
-    explicit SdbWidget(MainWindow *main, QAction *action = nullptr);
+    explicit SdbWidget(MainWindow *main);
     ~SdbWidget();
 
 private slots:

--- a/src/widgets/SearchWidget.cpp
+++ b/src/widgets/SearchWidget.cpp
@@ -167,8 +167,8 @@ bool SearchSortFilterProxyModel::lessThan(const QModelIndex &left, const QModelI
 }
 
 
-SearchWidget::SearchWidget(MainWindow *main, QAction *action) :
-    CutterDockWidget(main, action),
+SearchWidget::SearchWidget(MainWindow *main) :
+    CutterDockWidget(main),
     ui(new Ui::SearchWidget)
 {
     ui->setupUi(this);

--- a/src/widgets/SearchWidget.h
+++ b/src/widgets/SearchWidget.h
@@ -64,7 +64,7 @@ class SearchWidget : public CutterDockWidget
     Q_OBJECT
 
 public:
-    explicit SearchWidget(MainWindow *main, QAction *action = nullptr);
+    explicit SearchWidget(MainWindow *main);
     ~SearchWidget();
 
 private slots:

--- a/src/widgets/SectionsWidget.cpp
+++ b/src/widgets/SectionsWidget.cpp
@@ -154,8 +154,8 @@ bool SectionsProxyModel::lessThan(const QModelIndex &left, const QModelIndex &ri
     }
 }
 
-SectionsWidget::SectionsWidget(MainWindow *main, QAction *action) :
-    ListDockWidget(main, action)
+SectionsWidget::SectionsWidget(MainWindow *main) :
+    ListDockWidget(main)
 {
     setObjectName("SectionsWidget");
     setWindowTitle(QStringLiteral("Sections"));

--- a/src/widgets/SectionsWidget.h
+++ b/src/widgets/SectionsWidget.h
@@ -67,7 +67,7 @@ class SectionsWidget : public ListDockWidget
     Q_OBJECT
 
 public:
-    explicit SectionsWidget(MainWindow *main, QAction *action = nullptr);
+    explicit SectionsWidget(MainWindow *main);
     ~SectionsWidget();
 
 private slots:

--- a/src/widgets/SegmentsWidget.cpp
+++ b/src/widgets/SegmentsWidget.cpp
@@ -130,8 +130,8 @@ bool SegmentsProxyModel::lessThan(const QModelIndex &left, const QModelIndex &ri
     return false;
 }
 
-SegmentsWidget::SegmentsWidget(MainWindow *main, QAction *action) :
-    ListDockWidget(main, action)
+SegmentsWidget::SegmentsWidget(MainWindow *main) :
+    ListDockWidget(main)
 {
     setObjectName("SegmentsWidget");
     setWindowTitle(QStringLiteral("Segments"));

--- a/src/widgets/SegmentsWidget.h
+++ b/src/widgets/SegmentsWidget.h
@@ -53,7 +53,7 @@ class SegmentsWidget : public ListDockWidget
     Q_OBJECT
 
 public:
-    explicit SegmentsWidget(MainWindow *main, QAction *action = nullptr);
+    explicit SegmentsWidget(MainWindow *main);
     ~SegmentsWidget();
 
 private slots:

--- a/src/widgets/StackWidget.cpp
+++ b/src/widgets/StackWidget.cpp
@@ -8,8 +8,8 @@
 #include "QHeaderView"
 #include "QMenu"
 
-StackWidget::StackWidget(MainWindow *main, QAction *action) :
-    CutterDockWidget(main, action),
+StackWidget::StackWidget(MainWindow *main) :
+    CutterDockWidget(main),
     ui(new Ui::StackWidget),
     menuText(this),
     addressableItemContextMenu(this, main)

--- a/src/widgets/StackWidget.h
+++ b/src/widgets/StackWidget.h
@@ -52,7 +52,7 @@ class StackWidget : public CutterDockWidget
     Q_OBJECT
 
 public:
-    explicit StackWidget(MainWindow *main, QAction *action = nullptr);
+    explicit StackWidget(MainWindow *main);
     ~StackWidget();
 
 private slots:

--- a/src/widgets/StringsWidget.cpp
+++ b/src/widgets/StringsWidget.cpp
@@ -137,8 +137,8 @@ bool StringsProxyModel::lessThan(const QModelIndex &left, const QModelIndex &rig
     return leftStr->vaddr < rightStr->vaddr;
 }
 
-StringsWidget::StringsWidget(MainWindow *main, QAction *action) :
-    CutterDockWidget(main, action),
+StringsWidget::StringsWidget(MainWindow *main) :
+    CutterDockWidget(main),
     ui(new Ui::StringsWidget),
     tree(new CutterTreeWidget(this))
 {
@@ -154,8 +154,7 @@ StringsWidget::StringsWidget(MainWindow *main, QAction *action) :
     QShortcut *toggle_shortcut = new QShortcut(widgetShortcuts["StringsWidget"], main);
     connect(toggle_shortcut, &QShortcut::activated, this, [ = ] () {
         toggleDockWidget(true);
-        main->updateDockActionChecked(action);
-    } );
+    });
 
     connect(ui->actionCopy_String, SIGNAL(triggered()), this, SLOT(on_actionCopy()));
 

--- a/src/widgets/StringsWidget.h
+++ b/src/widgets/StringsWidget.h
@@ -70,7 +70,7 @@ class StringsWidget : public CutterDockWidget
     Q_OBJECT
 
 public:
-    explicit StringsWidget(MainWindow *main, QAction *action = nullptr);
+    explicit StringsWidget(MainWindow *main);
     ~StringsWidget();
 
 private slots:

--- a/src/widgets/SymbolsWidget.cpp
+++ b/src/widgets/SymbolsWidget.cpp
@@ -113,8 +113,8 @@ bool SymbolsProxyModel::lessThan(const QModelIndex &left, const QModelIndex &rig
     return false;
 }
 
-SymbolsWidget::SymbolsWidget(MainWindow *main, QAction *action) :
-    ListDockWidget(main, action)
+SymbolsWidget::SymbolsWidget(MainWindow *main) :
+    ListDockWidget(main)
 {
     setWindowTitle(tr("Symbols"));
     setObjectName("SymbolsWidget");

--- a/src/widgets/SymbolsWidget.h
+++ b/src/widgets/SymbolsWidget.h
@@ -58,7 +58,7 @@ class SymbolsWidget : public ListDockWidget
     Q_OBJECT
 
 public:
-    explicit SymbolsWidget(MainWindow *main, QAction *action = nullptr);
+    explicit SymbolsWidget(MainWindow *main);
     ~SymbolsWidget();
 
 private slots:

--- a/src/widgets/ThreadsWidget.cpp
+++ b/src/widgets/ThreadsWidget.cpp
@@ -15,8 +15,8 @@ enum ColumnIndex {
     COLUMN_PATH,
 };
 
-ThreadsWidget::ThreadsWidget(MainWindow *main, QAction *action) :
-    CutterDockWidget(main, action),
+ThreadsWidget::ThreadsWidget(MainWindow *main) :
+    CutterDockWidget(main),
     ui(new Ui::ThreadsWidget)
 {
     ui->setupUi(this);

--- a/src/widgets/ThreadsWidget.h
+++ b/src/widgets/ThreadsWidget.h
@@ -31,7 +31,7 @@ class ThreadsWidget : public CutterDockWidget
     Q_OBJECT
 
 public:
-    explicit ThreadsWidget(MainWindow *main, QAction *action = nullptr);
+    explicit ThreadsWidget(MainWindow *main);
     ~ThreadsWidget();
 
 private slots:

--- a/src/widgets/TypesWidget.cpp
+++ b/src/widgets/TypesWidget.cpp
@@ -127,8 +127,8 @@ bool TypesSortFilterProxyModel::lessThan(const QModelIndex &left, const QModelIn
 
 
 
-TypesWidget::TypesWidget(MainWindow *main, QAction *action) :
-    CutterDockWidget(main, action),
+TypesWidget::TypesWidget(MainWindow *main) :
+    CutterDockWidget(main),
     ui(new Ui::TypesWidget),
     tree(new CutterTreeWidget(this))
 {

--- a/src/widgets/TypesWidget.h
+++ b/src/widgets/TypesWidget.h
@@ -72,7 +72,7 @@ class TypesWidget : public CutterDockWidget
     Q_OBJECT
 
 public:
-    explicit TypesWidget(MainWindow *main, QAction *action = nullptr);
+    explicit TypesWidget(MainWindow *main);
     ~TypesWidget();
 
 private slots:

--- a/src/widgets/VTablesWidget.cpp
+++ b/src/widgets/VTablesWidget.cpp
@@ -127,8 +127,8 @@ bool VTableSortFilterProxyModel::filterAcceptsRow(int source_row,
 }
 
 
-VTablesWidget::VTablesWidget(MainWindow *main, QAction *action) :
-    CutterDockWidget(main, action),
+VTablesWidget::VTablesWidget(MainWindow *main) :
+    CutterDockWidget(main),
     ui(new Ui::VTablesWidget),
     tree(new CutterTreeWidget(this))
 {

--- a/src/widgets/VTablesWidget.h
+++ b/src/widgets/VTablesWidget.h
@@ -56,7 +56,7 @@ class VTablesWidget : public CutterDockWidget
     Q_OBJECT
 
 public:
-    explicit VTablesWidget(MainWindow *main, QAction *action = nullptr);
+    explicit VTablesWidget(MainWindow *main);
     ~VTablesWidget();
 
 private slots:

--- a/src/widgets/ZignaturesWidget.cpp
+++ b/src/widgets/ZignaturesWidget.cpp
@@ -113,8 +113,8 @@ bool ZignaturesProxyModel::lessThan(const QModelIndex &left, const QModelIndex &
     return leftZignature.offset < rightZignature.offset;
 }
 
-ZignaturesWidget::ZignaturesWidget(MainWindow *main, QAction *action) :
-    CutterDockWidget(main, action),
+ZignaturesWidget::ZignaturesWidget(MainWindow *main) :
+    CutterDockWidget(main),
     ui(new Ui::ZignaturesWidget)
 {
     ui->setupUi(this);

--- a/src/widgets/ZignaturesWidget.h
+++ b/src/widgets/ZignaturesWidget.h
@@ -61,7 +61,7 @@ class ZignaturesWidget : public CutterDockWidget
     Q_OBJECT
 
 public:
-    explicit ZignaturesWidget(MainWindow *main, QAction *action = nullptr);
+    explicit ZignaturesWidget(MainWindow *main);
     ~ZignaturesWidget();
 
 private slots:


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/developers-docs/first-time.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/developers-docs.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)

**WARNING** :exclamation: 

This branch performs one way upgrade of settings and layout. If you have some complex layout that you want to keep using in the old Cutter backup your cutter settings.


**Detailed description**

Can be reviewed. Do not merge into 1.10.3 !

* Separate all layout state into a structure making it clearer when and where it's saved, loaded, switched.
* As part of layout state introduce dock view properties which is QVariant dictionary that can be used for easily saving single dock config. Makers of new widgets should consider if an option belongs to global settings or the new widget/layout specific properties. The new mechanism is suitable for situations where user might want to open two copies of a  widget with different view settings. For example two hexwidgets one showing memory as hex bytes, other as floating point numbers. To use the new mechanism developer needs to override @CutterDockWidget::serializeViewProperties@ and @CutterDockWidget::deSerializeViewProperties@   methods. 
* Allow saving multiple layout profiles in addition to builtin Default and Debug. The logic is that "Default" and "[default]Debug" always contain the last layout in corresponding mode. When user loads new profile or modifies the current layout it becomes the new "Default". Saved layouts are never automatically modified.
* Window size is separated from layout. It is loaded when opening Cutter. Switching layout doesn't touch the window size. It's possible to imagine that for some elaborate layouts window size is important but in most cases changing window size when switching layout would be unexpected. To be safe I kept the the window geometry in layout state but it isn't loaded. It will be easier to ignore or remove it later, than making it out of nothing in case it turns out to be necessary. Most examples show restoring state(dock placement) together with geometry(main window size and placement).
* Remove the custom mechanism for synchronizing widget visibility with action checkboxes in windows menu. Qt has it builtin, no need to reinvent it poorly. The old mechanism tried to deal with multiple widgets of the same kind but it only increased complexity and wasn't actually used.
* Code attempts to put new docks (new extra, plugins, or after Cutter upgrade) in the biggest area with existing disassembly, graph, hex widget. From my observations in https://github.com/radareorg/cutter/issues/694#issuecomment-621345529 and later it seems that any attempts to put something on the side may potentially result in broken layout. 

When I started working on this I tried to visualize layout related code structure. 
before:
![before](https://user-images.githubusercontent.com/7101031/80803229-62716d00-8bba-11ea-9ccc-1cd4da972e57.png)
after:
![after](https://user-images.githubusercontent.com/7101031/80803239-669d8a80-8bba-11ea-8978-5ae1fc42609e.png)


**Test plan (required)**

* Clean start without upgrade
  * remove cutter config
  * start cutter 
  * make sure default layout is reasonable
  * start debuging make sure layout is reasonable
* layout upgrade a)
  * remove cutter config
  * open 1.10.3 cutter
  * make minor modifications to layout
  * close 1.10.3 cutter
  * open new cutter make sure sure layout is reasonable
  * start debugging make sure layout is reasonable
* layout upgrade b)
  * remove cutter config
  * open 1.10.3 cutter
  * start debugging 
  * make some modification to layout 
  * stop debugging
  * close 1.10.3 cutter
  * open new cutter make sure sure layout is reasonable
  * start debugging make sure layout is reasonable
* saving layout modifications
  * open cutter modify layout
  * restart cutter, make sure layout is preserved
  * start debugging
  * modify debug layout
  * stop debugging
  * start debugging
  * make sure debug layout is preserved
  * restart cutter
  * start debugging 
  * make sure debug layout is preserved
  * stop debugging
* resetting layout (do after previous step)
  * be in non debug mode
  * reset layout
  * make sure it matches initial layout
  * start debugging
  * make sure debug layout isn't reset
  * reset layout
  * make sure you see the initial debug layout
  * modify both debug and normal layout again
  * reset settings
  * make sure both layouts were reset
* view property saving
  * Open multiple memory widgets(disassembly, hex or graph). At least two copies for one of them and place them side by side.
  * synchronize some of them, desynchronize others
  * restart cutter
  * make sure all the the memory widgets are opened and synchronization state is correctly restored

* It would be useful if reviewer and maybe more people tried a bunch of random things to see if some sequence of operations or specific layout can cause layout to break.
 
**Closing issues**

Not closing #694 , that should be done after finishing second part and implementing layout management UI.
Closes #1921
Maybe closes #1737 . Doesn't do exactly what was asked there, but in my opinion solves the problem in a somewhat acceptable way.
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->

**Followup tasks**
* The new mechanism for saving view properties could be used to easily implement  #1704
* Better UI for managing layouts
* view properties could be used for saving some of hex widget config
* update Plugins to use the new API for dock action
* Overview widget showing/hiding. Looks there are some leftover code trying to do more than basic checkbox to show, but it doesn't seem to be working in current master or this PR. #2209 
