### PR TITLE
Fix duplicate hashes in Dashboard after refreshing

### DIFF
--- a/src/widgets/Dashboard.cpp
+++ b/src/widgets/Dashboard.cpp
@@ -80,6 +80,17 @@ void Dashboard::updateContents()
 
     QJsonObject hashes = Core()->cmdj("itj").object();
 
+    // Delete hashesWidget if it isn't null to avoid duplicate components
+    if (hashesWidget) {
+        hashesWidget->deleteLater();
+    }
+
+    // Define dynamic components to hold the hashes
+    hashesWidget = new QWidget();
+    QFormLayout *hashesLayout = new QFormLayout;
+    hashesWidget->setLayout(hashesLayout);
+    ui->hashesVerticalLayout->addWidget(hashesWidget);
+
     // Add hashes as a pair of Hash Name : Hash Value.
     for (const QString& key : hashes.keys()) {
         // Create a bold QString with the hash name uppercased
@@ -89,12 +100,13 @@ void Dashboard::updateContents()
         QLineEdit *hashLineEdit = new QLineEdit();
         hashLineEdit->setReadOnly(true);
         hashLineEdit->setText(hashes.value(key).toString());
+
         // Set cursor position to begining to avoid long hashes (e.g sha256)
         // to look truncated at the begining
         hashLineEdit->setCursorPosition(0);
 
         // Add both controls to a form layout in a single row
-        ui->formLayout_2->addRow(new QLabel(label), hashLineEdit);
+        hashesLayout->addRow(new QLabel(label), hashLineEdit);
     }
 
     // Add the Entropy value of the file to the dashboard
@@ -111,7 +123,7 @@ void Dashboard::updateContents()
         QLineEdit *entropyLineEdit = new QLineEdit();
         entropyLineEdit->setReadOnly(true);
         entropyLineEdit->setText(entropy);
-        ui->formLayout_2->addRow(new QLabel(tr("<b>Entropy:</b>")), entropyLineEdit);
+        hashesLayout->addRow(new QLabel(tr("<b>Entropy:</b>")), entropyLineEdit);
     }
 
     QJsonObject analinfo = Core()->cmdj("aaij").object();

--- a/src/widgets/Dashboard.h
+++ b/src/widgets/Dashboard.h
@@ -1,6 +1,7 @@
 #ifndef DASHBOARD_H
 #define DASHBOARD_H
 
+#include <QFormLayout>
 #include <memory>
 #include "CutterDockWidget.h"
 
@@ -32,6 +33,8 @@ private:
     std::unique_ptr<Ui::Dashboard>   ui;
     void setPlainText(QLineEdit *textBox, const QString &text);
     void setBool(QLineEdit *textBox, const QJsonObject &jsonObject, const QString &key);
+
+    QWidget *hashesWidget = nullptr;
 };
 
 #endif // DASHBOARD_H

--- a/src/widgets/Dashboard.ui
+++ b/src/widgets/Dashboard.ui
@@ -1068,17 +1068,7 @@
                 <number>5</number>
                </property>
                <item>
-                <layout class="QFormLayout" name="formLayout_2">
-                 <property name="fieldGrowthPolicy">
-                  <enum>QFormLayout::ExpandingFieldsGrow</enum>
-                 </property>
-                 <property name="labelAlignment">
-                  <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-                 </property>
-                 <property name="verticalSpacing">
-                  <number>3</number>
-                 </property>
-                </layout>
+                <layout class="QVBoxLayout" name="hashesVerticalLayout"/>
                </item>
                <item>
                 <widget class="QLabel" name="label_9">


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/developers-docs/first-time.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/developers-docs.html)

**Detailed description**
The dynamic implementation of the hashes displayed on dashboard was buggy because the widgets were appended again and again after refreshing. This PR fixes this by removing the previously created widgets.

**Test plan (required)**

1. Go to dashboard and see the hashes displayed
2. Click view->refresh contents
3. See that nothing changed and that the hashes are displayed correctly.

