### PR TITLE
Fix mismatch parenthesis "Auto Analysis (experimental}"

### DIFF
--- a/src/dialogs/InitialOptionsDialog.cpp
+++ b/src/dialogs/InitialOptionsDialog.cpp
@@ -281,7 +281,7 @@ void InitialOptionsDialog::setupAndStartAnalysis(/*int level, QList<QString> adv
         options.analCmd = { {"aaa", "Auto analysis"} };
         break;
     case 2:
-        options.analCmd = { {"aaaa", "Auto analysis (experimental}"} };
+        options.analCmd = { {"aaaa", "Auto analysis (experimental)"} };
         break;
     case 3:
         options.analCmd = getSelectedAdvancedAnalCmds();


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/developers-docs/first-time.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/developers-docs.html)
- [ ]  ~~I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)~~ No changes to document

**Detailed description**

When analysising progress messages are drawn from `InitialOptionsDialog.cpp` for some reason Auto Analysis (experimental**}** was used instead of a **)**.

**Test plan (required)**

Here is the change as a screenshot

![image](https://user-images.githubusercontent.com/355742/83695080-50d41880-a5f1-11ea-9f6c-bb2f7c9ba831.png)

