### PR TITLE
add pci to hexwidget sidepanel

### DIFF
--- a/src/widgets/HexdumpWidget.cpp
+++ b/src/widgets/HexdumpWidget.cpp
@@ -295,7 +295,7 @@ void HexdumpWidget::updateParseWindow(RVA start_address, int size)
 
 void HexdumpWidget::on_parseTypeComboBox_currentTextChanged(const QString &)
 {
-    if (ui->parseTypeComboBox->currentIndex() == 0) {
+    if (ui->parseTypeComboBox->currentIndex() == 0 || ui->parseTypeComboBox->currentIndex() == 4) {
         ui->hexSideFrame_2->show();
     } else {
         ui->hexSideFrame_2->hide();

--- a/src/widgets/HexdumpWidget.cpp
+++ b/src/widgets/HexdumpWidget.cpp
@@ -250,25 +250,28 @@ void HexdumpWidget::updateParseWindow(RVA start_address, int size)
         case 3: // C byte array
             selectedCommand = "pc";
             break;
-        case 4: // C half-word
+        case 4: // C byte array with instructions
+            selectedCommand = "pci";
+            break;
+        case 5: // C half-word
             selectedCommand = "pch";
             break;
-        case 5: // C word
+        case 6: // C word
             selectedCommand = "pcw";
             break;
-        case 6: // C dword
+        case 7: // C dword
             selectedCommand = "pcd";
             break;
-        case 7: // Python
+        case 8: // Python
             selectedCommand = "pcp";
             break;
-        case 8: // JSON
+        case 9: // JSON
             selectedCommand = "pcj";
             break;
-        case 9: // JavaScript
+        case 10: // JavaScript
             selectedCommand = "pcJ";
             break;
-        case 10: // Yara
+        case 11: // Yara
             selectedCommand = "pcy";
             break;
         }

--- a/src/widgets/HexdumpWidget.ui
+++ b/src/widgets/HexdumpWidget.ui
@@ -131,6 +131,11 @@
                </item>
                <item>
                 <property name="text">
+                 <string>C bytes with instructions</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
                  <string>C half-words (2 byte)</string>
                 </property>
                </item>


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/developers-docs/first-time.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/developers-docs.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed) **Not sure**


**Detailed description**

As requested in #2196 this PR adds support for `pci` command

**Test plan (required)**

- Open Hexdump widget
- Select bytes
- From side panel choose `Parsing` > `C bytes with instructions`
<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->


<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**

Closes #2196 
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
