### PR TITLE
Refactored Decompiler Widget and R2Dec Plugin to use RAnnotatedCode

### DIFF
--- a/src/common/Decompiler.cpp
+++ b/src/common/Decompiler.cpp
@@ -5,42 +5,6 @@
 #include <QJsonObject>
 #include <QJsonArray>
 
-
-// ut64 AnnotatedCode::OffsetForPosition(size_t pos) const
-// {
-//     size_t closestPos = SIZE_MAX;
-//     ut64 closestOffset = UT64_MAX;
-//     for (const auto &annotation : annotations) {
-//         if (annotation.type != CodeAnnotation::Type::Offset || annotation.start > pos || annotation.end <= pos) {
-//             continue;
-//         }
-//         if (closestPos != SIZE_MAX && closestPos >= annotation.start) {
-//             continue;
-//         }
-//         closestPos = annotation.start;
-//         closestOffset = annotation.offset.offset;
-//     }
-//     return closestOffset;
-// }
-
-// size_t AnnotatedCode::PositionForOffset(ut64 offset) const
-// {
-//     size_t closestPos = SIZE_MAX;
-//     ut64 closestOffset = UT64_MAX;
-//     for (const auto &annotation : annotations) {
-//         if (annotation.type != CodeAnnotation::Type::Offset || annotation.offset.offset > offset) {
-//             continue;
-//         }
-//         if (closestOffset != UT64_MAX && closestOffset >= annotation.offset.offset) {
-//             continue;
-//         }
-//         closestPos = annotation.start;
-//         closestOffset = annotation.offset.offset;
-//     }
-//     return closestPos;
-// }
-
-
 Decompiler::Decompiler(const QString &id, const QString &name, QObject *parent)
     : QObject(parent),
     id(id),

--- a/src/common/Decompiler.cpp
+++ b/src/common/Decompiler.cpp
@@ -37,8 +37,8 @@ void R2DecDecompiler::decompileAt(RVA addr)
         task = nullptr;
         if (json.isEmpty()) {
             codeString = tr("Failed to parse JSON from r2dec");
-            QByteArray ba = codeString.toUtf8();
-            code->code = ba.data();
+            std::string temporary = codeString.toStdString();
+            code->code = strdup (temporary.c_str());
             emit finished(code);
             return;
         }

--- a/src/common/Decompiler.cpp
+++ b/src/common/Decompiler.cpp
@@ -66,7 +66,7 @@ void R2DecDecompiler::decompileAt(RVA addr)
     }
     task = new R2Task("pddj @ " + QString::number(addr));
     connect(task, &R2Task::finished, this, [this]() {
-        RAnnotatedCode *codi = r_annotated_code_new (nullptr);
+        RAnnotatedCode *code = r_annotated_code_new (nullptr);
         QString codeString = "";
         QJsonObject json = task->getResultJson().object();
         delete task;
@@ -74,8 +74,8 @@ void R2DecDecompiler::decompileAt(RVA addr)
         if (json.isEmpty()) {
             codeString = tr("Failed to parse JSON from r2dec");
             QByteArray ba = codeString.toUtf8();
-            codi->code = ba.data();
-            emit finished(codi);
+            code->code = ba.data();
+            emit finished(code);
             return;
         }
 
@@ -99,7 +99,7 @@ void R2DecDecompiler::decompileAt(RVA addr)
             bool ok;
             annotationi->type = R_CODE_ANNOTATION_TYPE_OFFSET;
             annotationi->offset.offset = lineObject["offset"].toVariant().toULongLong(&ok);
-            r_annotated_code_add_annotation (codi, annotationi);
+            r_annotated_code_add_annotation (code, annotationi);
         }
 
         for (const auto &line : json["errors"].toArray()) {
@@ -109,8 +109,8 @@ void R2DecDecompiler::decompileAt(RVA addr)
             codeString.append(line.toString() + "\n");
         }
         QByteArray ba = codeString.toUtf8();
-        codi->code = ba.data();
-        emit finished(codi);
+        code->code = ba.data();
+        emit finished(code);
     });
     task->startTask();
 }

--- a/src/common/Decompiler.cpp
+++ b/src/common/Decompiler.cpp
@@ -64,22 +64,19 @@ void R2DecDecompiler::decompileAt(RVA addr)
     if (task) {
         return;
     }
-    // RAnnotatedCode *codi = r_annotated_code_new (nullptr);
     task = new R2Task("pddj @ " + QString::number(addr));
     connect(task, &R2Task::finished, this, [this]() {
         RAnnotatedCode *codi = r_annotated_code_new (nullptr);
         QString codeString = "";
         AnnotatedCode code = {};
-        // code.code = "codeString";
-        //     emit finished(code);return;
         QJsonObject json = task->getResultJson().object();
         delete task;
         task = nullptr;
         if (json.isEmpty()) {
             codeString = tr("Failed to parse JSON from r2dec");
-            // codi->code = strdup (codeString);
-            code.code = "codeString";
-            emit finished(code);
+            QByteArray ba = codeString.toUtf8();
+            codi->code = ba.data();
+            emit finished(codi);
             return;
         }
 
@@ -112,14 +109,9 @@ void R2DecDecompiler::decompileAt(RVA addr)
             }
             codeString.append(line.toString() + "\n");
         }
-        codeString.append("HEOWE");
-
-        // codi->code = codeString.toUtf8().data();
         QByteArray ba = codeString.toUtf8();
         codi->code = ba.data();
-        code.code = QString(QLatin1String(codi->code));
-        // code.code = codeString;
-        emit finished(code);
+        emit finished(codi);
     });
     task->startTask();
 }

--- a/src/common/Decompiler.cpp
+++ b/src/common/Decompiler.cpp
@@ -72,8 +72,8 @@ void R2DecDecompiler::decompileAt(RVA addr)
             }
             codeString.append(line.toString() + "\n");
         }
-        QByteArray ba = codeString.toUtf8();
-        code->code = ba.data();
+        std::string tmp = codeString.toStdString();
+        code->code = strdup (tmp.c_str());
         emit finished(code);
     });
     task->startTask();

--- a/src/common/Decompiler.cpp
+++ b/src/common/Decompiler.cpp
@@ -70,12 +70,15 @@ void R2DecDecompiler::decompileAt(RVA addr)
         RAnnotatedCode *codi = r_annotated_code_new (nullptr);
         QString codeString = "";
         AnnotatedCode code = {};
