### PR TITLE
Improve warning for multiple x-refs causing unexpected behavior

### DIFF
--- a/src/common/CutterSeekable.cpp
+++ b/src/common/CutterSeekable.cpp
@@ -75,7 +75,7 @@ void CutterSeekable::seekToReference(RVA offset)
     
     if (refs.length()) {
         if (refs.length() > 1) {
-            qWarning() << tr("Too many (%1) references here. Weird behaviour expected.")
+            qWarning() << tr("More than one (%1) references here. Weird behaviour expected.")
                             .arg(refs.length());
         }
         

--- a/src/common/CutterSeekable.cpp
+++ b/src/common/CutterSeekable.cpp
@@ -75,7 +75,8 @@ void CutterSeekable::seekToReference(RVA offset)
     
     if (refs.length()) {
         if (refs.length() > 1) {
-            qWarning() << "Too many references here. Weird behaviour expected.";
+            qWarning() << tr("Too many (%1) references here. Weird behaviour expected.")
+                            .arg(refs.length());
         }
         
         target = refs.at(0).to;


### PR DESCRIPTION
**Detailed description**
Minor fix to a warning that wasn't informative enough

