### PR TITLE
Expose asm.reloff.flags in Preferences

### DIFF
--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -130,6 +130,7 @@ static const QHash<QString, QVariant> asmOptions = {
     { "asm.refptr",         false },
     { "asm.flags.real",     true },
     { "asm.reloff",         false },
+    { "asm.reloff.flags",   false },
     { "esil.breakoninvalid",true },
     { "graph.offset",       false}
 };

--- a/src/dialogs/preferences/AsmOptionsWidget.cpp
+++ b/src/dialogs/preferences/AsmOptionsWidget.cpp
@@ -35,6 +35,7 @@ AsmOptionsWidget::AsmOptionsWidget(PreferencesDialog *dialog)
         { ui->indentCheckBox,       "asm.indent" },
         { ui->offsetCheckBox,       "asm.offset" },
         { ui->relOffsetCheckBox,    "asm.reloff" },
+        { ui->relOffFlagsCheckBox,  "asm.reloff.flags" },
         { ui->slowCheckBox,         "asm.slow" },
         { ui->linesCheckBox,        "asm.lines" },
         { ui->fcnlinesCheckBox,     "asm.lines.fcn" },
@@ -62,6 +63,7 @@ AsmOptionsWidget::AsmOptionsWidget(PreferencesDialog *dialog)
     connect(ui->asmComboBox, static_cast<indexSignalType>(&QComboBox::currentIndexChanged), this,
                 &AsmOptionsWidget::asmComboBoxChanged);
     connect(ui->offsetCheckBox, &QCheckBox::toggled, this, &AsmOptionsWidget::offsetCheckBoxToggled);
+    connect(ui->relOffsetCheckBox, &QCheckBox::toggled, this, &AsmOptionsWidget::relOffCheckBoxToggled);
     connect(Core(), SIGNAL(asmOptionsChanged()), this, SLOT(updateAsmOptionsFromVars()));
     updateAsmOptionsFromVars();
 }
@@ -79,6 +81,7 @@ void AsmOptionsWidget::updateAsmOptionsFromVars()
 
     bool offsetsEnabled = Config()->getConfigBool("asm.offset") || Config()->getConfigBool("graph.offset");
     ui->relOffsetCheckBox->setEnabled(offsetsEnabled);
+    ui->relOffFlagsCheckBox->setEnabled(Config()->getConfigBool("asm.offset") && Config()->getConfigBool("asm.reloff"));
 
     bool bytesEnabled = Config()->getConfigBool("asm.bytes");
     ui->bytespaceCheckBox->setEnabled(bytesEnabled);