+        // code.code = "codeString";
+        //     emit finished(code);return;
         QJsonObject json = task->getResultJson().object();
         delete task;
         task = nullptr;
         if (json.isEmpty()) {
             codeString = tr("Failed to parse JSON from r2dec");
             // codi->code = strdup (codeString);
+            code.code = "codeString";
             emit finished(code);
             return;
         }
@@ -110,8 +113,12 @@ void R2DecDecompiler::decompileAt(RVA addr)
             codeString.append(line.toString() + "\n");
         }
         codeString.append("HEOWE");
-        codi->code = codeString.toUtf8().data();
+
+        // codi->code = codeString.toUtf8().data();
+        QByteArray ba = codeString.toUtf8();
+        codi->code = ba.data();
         code.code = QString(QLatin1String(codi->code));
+        // code.code = codeString;
         emit finished(code);
     });
     task->startTask();

--- a/src/common/Decompiler.cpp
+++ b/src/common/Decompiler.cpp
@@ -30,7 +30,7 @@ void R2DecDecompiler::decompileAt(RVA addr)
     }
     task = new R2Task("pddj @ " + QString::number(addr));
     connect(task, &R2Task::finished, this, [this]() {
-        RAnnotatedCode *code = r_annotated_code_new (nullptr);
+        RAnnotatedCode *code = r_annotated_code_new(nullptr);
         QString codeString = "";
         QJsonObject json = task->getResultJson().object();
         delete task;
@@ -38,7 +38,7 @@ void R2DecDecompiler::decompileAt(RVA addr)
         if (json.isEmpty()) {
             codeString = tr("Failed to parse JSON from r2dec");
             std::string temporary = codeString.toStdString();
-            code->code = strdup (temporary.c_str());
+            code->code = strdup(temporary.c_str());
             emit finished(code);
             return;
         }
@@ -63,7 +63,7 @@ void R2DecDecompiler::decompileAt(RVA addr)
             bool ok;
             annotationi->type = R_CODE_ANNOTATION_TYPE_OFFSET;
             annotationi->offset.offset = lineObject["offset"].toVariant().toULongLong(&ok);
-            r_annotated_code_add_annotation (code, annotationi);
+            r_annotated_code_add_annotation(code, annotationi);
         }
 
         for (const auto &line : json["errors"].toArray()) {
@@ -73,7 +73,7 @@ void R2DecDecompiler::decompileAt(RVA addr)
             codeString.append(line.toString() + "\n");
         }
         std::string tmp = codeString.toStdString();
-        code->code = strdup (tmp.c_str());
+        code->code = strdup(tmp.c_str());
         emit finished(code);
     });
     task->startTask();

