### PR TITLE
Toggle Console Widget and  clear output

### DIFF
--- a/docs/source/shortcuts.rst
+++ b/docs/source/shortcuts.rst
@@ -30,6 +30,10 @@ Widget shortcuts
 +-----------+---------+
 | Shift+E   | Exports |
 +-----------+---------+
+| Ctrl+`    | Console |
++-----------+---------+
+| :         | Console |
++-----------+---------+
 
 Disassembly view shortcuts
 --------------------------

--- a/src/widgets/ConsoleWidget.cpp
+++ b/src/widgets/ConsoleWidget.cpp
@@ -65,12 +65,18 @@ ConsoleWidget::ConsoleWidget(MainWindow *main) :
     QList<QKeySequence> toggleShortcuts;
     toggleShortcuts << widgetShortcuts["ConsoleWidget"] << widgetShortcuts["ConsoleWidgetAlternative"];
     toggleConsole->setShortcuts(toggleShortcuts);
+    connect(toggleConsole, &QAction::triggered, this, [this, toggleConsole](){
+        if (toggleConsole->isChecked()) {
+            widgetToFocusOnRaise()->setFocus();
+        }
+    });
 
-    QAction *actionClear = new QAction(tr("Clear Output"), ui->outputTextEdit);
-    connect(actionClear, SIGNAL(triggered(bool)), ui->outputTextEdit, SLOT(clear()));
+    QAction *actionClear = new QAction(tr("Clear Output"), this);
+    connect(actionClear, &QAction::triggered, ui->outputTextEdit, &QPlainTextEdit::clear);
+    addAction(actionClear);
 
     // Ctrl+l to clear the output
-    actionClear->setShortcut(QKeySequence("Ctrl+l"));
+    actionClear->setShortcut(Qt::CTRL + Qt::Key_L);
     actionClear->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     actions.append(actionClear);
 
@@ -166,6 +172,11 @@ bool ConsoleWidget::eventFilter(QObject *obj, QEvent *event)
         }
     }
     return false;
+}
+
+QWidget *ConsoleWidget::widgetToFocusOnRaise()
+{
+    return ui->r2InputLineEdit;
 }
 
 void ConsoleWidget::setupFont()

--- a/src/widgets/ConsoleWidget.cpp
+++ b/src/widgets/ConsoleWidget.cpp
@@ -14,6 +14,7 @@
 #include "ui_ConsoleWidget.h"
 #include "common/Helpers.h"
 #include "common/SvgIconEngine.h"
+#include "WidgetShortcuts.h"
 
 #ifdef Q_OS_WIN
 #include <io.h>
@@ -59,8 +60,18 @@ ConsoleWidget::ConsoleWidget(MainWindow *main) :
     QTextDocument *console_docu = ui->outputTextEdit->document();
     console_docu->setDocumentMargin(10);
 
+    // Ctrl+` and ';' to toggle console widget
+    QAction *toggleConsole = toggleViewAction();
+    QList<QKeySequence> toggleShortcuts;
+    toggleShortcuts << widgetShortcuts["ConsoleWidget"] << widgetShortcuts["ConsoleWidgetAlternative"];
+    toggleConsole->setShortcuts(toggleShortcuts);
+
     QAction *actionClear = new QAction(tr("Clear Output"), ui->outputTextEdit);
     connect(actionClear, SIGNAL(triggered(bool)), ui->outputTextEdit, SLOT(clear()));
+
+    // Ctrl+l to clear the output
+    actionClear->setShortcut(QKeySequence("Ctrl+l"));
+    actionClear->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     actions.append(actionClear);
 
     actionWrapLines = new QAction(tr("Wrap Lines"), ui->outputTextEdit);

--- a/src/widgets/ConsoleWidget.h
+++ b/src/widgets/ConsoleWidget.h
@@ -39,7 +39,8 @@ public:
     }
 
 protected:
-    bool eventFilter(QObject *obj, QEvent *event);
+    bool eventFilter(QObject *obj, QEvent *event) override;
+    QWidget* widgetToFocusOnRaise() override;
 
 public slots:
     void focusInputLineEdit();

--- a/src/widgets/WidgetShortcuts.h
+++ b/src/widgets/WidgetShortcuts.h
@@ -2,10 +2,12 @@
 #define WIDGETSHORTCUTS_H
 
 static const QHash<QString, QKeySequence> widgetShortcuts = {
-    { "StringsWidget",      Qt::SHIFT + Qt::Key_F12 },
-    { "GraphWidget",        Qt::SHIFT + Qt::Key_G },
-    { "ImportsWidget",      Qt::SHIFT + Qt::Key_I },
-    { "ExportsWidget",      Qt::SHIFT + Qt::Key_E }
+    { "StringsWidget",              Qt::SHIFT + Qt::Key_F12 },
+    { "GraphWidget",                Qt::SHIFT + Qt::Key_G },
+    { "ImportsWidget",              Qt::SHIFT + Qt::Key_I },
+    { "ExportsWidget",              Qt::SHIFT + Qt::Key_E },
+    { "ConsoleWidget",              Qt::CTRL + Qt::Key_QuoteLeft },
+    { "ConsoleWidgetAlternative",   Qt::Key_Colon }
 };
 
 #endif


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/developers-docs/first-time.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/developers-docs.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)

**Detailed description**

This pull request adds two shortcuts to toggle the Console Widget
 - <kbd>:</kbd> 
 - <kbd>Ctrl</kbd>+<kbd>`</kbd> 

It also tries to add <kbd>Ctrl</kbd>+<kbd>L</kbd> to clear the output window of the console but I failed with it so **I will appreciate** if someone will do some Qt magic to solve this. 

**Test plan (required)**
Use each of the screenshots to toggle the Console widget
