### PR TITLE
Don't do e- when resetting settings.

### DIFF
--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -211,7 +211,10 @@ int Configuration::getNewFileLastClicked()
 
 void Configuration::resetAll()
 {
-    Core()->cmdRaw("e-");
+    // Don't reset all r2 vars, that currently breaks a bunch of stuff.
+    // settingsFile.remove()+loadInitials() should reset all settings configurable using Cutter GUI.
+    //Core()->cmdRaw("e-");
+
     Core()->setSettings();
     // Delete the file so no extra configuration is in it.
     QFile settingsFile(s.fileName());


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/developers-docs/first-time.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/developers-docs.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

 Don't reset all r2 vars, that currently breaks a bunch of stuff.
`settingsFile.remove()`+`loadInitials()` should reset all settings configurable using Cutter GUI.

**Test plan (required)**

* test that changes fix r2hidra crash after reset :heavy_check_mark: 
* Open 32bit arm elf. Reset settings and check that arch and bits isn't changed to 64bit x86 (or whatever system platform is). :heavy_check_mark: 
* open settings change something with obvious effect in disassembly options :heavy_check_mark: 
* modify graph options :heavy_check_mark: 
* Unselect Debg/break esil execution when instruction is invalid :heavy_check_mark: 
* change Appearance/font :heavy_check_mark: 
* reset settings, check that changes aren't visible in disassembly and graph widgets :heavy_check_mark: 
* open settings and check that changes have been reset to defaults :heavy_check_mark: 

<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