--- a/src/common/Decompiler.cpp
+++ b/src/common/Decompiler.cpp
@@ -68,7 +68,6 @@ void R2DecDecompiler::decompileAt(RVA addr)
     connect(task, &R2Task::finished, this, [this]() {
         RAnnotatedCode *codi = r_annotated_code_new (nullptr);
         QString codeString = "";
-        AnnotatedCode code = {};
         QJsonObject json = task->getResultJson().object();
         delete task;
         task = nullptr;

--- a/src/common/Decompiler.cpp
+++ b/src/common/Decompiler.cpp
@@ -12,7 +12,7 @@ Decompiler::Decompiler(const QString &id, const QString &name, QObject *parent)
 {
 }
 
-static RAnnotatedCode *makeWarning(QString warningMessage){
+RAnnotatedCode *Decompiler::makeWarning(QString warningMessage){
     std::string temporary = warningMessage.toStdString();
     return r_annotated_code_new(strdup(temporary.c_str()));
 }
@@ -39,7 +39,7 @@ void R2DecDecompiler::decompileAt(RVA addr)
         delete task;
         task = nullptr;
         if (json.isEmpty()) {
-            emit finished(makeWarning(tr("Failed to parse JSON from r2dec")));
+            emit finished(Decompiler::makeWarning(tr("Failed to parse JSON from r2dec")));
             return;
         }
         RAnnotatedCode *code = r_annotated_code_new(nullptr);

--- a/src/common/Decompiler.cpp
+++ b/src/common/Decompiler.cpp
@@ -6,39 +6,39 @@
 #include <QJsonArray>
 
 
-ut64 AnnotatedCode::OffsetForPosition(size_t pos) const
-{
-    size_t closestPos = SIZE_MAX;
-    ut64 closestOffset = UT64_MAX;
-    for (const auto &annotation : annotations) {
-        if (annotation.type != CodeAnnotation::Type::Offset || annotation.start > pos || annotation.end <= pos) {
-            continue;
-        }
-        if (closestPos != SIZE_MAX && closestPos >= annotation.start) {
-            continue;
-        }
-        closestPos = annotation.start;
-        closestOffset = annotation.offset.offset;
-    }
-    return closestOffset;
-}
+// ut64 AnnotatedCode::OffsetForPosition(size_t pos) const
+// {
+//     size_t closestPos = SIZE_MAX;
+//     ut64 closestOffset = UT64_MAX;
+//     for (const auto &annotation : annotations) {
+//         if (annotation.type != CodeAnnotation::Type::Offset || annotation.start > pos || annotation.end <= pos) {
+//             continue;
+//         }
+//         if (closestPos != SIZE_MAX && closestPos >= annotation.start) {
+//             continue;
+//         }
+//         closestPos = annotation.start;
+//         closestOffset = annotation.offset.offset;
+//     }
+//     return closestOffset;
+// }
 
-size_t AnnotatedCode::PositionForOffset(ut64 offset) const
-{
-    size_t closestPos = SIZE_MAX;
-    ut64 closestOffset = UT64_MAX;
-    for (const auto &annotation : annotations) {
-        if (annotation.type != CodeAnnotation::Type::Offset || annotation.offset.offset > offset) {
-            continue;
-        }
-        if (closestOffset != UT64_MAX && closestOffset >= annotation.offset.offset) {
-            continue;
-        }
-        closestPos = annotation.start;
-        closestOffset = annotation.offset.offset;
-    }
-    return closestPos;
-}
+// size_t AnnotatedCode::PositionForOffset(ut64 offset) const
+// {
+//     size_t closestPos = SIZE_MAX;
+//     ut64 closestOffset = UT64_MAX;
+//     for (const auto &annotation : annotations) {
+//         if (annotation.type != CodeAnnotation::Type::Offset || annotation.offset.offset > offset) {
+//             continue;
+//         }
+//         if (closestOffset != UT64_MAX && closestOffset >= annotation.offset.offset) {
+//             continue;
+//         }
+//         closestPos = annotation.start;
+//         closestOffset = annotation.offset.offset;
+//     }
+//     return closestPos;
+// }
 
 
 Decompiler::Decompiler(const QString &id, const QString &name, QObject *parent)

--- a/src/common/Decompiler.h
+++ b/src/common/Decompiler.h
@@ -8,39 +8,6 @@
 #include <QString>
 #include <QObject>
 
-// struct CodeAnnotation
-// {
-//     size_t start;
-//     size_t end;
-
-//     enum class Type { Offset };
-//     Type type;
-
-//     union
-//     {
-//         struct
-//         {
-//             ut64 offset;
-//         } offset;
-//     };
-// };
-
-// /**
-//  * Describes the result of a Decompilation Process with optional metadata
-//  */
-// struct AnnotatedCode
-// {
-//     /**
-//      * The entire decompiled code
-//      */
-//     QString code;
-
-//     QList<CodeAnnotation> annotations;
-
-//     ut64 OffsetForPosition(size_t pos) const;
-//     size_t PositionForOffset(ut64 offset) const;
-// };
-
 /**
  * Implements a decompiler that can be registered using CutterCore::registerDecompiler()
  */

--- a/src/common/Decompiler.h
+++ b/src/common/Decompiler.h
@@ -8,38 +8,38 @@
 #include <QString>
 #include <QObject>
 
-struct CodeAnnotation
-{
-    size_t start;
-    size_t end;
+// struct CodeAnnotation
+// {
+//     size_t start;
+//     size_t end;
 
-    enum class Type { Offset };
-    Type type;
+//     enum class Type { Offset };
+//     Type type;
 
-    union
-    {
-        struct
-        {
-            ut64 offset;
-        } offset;
-    };
-};
+//     union
+//     {
+//         struct
+//         {
+//             ut64 offset;
+//         } offset;
+//     };
+// };
 
-/**
- * Describes the result of a Decompilation Process with optional metadata
- */
-struct AnnotatedCode
-{
-    /**
-     * The entire decompiled code
-     */
-    QString code;
+// /**
+//  * Describes the result of a Decompilation Process with optional metadata
+//  */
+// struct AnnotatedCode
+// {
+//     /**
+//      * The entire decompiled code
+//      */
+//     QString code;
 
-    QList<CodeAnnotation> annotations;
+//     QList<CodeAnnotation> annotations;
 
-    ut64 OffsetForPosition(size_t pos) const;
-    size_t PositionForOffset(ut64 offset) const;
-};
+//     ut64 OffsetForPosition(size_t pos) const;
+//     size_t PositionForOffset(ut64 offset) const;
+// };
 
 /**
  * Implements a decompiler that can be registered using CutterCore::registerDecompiler()

--- a/src/common/Decompiler.h
+++ b/src/common/Decompiler.h
@@ -65,7 +65,7 @@ public:
     virtual void cancel() {}
 
 signals:
-    void finished(RAnnotatedCode *code);
+    void finished(RAnnotatedCode *codeDecompiled);
 };
 
 class R2DecDecompiler: public Decompiler

--- a/src/common/Decompiler.h
+++ b/src/common/Decompiler.h
@@ -3,7 +3,7 @@
 
 #include "CutterCommon.h"
 #include "R2Task.h"
-#include <r_util/r_annotated_code.h>//For RAnnotatedCode
+#include <r_util/r_annotated_code.h>
 
 #include <QString>
 #include <QObject>

--- a/src/common/Decompiler.h
+++ b/src/common/Decompiler.h
@@ -3,6 +3,7 @@
 
 #include "CutterCommon.h"
 #include "R2Task.h"
+#include <r_util/r_annotated_code.h>//For RAnnotatedCode
 
 #include <QString>
 #include <QObject>

--- a/src/common/Decompiler.h
+++ b/src/common/Decompiler.h
@@ -65,7 +65,7 @@ public:
     virtual void cancel() {}
 
 signals:
-    void finished(AnnotatedCode code);
+    void finished(RAnnotatedCode *code);
 };
 
 class R2DecDecompiler: public Decompiler

--- a/src/common/Decompiler.h
+++ b/src/common/Decompiler.h
@@ -23,6 +23,8 @@ public:
     Decompiler(const QString &id, const QString &name, QObject *parent = nullptr);
     virtual ~Decompiler() = default;
 
+    static RAnnotatedCode *makeWarning(QString warningMessage);
+
     QString getId() const       { return id; }
     QString getName() const     { return name; }
     virtual bool isRunning()    { return false; }

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -14,6 +14,7 @@
 #include <QTextBlock>
 #include <QObject>
 #include <QTextBlockUserData>
+#include <QString>
 
 DecompilerWidget::DecompilerWidget(MainWindow *main) :
     MemoryDockWidget(MemoryWidgetType::Decompiler, main),
@@ -200,7 +201,7 @@ void DecompilerWidget::decompilationFinished(RAnnotatedCode *code)
     updateRefreshButton();
 
     this->code = std::make_shared<RAnnotatedCode>(code);
-    QString codeString = fromUtf8(this->code->code);
+    QString codeString = QString::fromUtf8(this->code->code);
     if (codeString.isEmpty()) {
         ui->textEdit->setPlainText(tr("Cannot decompile at this address (Not a function?)"));
         return;
@@ -212,7 +213,7 @@ void DecompilerWidget::decompilationFinished(RAnnotatedCode *code)
         highlightPC();
         highlightBreakpoints();
     }
-    
+
     if (decompilerWasBusy) {
         decompilerWasBusy = false;
         doAutoRefresh();

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -150,8 +150,8 @@ void DecompilerWidget::updateRefreshButton()
 // static ut64 offsetForPosition(RAnnotatedCode *codeDecompiled, size_t pos){
 //     size_t closestPos = SIZE_MAX;
 //     ut64 closestOffset = UT64_MAX;
-//     RCodeAnnotation *anno;
-//     r_vector_foreach (&codeDecompiled->annotations, anno){
+    // RCodeAnnotation *anno;
+    // r_vector_foreach (&codeDecompiled->annotations, anno){
 //         if (anno->type != R_CODE_ANNOTATION_TYPE_OFFSET || anno->start > pos || anno->end <= pos){
 //             continue;
 //         }
@@ -163,11 +163,12 @@ void DecompilerWidget::updateRefreshButton()
 //     }
 //     return closestOffset;
 // }
-ut64 offsetForPosition(RAnnotatedCode *codeDecompiled, size_t pos){
+static ut64 offsetForPosition(RAnnotatedCode *codeDecompiled, size_t pos){
     size_t closestPos = SIZE_MAX;
     ut64 closestOffset = UT64_MAX;
-    RCodeAnnotation *annotation = new RCodeAnnotation;
-    r_vector_foreach (&codeDecompiled->annotations, annotation){
+    void *annotationi;
+    r_vector_foreach (&codeDecompiled->annotations, annotationi){
+        RCodeAnnotation *annotation = (RCodeAnnotation *)annotationi;
         if (annotation->type != R_CODE_ANNOTATION_TYPE_OFFSET || annotation->start > pos || annotation->end <= pos){
             continue;
         }
@@ -179,11 +180,12 @@ ut64 offsetForPosition(RAnnotatedCode *codeDecompiled, size_t pos){
     }
     return closestOffset;
 }
-size_t positionForOffset(RAnnotatedCode *codeDecompiled, ut64 offset) {
+static size_t positionForOffset(RAnnotatedCode *codeDecompiled, ut64 offset) {
     size_t closestPos = SIZE_MAX;
     ut64 closestOffset = UT64_MAX;
-    RCodeAnnotation *annotation;
-    r_vector_foreach (&codeDecompiled->annotations, annotation){
+    void *annotationi;
+    r_vector_foreach (&codeDecompiled->annotations, annotationi){
+        RCodeAnnotation *annotation = (RCodeAnnotation *)annotationi;
         if(annotation->type != R_CODE_ANNOTATION_TYPE_OFFSET || annotation->offset.offset > offset){
             continue;
         }
@@ -240,8 +242,8 @@ void DecompilerWidget::refreshDecompiler()
 
 QTextCursor DecompilerWidget::getCursorForAddress(RVA addr)
 {
-    // size_t pos = positionForOffset(code.get(), addr);
-    size_t pos = 100; //Temp
+    size_t pos = positionForOffset(code.get(), addr);
+    // size_t pos = 100; //Temp
     if (pos == SIZE_MAX || pos == 0) {
         return QTextCursor();
     }
@@ -321,8 +323,8 @@ void DecompilerWidget::cursorPositionChanged()
     }
 
     size_t pos = ui->textEdit->textCursor().position();
-    // RVA offset = offsetForPosition(code.get(), pos);
-    RVA offset = 10; //Temp 
+    RVA offset = offsetForPosition(code.get(), pos);
+    // RVA offset = 10; //Temp 
     if (offset != RVA_INVALID && offset != Core()->getOffset()) {
         seekFromCursor = true;
         Core()->seek(offset);
@@ -352,8 +354,8 @@ void DecompilerWidget::seekChanged()
 void DecompilerWidget::updateCursorPosition()
 {
     RVA offset = Core()->getOffset();
-    // size_t pos = positionForOffset(code.get(), offset);
-    size_t pos = 12; //TEMP
+    size_t pos = positionForOffset(code.get(), offset);
+    // size_t pos = 12; //TEMP
     if (pos == SIZE_MAX) {
         return;
     }
@@ -413,8 +415,8 @@ void DecompilerWidget::showDisasContextMenu(const QPoint &pt)
 void DecompilerWidget::seekToReference()
 {
     size_t pos = ui->textEdit->textCursor().position();
-    // RVA offset = offsetForPosition(code.get(), pos);
-    RVA offset = 100; //TEMP
+    RVA offset = offsetForPosition(code.get(), pos);
+    // RVA offset = 100; //TEMP
     seekable->seekToReference(offset);
 }
 

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -18,7 +18,8 @@
 DecompilerWidget::DecompilerWidget(MainWindow *main) :
     MemoryDockWidget(MemoryWidgetType::Decompiler, main),
     mCtxMenu(new DisassemblyContextMenu(this, main)),
-    ui(new Ui::DecompilerWidget)
+    ui(new Ui::DecompilerWidget),
+    code(r_annotated_code_new (strdup ("Choose an offset and refresh to get decompiled code")), &r_annotated_code_free)
 {
     ui->setupUi(this);
 
@@ -105,12 +106,6 @@ DecompilerWidget::DecompilerWidget(MainWindow *main) :
     seekPrevAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     addAction(seekPrevAction);
     connect(seekPrevAction, &QAction::triggered, seekable, &CutterSeekable::seekPrev);
-
-    // Initializing this->code (RAnnotatedCode)
-
-    // This will never be shown to users in normal circumstances
-    RAnnotatedCode *codeDecompiled = r_annotated_code_new (strdup ("Choose an offset and refresh to get decompiled code"));
-    this->code = std::unique_ptr<RAnnotatedCode, decltype(&r_annotated_code_free)>(codeDecompiled, &r_annotated_code_free);
 }
 
 DecompilerWidget::~DecompilerWidget() = default;
@@ -243,7 +238,7 @@ void DecompilerWidget::decompilationFinished(RAnnotatedCode *codeDecompiled)
     ui->progressLabel->setVisible(false);
     ui->decompilerComboBox->setEnabled(decompilerSelectionEnabled);
     updateRefreshButton();
-    
+
     this->code.reset(codeDecompiled);
     QString codeString = QString::fromUtf8(this->code->code);
     if (codeString.isEmpty()) {

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -221,7 +221,6 @@ void DecompilerWidget::refreshDecompiler()
 QTextCursor DecompilerWidget::getCursorForAddress(RVA addr)
 {
     size_t pos = positionForOffset(code.get(), addr);
-    // size_t pos = 100; //Temp
     if (pos == SIZE_MAX || pos == 0) {
         return QTextCursor();
     }
@@ -374,7 +373,6 @@ void DecompilerWidget::seekToReference()
 {
     size_t pos = ui->textEdit->textCursor().position();
     RVA offset = offsetForPosition(code.get(), pos);
-    // RVA offset = 100; //TEMP
     seekable->seekToReference(offset);
 }
 

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -46,7 +46,6 @@ DecompilerWidget::DecompilerWidget(MainWindow *main) :
     });
 
     autoRefreshEnabled = Config()->getDecompilerAutoRefreshEnabled();
-    // autoRefreshEnabled = false;
     ui->autoRefreshCheckBox->setChecked(autoRefreshEnabled);
     setAutoRefresh(autoRefreshEnabled);
     connect(ui->autoRefreshCheckBox, &QCheckBox::stateChanged, this, [this](int state) {
@@ -106,6 +105,13 @@ DecompilerWidget::DecompilerWidget(MainWindow *main) :
     seekPrevAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     addAction(seekPrevAction);
     connect(seekPrevAction, &QAction::triggered, seekable, &CutterSeekable::seekPrev);
+
+    // Initializing this->code (RAnnotatedCode)
+    RAnnotatedCode *codeDecompiled = r_annotated_code_new (strdup ("Choose an offset and refresh to get decompiled code"));
+    auto deleterForRAnnotatedCode = [](RAnnotatedCode* ptrr){
+        r_annotated_code_free(ptrr);
+    };
+    this->code = std::unique_ptr<RAnnotatedCode, decltype(deleterForRAnnotatedCode)>(codeDecompiled, deleterForRAnnotatedCode);
 }
 
 DecompilerWidget::~DecompilerWidget() = default;

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -140,14 +140,61 @@ void DecompilerWidget::updateRefreshButton()
     }
 }
 
-static ut64 offsetForPosition(RAnnotatedCode *codeDecompiled, size_t pos){
-    return UT64_MAX;
+// static ut64 offsetForPosition(RAnnotatedCode *codeDecompiled, size_t pos){
+//     return UT64_MAX;
+// }
+// static size_t positionForOffset(RAnnotatedCode *codeDecompiled, ut64 offset) {
+//     size_t axy = 213;
+//     return axy;
+// }
+// static ut64 offsetForPosition(RAnnotatedCode *codeDecompiled, size_t pos){
+//     size_t closestPos = SIZE_MAX;
+//     ut64 closestOffset = UT64_MAX;
+//     RCodeAnnotation *anno;
+//     r_vector_foreach (&codeDecompiled->annotations, anno){
+//         if (anno->type != R_CODE_ANNOTATION_TYPE_OFFSET || anno->start > pos || anno->end <= pos){
+//             continue;
+//         }
+//         if (closestPos != SIZE_MAX && closestPos >= anno->start){
+//             continue;
+//         }
+//         closestPos = anno->start;
+//         closestOffset = anno->offset.offset;
+//     }
+//     return closestOffset;
+// }
+ut64 offsetForPosition(RAnnotatedCode *codeDecompiled, size_t pos){
+    size_t closestPos = SIZE_MAX;
+    ut64 closestOffset = UT64_MAX;
+    RCodeAnnotation *annotation = new RCodeAnnotation;
+    r_vector_foreach (&codeDecompiled->annotations, annotation){
+        if (annotation->type != R_CODE_ANNOTATION_TYPE_OFFSET || annotation->start > pos || annotation->end <= pos){
+            continue;
+        }
+        if (closestPos != SIZE_MAX && closestPos >= annotation->start){
+            continue;
+        }
+        closestPos = annotation->start;
+        closestOffset = annotation->offset.offset;
+    }
+    return closestOffset;
 }
-static size_t positionForOffset(RAnnotatedCode *codeDecompiled, ut64 offset) {
-    size_t axy = 213;
-    return axy;
+size_t positionForOffset(RAnnotatedCode *codeDecompiled, ut64 offset) {
+    size_t closestPos = SIZE_MAX;
+    ut64 closestOffset = UT64_MAX;
+    RCodeAnnotation *annotation;
+    r_vector_foreach (&codeDecompiled->annotations, annotation){
+        if(annotation->type != R_CODE_ANNOTATION_TYPE_OFFSET || annotation->offset.offset > offset){
+            continue;
+        }
+        if(closestOffset != UT64_MAX && closestOffset >= annotation->offset.offset) {
+            continue;
+        }
+        closestPos = annotation->start;
+        closestOffset = annotation->offset.offset;
+    }
+    return closestPos;
 }
-
 
 void DecompilerWidget::doRefresh(RVA addr)
 {

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -193,29 +193,46 @@ QTextCursor DecompilerWidget::getCursorForAddress(RVA addr)
     return cursor;
 }
 
-void DecompilerWidget::decompilationFinished(AnnotatedCode code)
+void DecompilerWidget::decompilationFinished(RAnnotatedCode *code)
 {
     ui->progressLabel->setVisible(false);
     ui->decompilerComboBox->setEnabled(decompilerSelectionEnabled);
     updateRefreshButton();
 
-    this->code = code;
-    if (code.code.isEmpty()) {
+    this->code = std::make_shared<RAnnotatedCode>(code);
+    QString codeString = fromUtf8(this->code->code);
+    if (codeString.isEmpty()) {
         ui->textEdit->setPlainText(tr("Cannot decompile at this address (Not a function?)"));
         return;
     } else {
         connectCursorPositionChanged(true);
-        ui->textEdit->setPlainText(code.code);
+        ui->textEdit->setPlainText(codeString);
         connectCursorPositionChanged(false);
         updateCursorPosition();
         highlightPC();
         highlightBreakpoints();
     }
-
+    
     if (decompilerWasBusy) {
         decompilerWasBusy = false;
         doAutoRefresh();
     }
+    // if (code.code.isEmpty()) {
+    //     ui->textEdit->setPlainText(tr("Cannot decompile at this address (Not a function?)"));
+    //     return;
+    // } else {
+    //     connectCursorPositionChanged(true);
+    //     ui->textEdit->setPlainText(code.code);
+    //     connectCursorPositionChanged(false);
+    //     updateCursorPosition();
+    //     highlightPC();
+    //     highlightBreakpoints();
+    // }
+
+    // if (decompilerWasBusy) {
+    //     decompilerWasBusy = false;
+    //     doAutoRefresh();
+    // }
 }
 
 void DecompilerWidget::decompilerSelected()

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -139,16 +139,18 @@ void DecompilerWidget::updateRefreshButton()
     }
 }
 
-static ut64 offsetForPosition(RAnnotatedCode *codeDecompiled, size_t pos){
+static ut64 offsetForPosition(RAnnotatedCode *codeDecompiled, size_t pos)
+{
     size_t closestPos = SIZE_MAX;
     ut64 closestOffset = UT64_MAX;
     void *annotationi;
-    r_vector_foreach (&codeDecompiled->annotations, annotationi){
+    r_vector_foreach (&codeDecompiled->annotations, annotationi) {
         RCodeAnnotation *annotation = (RCodeAnnotation *)annotationi;
-        if (annotation->type != R_CODE_ANNOTATION_TYPE_OFFSET || annotation->start > pos || annotation->end <= pos){
+        if (annotation->type != R_CODE_ANNOTATION_TYPE_OFFSET || annotation->start > pos
+                || annotation->end <= pos) {
             continue;
         }
-        if (closestPos != SIZE_MAX && closestPos >= annotation->start){
+        if (closestPos != SIZE_MAX && closestPos >= annotation->start) {
             continue;
         }
         closestPos = annotation->start;
@@ -157,16 +159,17 @@ static ut64 offsetForPosition(RAnnotatedCode *codeDecompiled, size_t pos){
     return closestOffset;
 }
 
-static size_t positionForOffset(RAnnotatedCode *codeDecompiled, ut64 offset) {
+static size_t positionForOffset(RAnnotatedCode *codeDecompiled, ut64 offset)
+{
     size_t closestPos = SIZE_MAX;
     ut64 closestOffset = UT64_MAX;
     void *annotationi;
-    r_vector_foreach (&codeDecompiled->annotations, annotationi){
+    r_vector_foreach (&codeDecompiled->annotations, annotationi) {
         RCodeAnnotation *annotation = (RCodeAnnotation *)annotationi;
-        if(annotation->type != R_CODE_ANNOTATION_TYPE_OFFSET || annotation->offset.offset > offset){
+        if (annotation->type != R_CODE_ANNOTATION_TYPE_OFFSET || annotation->offset.offset > offset) {
             continue;
         }
-        if(closestOffset != UT64_MAX && closestOffset >= annotation->offset.offset) {
+        if (closestOffset != UT64_MAX && closestOffset >= annotation->offset.offset) {
             continue;
         }
         closestPos = annotation->start;

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -19,7 +19,7 @@ DecompilerWidget::DecompilerWidget(MainWindow *main) :
     MemoryDockWidget(MemoryWidgetType::Decompiler, main),
     mCtxMenu(new DisassemblyContextMenu(this, main)),
     ui(new Ui::DecompilerWidget),
-    code(r_annotated_code_new (strdup ("Choose an offset and refresh to get decompiled code")), &r_annotated_code_free)
+    code(r_annotated_code_new(strdup("Choose an offset and refresh to get decompiled code")), &r_annotated_code_free)
 {
     ui->setupUi(this);
 
@@ -145,7 +145,7 @@ static ut64 offsetForPosition(RAnnotatedCode &codeDecompiled, size_t pos)
     size_t closestPos = SIZE_MAX;
     ut64 closestOffset = UT64_MAX;
     void *annotationi;
-    r_vector_foreach (&codeDecompiled.annotations, annotationi) {
+    r_vector_foreach(&codeDecompiled.annotations, annotationi) {
         RCodeAnnotation *annotation = (RCodeAnnotation *)annotationi;
         if (annotation->type != R_CODE_ANNOTATION_TYPE_OFFSET || annotation->start > pos
                 || annotation->end <= pos) {
@@ -165,7 +165,7 @@ static size_t positionForOffset(RAnnotatedCode &codeDecompiled, ut64 offset)
     size_t closestPos = SIZE_MAX;
     ut64 closestOffset = UT64_MAX;
     void *annotationi;
-    r_vector_foreach (&codeDecompiled.annotations, annotationi) {
+    r_vector_foreach(&codeDecompiled.annotations, annotationi) {
         RCodeAnnotation *annotation = (RCodeAnnotation *)annotationi;
         if (annotation->type != R_CODE_ANNOTATION_TYPE_OFFSET || annotation->offset.offset > offset) {
             continue;

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -46,7 +46,7 @@ DecompilerWidget::DecompilerWidget(MainWindow *main) :
     });
 
     autoRefreshEnabled = Config()->getDecompilerAutoRefreshEnabled();
-    // autoRefreshEnabled = true;
+    // autoRefreshEnabled = false;
     ui->autoRefreshCheckBox->setChecked(autoRefreshEnabled);
     setAutoRefresh(autoRefreshEnabled);
     connect(ui->autoRefreshCheckBox, &QCheckBox::stateChanged, this, [this](int state) {

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -19,7 +19,7 @@ DecompilerWidget::DecompilerWidget(MainWindow *main) :
     MemoryDockWidget(MemoryWidgetType::Decompiler, main),
     mCtxMenu(new DisassemblyContextMenu(this, main)),
     ui(new Ui::DecompilerWidget),
-    code(r_annotated_code_new(strdup("Choose an offset and refresh to get decompiled code")), &r_annotated_code_free)
+    code(Decompiler::makeWarning(tr("Choose an offset and refresh to get decompiled code")), &r_annotated_code_free)
 {
     ui->setupUi(this);
 

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -140,6 +140,15 @@ void DecompilerWidget::updateRefreshButton()
     }
 }
 
+static ut64 offsetForPosition(RAnnotatedCode *codeDecompiled, size_t pos){
+    return UT64_MAX;
+}
+static size_t positionForOffset(RAnnotatedCode *codeDecompiled, ut64 offset) {
+    size_t axy = 213;
+    return axy;
+}
+
+
 void DecompilerWidget::doRefresh(RVA addr)
 {
     if (!refreshDeferrer->attemptRefresh(nullptr)) {
@@ -184,7 +193,8 @@ void DecompilerWidget::refreshDecompiler()
 
 QTextCursor DecompilerWidget::getCursorForAddress(RVA addr)
 {
-    size_t pos = code.PositionForOffset(addr);
+    // size_t pos = positionForOffset(code.get(), addr);
+    size_t pos = 100; //Temp
     if (pos == SIZE_MAX || pos == 0) {
         return QTextCursor();
     }
@@ -194,13 +204,15 @@ QTextCursor DecompilerWidget::getCursorForAddress(RVA addr)
     return cursor;
 }
 
-void DecompilerWidget::decompilationFinished(RAnnotatedCode *code)
+void DecompilerWidget::decompilationFinished(RAnnotatedCode *codeDecompiled)
 {
     ui->progressLabel->setVisible(false);
     ui->decompilerComboBox->setEnabled(decompilerSelectionEnabled);
     updateRefreshButton();
 
-    this->code = std::make_shared<RAnnotatedCode>(code);
+    // this->code = codeDecompiled;
+    // this->code = std::make_shared<RAnnotatedCode>(codeDecompiled);
+    this->code = std::unique_ptr<RAnnotatedCode>(codeDecompiled);
     QString codeString = QString::fromUtf8(this->code->code);
     if (codeString.isEmpty()) {
         ui->textEdit->setPlainText(tr("Cannot decompile at this address (Not a function?)"));
@@ -262,7 +274,8 @@ void DecompilerWidget::cursorPositionChanged()
     }
 
     size_t pos = ui->textEdit->textCursor().position();
-    RVA offset = code.OffsetForPosition(pos);
+    // RVA offset = offsetForPosition(code.get(), pos);
+    RVA offset = 10; //Temp 
     if (offset != RVA_INVALID && offset != Core()->getOffset()) {
         seekFromCursor = true;
         Core()->seek(offset);
@@ -292,7 +305,8 @@ void DecompilerWidget::seekChanged()
 void DecompilerWidget::updateCursorPosition()
 {
     RVA offset = Core()->getOffset();
-    size_t pos = code.PositionForOffset(offset);
+    // size_t pos = positionForOffset(code.get(), offset);
+    size_t pos = 12; //TEMP
     if (pos == SIZE_MAX) {
         return;
     }
@@ -352,7 +366,8 @@ void DecompilerWidget::showDisasContextMenu(const QPoint &pt)
 void DecompilerWidget::seekToReference()
 {
     size_t pos = ui->textEdit->textCursor().position();
-    RVA offset = code.OffsetForPosition(pos);
+    // RVA offset = offsetForPosition(code.get(), pos);
+    RVA offset = 100; //TEMP
     seekable->seekToReference(offset);
 }
 

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -140,29 +140,6 @@ void DecompilerWidget::updateRefreshButton()
     }
 }
 
-// static ut64 offsetForPosition(RAnnotatedCode *codeDecompiled, size_t pos){
-//     return UT64_MAX;
-// }
-// static size_t positionForOffset(RAnnotatedCode *codeDecompiled, ut64 offset) {
-//     size_t axy = 213;
-//     return axy;
-// }
-// static ut64 offsetForPosition(RAnnotatedCode *codeDecompiled, size_t pos){
-//     size_t closestPos = SIZE_MAX;
-//     ut64 closestOffset = UT64_MAX;
-    // RCodeAnnotation *anno;
-    // r_vector_foreach (&codeDecompiled->annotations, anno){
-//         if (anno->type != R_CODE_ANNOTATION_TYPE_OFFSET || anno->start > pos || anno->end <= pos){
-//             continue;
-//         }
-//         if (closestPos != SIZE_MAX && closestPos >= anno->start){
-//             continue;
-//         }
-//         closestPos = anno->start;
-//         closestOffset = anno->offset.offset;
-//     }
-//     return closestOffset;
-// }
 static ut64 offsetForPosition(RAnnotatedCode *codeDecompiled, size_t pos){
     size_t closestPos = SIZE_MAX;
     ut64 closestOffset = UT64_MAX;
@@ -180,6 +157,7 @@ static ut64 offsetForPosition(RAnnotatedCode *codeDecompiled, size_t pos){
     }
     return closestOffset;
 }
+
 static size_t positionForOffset(RAnnotatedCode *codeDecompiled, ut64 offset) {
     size_t closestPos = SIZE_MAX;
     ut64 closestOffset = UT64_MAX;
@@ -259,8 +237,6 @@ void DecompilerWidget::decompilationFinished(RAnnotatedCode *codeDecompiled)
     ui->decompilerComboBox->setEnabled(decompilerSelectionEnabled);
     updateRefreshButton();
 
-    // this->code = codeDecompiled;
-    // this->code = std::make_shared<RAnnotatedCode>(codeDecompiled);
     this->code = std::unique_ptr<RAnnotatedCode>(codeDecompiled);
     QString codeString = QString::fromUtf8(this->code->code);
     if (codeString.isEmpty()) {
@@ -279,22 +255,6 @@ void DecompilerWidget::decompilationFinished(RAnnotatedCode *codeDecompiled)
         decompilerWasBusy = false;
         doAutoRefresh();
     }
-    // if (code.code.isEmpty()) {
-    //     ui->textEdit->setPlainText(tr("Cannot decompile at this address (Not a function?)"));
-    //     return;
-    // } else {
-    //     connectCursorPositionChanged(true);
-    //     ui->textEdit->setPlainText(code.code);
-    //     connectCursorPositionChanged(false);
-    //     updateCursorPosition();
-    //     highlightPC();
-    //     highlightBreakpoints();
-    // }
-
-    // if (decompilerWasBusy) {
-    //     decompilerWasBusy = false;
-    //     doAutoRefresh();
-    // }
 }
 
 void DecompilerWidget::decompilerSelected()
@@ -324,7 +284,6 @@ void DecompilerWidget::cursorPositionChanged()
 
     size_t pos = ui->textEdit->textCursor().position();
     RVA offset = offsetForPosition(code.get(), pos);
-    // RVA offset = 10; //Temp 
     if (offset != RVA_INVALID && offset != Core()->getOffset()) {
         seekFromCursor = true;
         Core()->seek(offset);
@@ -355,7 +314,6 @@ void DecompilerWidget::updateCursorPosition()
 {
     RVA offset = Core()->getOffset();
     size_t pos = positionForOffset(code.get(), offset);
-    // size_t pos = 12; //TEMP
     if (pos == SIZE_MAX) {
         return;
     }
@@ -433,7 +391,6 @@ bool DecompilerWidget::eventFilter(QObject *obj, QEvent *event)
 
     return MemoryDockWidget::eventFilter(obj, event);
 }
-
 
 void DecompilerWidget::highlightPC()
 {

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -14,7 +14,6 @@
 #include <QTextBlock>
 #include <QObject>
 #include <QTextBlockUserData>
-#include <QString>
 
 DecompilerWidget::DecompilerWidget(MainWindow *main) :
     MemoryDockWidget(MemoryWidgetType::Decompiler, main),

--- a/src/widgets/DecompilerWidget.h
+++ b/src/widgets/DecompilerWidget.h
@@ -101,6 +101,12 @@ private:
      * It will also run when a breakpoint is added, removed or modified.
      */
     void highlightBreakpoints();
+
+
+    //New Functions
+    ut64 offsetForPosition(RAnnotatedCode *codeDecompiled, size_t pos);
+    size_t positionForOffset(RAnnotatedCode *codeDecompiled, ut64 offset);
+    //;
 };
 
 #endif // DECOMPILERWIDGET_H

--- a/src/widgets/DecompilerWidget.h
+++ b/src/widgets/DecompilerWidget.h
@@ -56,8 +56,7 @@ private:
     bool decompilerWasBusy;
 
     RVA decompiledFunctionAddr;
-    std::unique_ptr<RAnnotatedCode> code;
-
+    std::unique_ptr<RAnnotatedCode, std::function<void(RAnnotatedCode*)>> code;
     bool seekFromCursor = false;
 
     Decompiler *getCurrentDecompiler();

--- a/src/widgets/DecompilerWidget.h
+++ b/src/widgets/DecompilerWidget.h
@@ -56,7 +56,7 @@ private:
     bool decompilerWasBusy;
 
     RVA decompiledFunctionAddr;
-    std::unique_ptr<RAnnotatedCode, std::function<void(RAnnotatedCode*)>> code;
+    std::unique_ptr<RAnnotatedCode, void (*)(RAnnotatedCode*)> code;
     bool seekFromCursor = false;
 
     Decompiler *getCurrentDecompiler();

--- a/src/widgets/DecompilerWidget.h
+++ b/src/widgets/DecompilerWidget.h
@@ -7,6 +7,7 @@
 #include "core/Cutter.h"
 #include "MemoryDockWidget.h"
 #include "Decompiler.h"
+#include <r_util/r_annotated_code.h>//For RAnnotatedCode
 
 namespace Ui {
 class DecompilerWidget;
@@ -104,8 +105,8 @@ private:
 
 
     //New Functions
-    ut64 offsetForPosition(RAnnotatedCode *codeDecompiled, size_t pos);
-    size_t positionForOffset(RAnnotatedCode *codeDecompiled, ut64 offset);
+    // ut64 offsetForPosition(RAnnotatedCode *codeDecompiled, size_t pos);
+    // size_t positionForOffset(RAnnotatedCode *codeDecompiled, ut64 offset);
     //;
 };
 

--- a/src/widgets/DecompilerWidget.h
+++ b/src/widgets/DecompilerWidget.h
@@ -38,7 +38,7 @@ private slots:
     void decompilerSelected();
     void cursorPositionChanged();
     void seekChanged();
-    void decompilationFinished(AnnotatedCode code);
+    void decompilationFinished(RAnnotatedCode *code);
 
 private:
     std::unique_ptr<Ui::DecompilerWidget> ui;

--- a/src/widgets/DecompilerWidget.h
+++ b/src/widgets/DecompilerWidget.h
@@ -57,8 +57,6 @@ private:
     bool decompilerWasBusy;
 
     RVA decompiledFunctionAddr;
-    // RAnnotatedCode *code;
-    // std::shared_ptr<RAnnotatedCode> code;
     std::unique_ptr<RAnnotatedCode> code;
 
     bool seekFromCursor = false;
@@ -103,11 +101,6 @@ private:
      */
     void highlightBreakpoints();
 
-
-    //New Functions
-    // ut64 offsetForPosition(RAnnotatedCode *codeDecompiled, size_t pos);
-    // size_t positionForOffset(RAnnotatedCode *codeDecompiled, ut64 offset);
-    //;
 };
 
 #endif // DECOMPILERWIDGET_H

--- a/src/widgets/DecompilerWidget.h
+++ b/src/widgets/DecompilerWidget.h
@@ -56,7 +56,8 @@ private:
     bool decompilerWasBusy;
 
     RVA decompiledFunctionAddr;
-    AnnotatedCode code;
+    // RAnnotatedCode *code;
+    std::shared_ptr<RAnnotatedCode> code;
 
     bool seekFromCursor = false;
 

--- a/src/widgets/DecompilerWidget.h
+++ b/src/widgets/DecompilerWidget.h
@@ -57,7 +57,8 @@ private:
 
     RVA decompiledFunctionAddr;
     // RAnnotatedCode *code;
-    std::shared_ptr<RAnnotatedCode> code;
+    // std::shared_ptr<RAnnotatedCode> code;
+    std::unique_ptr<RAnnotatedCode> code;
 
     bool seekFromCursor = false;
 

--- a/src/widgets/DecompilerWidget.h
+++ b/src/widgets/DecompilerWidget.h
@@ -7,7 +7,6 @@
 #include "core/Cutter.h"
 #include "MemoryDockWidget.h"
 #include "Decompiler.h"
-#include <r_util/r_annotated_code.h>//For RAnnotatedCode
 
 namespace Ui {
 class DecompilerWidget;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/developers-docs/first-time.html) to this repository
- [ ] I made sure to follow the project's [coding style](https://cutter.re/docs/developers-docs.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**
This PR refactors decompiler widget and r2dec cutter plugin to use RAnnotatedCode instead of the custom AnnotatedCode we have been using. Using RAnnotatedCode will enable us to have more data about the decompiled code that is essential for a good decompiler.

The following are the major changes I have made.

1. Refactored `R2Dec::decompileAt()` to emit `RAnnotatedCode*`.
2. Deleted structures `AnnotatedCode`, `CodeAnnotation`, and functions that made to handle these structures.
3. Used a smart pointer to represent code in `DecompilerWidget`
`std::unique_ptr<RAnnotatedCode> code;`
4. Refactored slot `decompilationFinished(AnnotatedCode code)` to `decompilationFinished(RAnnotatedCode *code)`
5. Made two static functions `static ut64 offsetForPosition(RAnnotatedCode *codeDecompiled, size_t pos)` and `static size_t positionForOffset(RAnnotatedCode *codeDecompiled, ut64 offset)`. These are the corresponding functions that were deleted from `AnnotatedCode`. Made required changes in all functions that use these two functions.
 

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->
Use only R2Dec decompiler for these tests, other decompilers are outside the scope of this PR.
1. Fetch the PR and compile it.
2. Open the decompiler widget and make sure that the correct decompiled code is being shown while you select offsets from functions and other widgets.
3. Make sure that the decompiler widget is seeking the correct address while clicking on functions(and other offsets) in the decompiler widget.
4. Make sure that invalid offsets are not causing Segmentation Fault.


<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Notes**
Merge all these three PRs together to ensure smooth functioning of all decompilers.
Refactored decompiler widget and R2Dec plugin: [Cutter #2227 ](https://github.com/radareorg/cutter/pull/2227)
Refactored R2Ghidra plugin that emits RAnnotatedCode: [R2Ghidra-dec #112](https://github.com/radareorg/r2ghidra-dec/pull/112)
Refactored retdec plugin that emits RAnnotatedCode:[ Florian's fork #1](https://github.com/thestr4ng3r/retdec-r2plugin/pull/1), after this PR is verified, I will send it to retdec's repo.

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