@@ -264,6 +267,12 @@ void AsmOptionsWidget::asmComboBoxChanged(int index)
 void AsmOptionsWidget::offsetCheckBoxToggled(bool checked)
 {
     ui->relOffsetCheckBox->setEnabled(checked || Config()->getConfigBool("graph.offset"));
+    ui->relOffFlagsCheckBox->setEnabled(checked && Config()->getConfigBool("asm.reloff"));
+}
+
+void AsmOptionsWidget::relOffCheckBoxToggled(bool checked)
+{
+    ui->relOffFlagsCheckBox->setEnabled(checked && Config()->getConfigBool("asm.offset"));
 }
 
 /**

--- a/src/dialogs/preferences/AsmOptionsWidget.cpp
+++ b/src/dialogs/preferences/AsmOptionsWidget.cpp
@@ -80,6 +80,7 @@ void AsmOptionsWidget::updateAsmOptionsFromVars()
     ui->cmtcolSpinBox->setEnabled(cmtRightEnabled);
 
     bool offsetsEnabled = Config()->getConfigBool("asm.offset") || Config()->getConfigBool("graph.offset");
+    ui->relOffsetLabel->setEnabled(offsetsEnabled);
     ui->relOffsetCheckBox->setEnabled(offsetsEnabled);
     ui->relOffFlagsCheckBox->setEnabled(Config()->getConfigBool("asm.offset") && Config()->getConfigBool("asm.reloff"));
 
@@ -266,6 +267,7 @@ void AsmOptionsWidget::asmComboBoxChanged(int index)
 
 void AsmOptionsWidget::offsetCheckBoxToggled(bool checked)
 {
+    ui->relOffsetLabel->setEnabled(checked || Config()->getConfigBool("graph.offset"));
     ui->relOffsetCheckBox->setEnabled(checked || Config()->getConfigBool("graph.offset"));
     ui->relOffFlagsCheckBox->setEnabled(checked && Config()->getConfigBool("asm.reloff"));
 }

--- a/src/dialogs/preferences/AsmOptionsWidget.h
+++ b/src/dialogs/preferences/AsmOptionsWidget.h
@@ -53,6 +53,7 @@ private slots:
     void commentsComboBoxChanged(int index);
     void asmComboBoxChanged(int index);
     void offsetCheckBoxToggled(bool checked);
+    void relOffCheckBoxToggled(bool checked);
     void checkboxEnabler(QCheckBox *checkbox, QString config);
 };
 

--- a/src/dialogs/preferences/AsmOptionsWidget.ui
+++ b/src/dialogs/preferences/AsmOptionsWidget.ui
@@ -65,7 +65,7 @@
                 <string>Disassembly</string>
                </property>
                <layout class="QGridLayout" name="gridLayout">
-                <item row="10" column="2">
+                <item row="11" column="2">
                  <widget class="QSpinBox" name="nbytesSpinBox">
                   <property name="enabled">
                    <bool>true</bool>

--- a/src/dialogs/preferences/AsmOptionsWidget.ui
+++ b/src/dialogs/preferences/AsmOptionsWidget.ui
@@ -254,7 +254,7 @@
                 <item row="8" column="1">
                  <layout class="QHBoxLayout" name="horizontalLayout">
                   <item>
-                   <widget class="QLabel" name="label_3">
+                   <widget class="QLabel" name="relOffsetLabel">
                     <property name="text">
                      <string>Show offsets relative to:</string>
                     </property>

--- a/src/dialogs/preferences/AsmOptionsWidget.ui
+++ b/src/dialogs/preferences/AsmOptionsWidget.ui
@@ -72,7 +72,7 @@
                   </property>
                  </widget>
                 </item>
-                <item row="10" column="1">
+                <item row="11" column="1">
                  <widget class="QLabel" name="nbytesLabel">
                   <property name="enabled">
                    <bool>true</bool>
@@ -85,7 +85,7 @@
                   </property>
                  </widget>
                 </item>
-                <item row="14" column="1">
+                <item row="15" column="1">
                  <widget class="QLabel" name="asmTabsOffLabel">
                   <property name="text">
                    <string>Tabs before assembly (asm.tabs.off):</string>
@@ -105,7 +105,7 @@
                   </property>
                  </widget>
                 </item>
-                <item row="14" column="2">
+                <item row="15" column="2">
                  <widget class="QSpinBox" name="asmTabsOffSpinBox">
                   <property name="maximum">
                    <number>100</number>
@@ -115,21 +115,21 @@
                   </property>
                  </widget>
                 </item>
-                <item row="17" column="1" colspan="2">
+                <item row="18" column="1" colspan="2">
                  <widget class="QCheckBox" name="bytespaceCheckBox">
                   <property name="text">
                    <string>Separate bytes with whitespace (asm.bytespace)</string>
                   </property>
                  </widget>
                 </item>
-                <item row="15" column="1" colspan="2">
+                <item row="16" column="1" colspan="2">
                  <widget class="QCheckBox" name="indentCheckBox">
                   <property name="text">
                    <string>Indent disassembly based on reflines depth (asm.indent)</string>
                   </property>
                  </widget>
                 </item>
-                <item row="13" column="2">
+                <item row="14" column="2">
                  <widget class="QSpinBox" name="asmTabsSpinBox">
                   <property name="maximum">
                    <number>100</number>
@@ -139,7 +139,7 @@
                   </property>
                  </widget>
                 </item>
-                <item row="13" column="1">
+                <item row="14" column="1">
                  <widget class="QLabel" name="asmTabsLabel">
                   <property name="text">
                    <string>Tabs in assembly (asm.tabs):</string>
@@ -149,7 +149,7 @@
                   </property>
                  </widget>
                 </item>
-                <item row="16" column="1" colspan="2">
+                <item row="17" column="1" colspan="2">
                  <widget class="QCheckBox" name="lbytesCheckBox">
                   <property name="text">
                    <string>Align bytes to the left (asm.lbytes)</string>
@@ -210,7 +210,7 @@
                   </item>
                  </widget>
                 </item>
-                <item row="12" column="1" colspan="2">
+                <item row="13" column="1" colspan="2">
                  <widget class="QCheckBox" name="bblineCheckBox">
                   <property name="text">
                    <string>Show empty line after every basic block (asm.bb.line)</string>
@@ -234,7 +234,7 @@
                   </property>
                  </widget>
                 </item>
-                <item row="9" column="1">
+                <item row="10" column="1">
                  <widget class="QCheckBox" name="bytesCheckBox">
                   <property name="text">
                    <string>Display the bytes of each instruction (asm.bytes)</string>
@@ -244,7 +244,7 @@
                 <item row="4" column="2">
                  <widget class="QComboBox" name="syntaxComboBox"/>
                 </item>
-                <item row="11" column="1">
+                <item row="12" column="1">
                  <widget class="QCheckBox" name="realnameCheckBox">
                   <property name="text">
                    <string>Display flags' real name (asm.flags.real)</string>
@@ -255,6 +255,13 @@
                  <widget class="QCheckBox" name="relOffsetCheckBox">
                   <property name="text">
                    <string>Show offsets relative to a function (asm.reloff)</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="9" column="1">
+                 <widget class="QCheckBox" name="relOffFlagsCheckBox">
+                  <property name="text">
+                   <string>Show offsets relative to a flag (asm.reloff.flags)</string>
                   </property>
                  </widget>
                 </item>

--- a/src/dialogs/preferences/AsmOptionsWidget.ui
+++ b/src/dialogs/preferences/AsmOptionsWidget.ui
@@ -65,33 +65,30 @@
                 <string>Disassembly</string>
                </property>
                <layout class="QGridLayout" name="gridLayout">
-                <item row="11" column="2">
-                 <widget class="QSpinBox" name="nbytesSpinBox">
-                  <property name="enabled">
-                   <bool>true</bool>
-                  </property>
-                 </widget>
-                </item>
                 <item row="11" column="1">
-                 <widget class="QLabel" name="nbytesLabel">
-                  <property name="enabled">
-                   <bool>true</bool>
-                  </property>
+                 <widget class="QCheckBox" name="bytesCheckBox">
                   <property name="text">
-                   <string>Number of bytes to display (asm.nbytes):</string>
+                   <string>Display the bytes of each instruction (asm.bytes)</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="4" column="1">
+                 <widget class="QLabel" name="syntaxLabel">
+                  <property name="text">
+                   <string>Syntax (asm.syntax):</string>
                   </property>
                   <property name="textInteractionFlags">
                    <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
                   </property>
                  </widget>
                 </item>
-                <item row="15" column="1">
-                 <widget class="QLabel" name="asmTabsOffLabel">
-                  <property name="text">
-                   <string>Tabs before assembly (asm.tabs.off):</string>
+                <item row="16" column="2">
+                 <widget class="QSpinBox" name="asmTabsOffSpinBox">
+                  <property name="maximum">
+                   <number>100</number>
                   </property>
-                  <property name="textInteractionFlags">
-                   <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+                  <property name="singleStep">
+                   <number>5</number>
                   </property>
                  </widget>
                 </item>
@@ -105,44 +102,13 @@
                   </property>
                  </widget>
                 </item>
-                <item row="15" column="2">
-                 <widget class="QSpinBox" name="asmTabsOffSpinBox">
-                  <property name="maximum">
-                   <number>100</number>
+                <item row="12" column="1">
+                 <widget class="QLabel" name="nbytesLabel">
+                  <property name="enabled">
+                   <bool>true</bool>
                   </property>
-                  <property name="singleStep">
-                   <number>5</number>
-                  </property>
-                 </widget>
-                </item>
-                <item row="18" column="1" colspan="2">
-                 <widget class="QCheckBox" name="bytespaceCheckBox">
                   <property name="text">
-                   <string>Separate bytes with whitespace (asm.bytespace)</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="16" column="1" colspan="2">
-                 <widget class="QCheckBox" name="indentCheckBox">
-                  <property name="text">
-                   <string>Indent disassembly based on reflines depth (asm.indent)</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="14" column="2">
-                 <widget class="QSpinBox" name="asmTabsSpinBox">
-                  <property name="maximum">
-                   <number>100</number>
-                  </property>
-                  <property name="singleStep">
-                   <number>5</number>
-                  </property>
-                 </widget>
-                </item>
-                <item row="14" column="1">
-                 <widget class="QLabel" name="asmTabsLabel">
-                  <property name="text">
-                   <string>Tabs in assembly (asm.tabs):</string>
+                   <string>Number of bytes to display (asm.nbytes):</string>
                   </property>
                   <property name="textInteractionFlags">
                    <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
@@ -150,9 +116,9 @@
                  </widget>
                 </item>
                 <item row="17" column="1" colspan="2">
-                 <widget class="QCheckBox" name="lbytesCheckBox">
+                 <widget class="QCheckBox" name="indentCheckBox">
                   <property name="text">
-                   <string>Align bytes to the left (asm.lbytes)</string>
+                   <string>Indent disassembly based on reflines depth (asm.indent)</string>
                   </property>
                  </widget>
                 </item>
@@ -172,23 +138,11 @@
                   </property>
                  </spacer>
                 </item>
-                <item row="5" column="2">
-                 <widget class="QComboBox" name="caseComboBox">
-                  <item>
-                   <property name="text">
-                    <string>Lowercase</string>
-                   </property>
-                  </item>
-                  <item>
-                   <property name="text">
-                    <string>Uppercase (asm.ucase)</string>
-                   </property>
-                  </item>
-                  <item>
-                   <property name="text">
-                    <string>Capitalize (asm.capitalize)</string>
-                   </property>
-                  </item>
+                <item row="12" column="2">
+                 <widget class="QSpinBox" name="nbytesSpinBox">
+                  <property name="enabled">
+                   <bool>true</bool>
+                  </property>
                  </widget>
                 </item>
                 <item row="3" column="2" colspan="2">
@@ -210,13 +164,6 @@
                   </item>
                  </widget>
                 </item>
-                <item row="13" column="1" colspan="2">
-                 <widget class="QCheckBox" name="bblineCheckBox">
-                  <property name="text">
-                   <string>Show empty line after every basic block (asm.bb.line)</string>
-                  </property>
-                 </widget>
-                </item>
                 <item row="7" column="1">
                  <widget class="QCheckBox" name="offsetCheckBox">
                   <property name="text">
@@ -224,44 +171,108 @@
                   </property>
                  </widget>
                 </item>
-                <item row="4" column="1">
-                 <widget class="QLabel" name="syntaxLabel">
+                <item row="16" column="1">
+                 <widget class="QLabel" name="asmTabsOffLabel">
                   <property name="text">
-                   <string>Syntax (asm.syntax):</string>
+                   <string>Tabs before assembly (asm.tabs.off):</string>
                   </property>
                   <property name="textInteractionFlags">
                    <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
                   </property>
                  </widget>
                 </item>
-                <item row="10" column="1">
-                 <widget class="QCheckBox" name="bytesCheckBox">
-                  <property name="text">
-                   <string>Display the bytes of each instruction (asm.bytes)</string>
-                  </property>
-                 </widget>
-                </item>
                 <item row="4" column="2">
                  <widget class="QComboBox" name="syntaxComboBox"/>
                 </item>
-                <item row="12" column="1">
+                <item row="14" column="1" colspan="2">
+                 <widget class="QCheckBox" name="bblineCheckBox">
+                  <property name="text">
+                   <string>Show empty line after every basic block (asm.bb.line)</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="5" column="2">
+                 <widget class="QComboBox" name="caseComboBox">
+                  <item>
+                   <property name="text">
+                    <string>Lowercase</string>
+                   </property>
+                  </item>
+                  <item>
+                   <property name="text">
+                    <string>Uppercase (asm.ucase)</string>
+                   </property>
+                  </item>
+                  <item>
+                   <property name="text">
+                    <string>Capitalize (asm.capitalize)</string>
+                   </property>
+                  </item>
+                 </widget>
+                </item>
+                <item row="18" column="1" colspan="2">
+                 <widget class="QCheckBox" name="lbytesCheckBox">
+                  <property name="text">
+                   <string>Align bytes to the left (asm.lbytes)</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="19" column="1" colspan="2">
+                 <widget class="QCheckBox" name="bytespaceCheckBox">
+                  <property name="text">
+                   <string>Separate bytes with whitespace (asm.bytespace)</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="13" column="1">
                  <widget class="QCheckBox" name="realnameCheckBox">
                   <property name="text">
                    <string>Display flags' real name (asm.flags.real)</string>
                   </property>
                  </widget>
                 </item>
-                <item row="8" column="1">
-                 <widget class="QCheckBox" name="relOffsetCheckBox">
+                <item row="15" column="1">
+                 <widget class="QLabel" name="asmTabsLabel">
                   <property name="text">
-                   <string>Show offsets relative to a function (asm.reloff)</string>
+                   <string>Tabs in assembly (asm.tabs):</string>
+                  </property>
+                  <property name="textInteractionFlags">
+                   <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
                   </property>
                  </widget>
                 </item>
-                <item row="9" column="1">
+                <item row="15" column="2">
+                 <widget class="QSpinBox" name="asmTabsSpinBox">
+                  <property name="maximum">
+                   <number>100</number>
+                  </property>
+                  <property name="singleStep">
+                   <number>5</number>
+                  </property>
+                 </widget>
+                </item>
+                <item row="8" column="1">
+                 <layout class="QHBoxLayout" name="horizontalLayout">
+                  <item>
+                   <widget class="QLabel" name="label_3">
+                    <property name="text">
+                     <string>Show offsets relative to:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="relOffsetCheckBox">
+                    <property name="text">
+                     <string>Functions (asm.reloff)</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </item>
+                <item row="8" column="2">
                  <widget class="QCheckBox" name="relOffFlagsCheckBox">
                   <property name="text">
-                   <string>Show offsets relative to a flag (asm.reloff.flags)</string>
+                   <string>Flags (asm.reloff.flags)</string>
                   </property>
                  </widget>
                 </item>


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/developers-docs/first-time.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/developers-docs.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**
This PR adds `asm.reloff.flags` checkbox under *Preferences* -> *Disassembly*.

![asm-reloff-flags](https://user-images.githubusercontent.com/11215000/84417993-1cd1a680-ac34-11ea-9595-8918f1e7402c.gif)
<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

**Test plan (required)**
Go to *Preferences* -> *Disassembly* -> check *Show offsets relative to a flag (asm.reloff.flags)*

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->


<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
