### PR TITLE
Detect when native theme's darkness doesn't match color theme.

### DIFF
--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -33,6 +33,9 @@ const QHash<QString, ColorFlags> Configuration::relevantThemes = {
     { "tango", LightFlag },
     { "white", LightFlag }
 };
+static const QString DEFAULT_LIGHT_COLOR_THEME = "cutter";
+static const QString DEFAULT_DARK_COLOR_THEME = "ayu";
+
 
 const QHash<QString, QHash<ColorFlags, QColor>> Configuration::cutterOptionColors = {
     { "gui.cflow",                 { { DarkFlag,  QColor(0xff, 0xff, 0xff) },
@@ -440,6 +443,8 @@ void Configuration::setInterfaceTheme(int theme)
         setColor(it.key(), it.value()[interfaceTheme.flag]);
     }
 
+    adjustColorThemeDarkness();
+
     emit interfaceThemeChanged();
     emit colorsUpdated();
 #ifdef CUTTER_ENABLE_KSYNTAXHIGHLIGHTING
@@ -541,6 +546,26 @@ void Configuration::setColorTheme(const QString &theme)
     }
 
     emit colorsUpdated();
+}
+
+void Configuration::adjustColorThemeDarkness()
+{
+    bool windowIsDark = windowColorIsDark();
+    int windowDarkness = windowIsDark ? DarkFlag : LightFlag;
+    int currentColorThemeDarkness = colorThemeDarkness(getColorTheme());
+
+    if ((currentColorThemeDarkness & windowDarkness) == 0) {
+        setColorTheme(windowIsDark ? DEFAULT_DARK_COLOR_THEME : DEFAULT_LIGHT_COLOR_THEME);
+    }
+}
+
+int Configuration::colorThemeDarkness(const QString &colorTheme) const
+{
+    auto flags = relevantThemes.find(colorTheme);
+    if (flags != relevantThemes.end()) {
+        return static_cast<int>(*flags);
+    }
+    return DarkFlag | LightFlag;
 }
 
 void Configuration::resetToDefaultAsmOptions()

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -141,6 +141,11 @@ public:
 
     QString getColorTheme() const     { return s.value("theme", "cutter").toString(); }
     void setColorTheme(const QString &theme);
+    /**
+     * @brief Change current color theme if it doesnt't much native theme's darkness.
+     */
+    void adjustColorThemeDarkness();
+    int colorThemeDarkness(const QString &colorTheme) const;
 
     void setColor(const QString &name, const QColor &color);
     const QColor getColor(const QString &name) const;

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -550,7 +550,7 @@ void MainWindow::finalizeOpen()
     // Add fortune message
     core->message("\n" + core->cmdRaw("fo"));
     showMaximized();
-
+    Config()->adjustColorThemeDarkness();
 
     QSettings s;
     QStringList unsync = s.value("unsync").toStringList();

--- a/src/dialogs/WelcomeDialog.cpp
+++ b/src/dialogs/WelcomeDialog.cpp
@@ -37,6 +37,7 @@ WelcomeDialog::WelcomeDialog(QWidget *parent) :
             this,
             &WelcomeDialog::onLanguageComboBox_currentIndexChanged);
 
+    Config()->adjustColorThemeDarkness();
 }
 
 /**
@@ -54,11 +55,6 @@ WelcomeDialog::~WelcomeDialog()
 void WelcomeDialog::on_themeComboBox_currentIndexChanged(int index)
 {
     Config()->setInterfaceTheme(index);
-
-    // use "ayu" as the default color theme for dark interface
-    if (Config()->windowColorIsDark()) {
-        Config()->setColorTheme("ayu");
-    }
 
     // make sure that Cutter's logo changes its color according to the selected theme
     ui->logoSvgWidget->load(Config()->getLogoFile());


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/developers-docs/first-time.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/developers-docs.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)

**Detailed description**

Detect when disassembly  color theme doesn't match color theme and change it.

**Test plan (required)**

1) Delete Cutter.ini
2) Select dark system theme
3) Open cutter and keep native theme
4) Make sure color theme is appropriate, use `eco` command if necessary
5) Reset settings, make sure color theme is still good 
6) Repeat steps 1-5 using light system theme
7) Change color theme and restart Cutter. Make sure color theme isn't changed when not necessary. 
Make sure color theme checking is done each time not only first run:
8) Close Cutter, change the system theme to dark.
9) Open cutter, make sure color theme is correct.

**Closing issues**

Closes #2174