### PR TITLE
Fix qt>5.14 build

### DIFF
--- a/src/widgets/ColorPicker.cpp
+++ b/src/widgets/ColorPicker.cpp
@@ -3,6 +3,7 @@
 
 #include <QPaintEvent>
 #include <QPainter>
+#include <QPainterPath>
 #include <QMouseEvent>
 #include <QDesktopWidget>
 #include <QPixmap>

--- a/src/widgets/ColorThemeListView.cpp
+++ b/src/widgets/ColorThemeListView.cpp
@@ -3,6 +3,7 @@
 #include <QJsonArray>
 #include <QMap>
 #include <QPainter>
+#include <QPainterPath>
 #include <QFontMetrics>
 #include <QScreen>
 #include <QJsonArray>

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -14,6 +14,7 @@
 #include <QRegularExpression>
 #include <QTextBlockUserData>
 #include <QPainter>
+#include <QPainterPath>
 #include <QSplitter>
 
 


### PR DESCRIPTION
Have some trouble building with qt:5.15.0 {os:Linux,distro:Arch,gcc:10.1.0}
GCC complains about incomplete type `QPainterPath`
Including `<qPainterPath>` fixes the issue.
```cpp
/build/radare2-cutter-git/src/radare2-cutter-git/src/widgets/ColorPicker.cpp:143:18: error: aggregate ‘QPainterPath path’ has incomplete type and cannot be defined
  143 |     QPainterPath path;
      |                  ^~~~
/build/radare2-cutter-git/src/radare2-cutter-git/src/widgets/ColorPicker.cpp: In member function ‘virtual void ColorPickerHelpers::AlphaChannelBar::paintEvent(QPaintEvent*)’:
/build/radare2-cutter-git/src/radare2-cutter-git/src/widgets/ColorPicker.cpp:417:18: error: aggregate ‘QPainterPath path’ has incomplete type and cannot be defined
  417 |     QPainterPath path;
      |                  ^~~~
...
/build/radare2-cutter-git/src/radare2-cutter-git/src/widgets/DisassemblyWidget.cpp:920:26: error: aggregate ‘QPainterPath arrow’ has incomplete type and cannot be defined
  920 |             QPainterPath arrow;
      |                          ^~~~~
...
/build/radare2-cutter-git/src/radare2-cutter-git/src/widgets/ColorThemeListView.cpp:132:18: error: aggregate ‘QPainterPath roundedOptionRect’ has incomplete type and cannot be defined
  132 |     QPainterPath roundedOptionRect;
      |                  ^~~~~~~~~~~~~~~~~
/build/radare2-cutter-git/src/radare2-cutter-git/src/widgets/ColorThemeListView.cpp:137:18: error: aggregate ‘QPainterPath roundedColorRect’ has incomplete type and cannot be defined
  137 |     QPainterPath roundedColorRect;
```

