### PR TITLE
Graph optimize

### DIFF
--- a/docs/doxygen-images/graph_grid_layout/layout_compacting.svg
+++ b/docs/doxygen-images/graph_grid_layout/layout_compacting.svg
@@ -1,0 +1,543 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="layout_compacting.svg"
+   id="svg33"
+   viewBox="0 0 266.6575 152.92204"
+   version="1.2"
+   height="203.89606"
+   width="355.54333">
+  <metadata
+     id="metadata37">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     lock-margins="true"
+     fit-margin-bottom="10"
+     fit-margin-right="10"
+     fit-margin-left="10"
+     fit-margin-top="10"
+     inkscape:current-layer="svg33"
+     inkscape:window-maximized="1"
+     inkscape:window-y="0"
+     inkscape:window-x="0"
+     inkscape:cy="120.22566"
+     inkscape:cx="319.30409"
+     inkscape:zoom="2.4621622"
+     inkscape:snap-midpoints="true"
+     inkscape:guide-bbox="true"
+     showguides="true"
+     inkscape:snap-object-midpoints="true"
+     showgrid="false"
+     id="namedview35"
+     inkscape:window-height="1390"
+     inkscape:window-width="2560"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <defs
+     id="defs11">
+    <marker
+       orient="auto"
+       overflow="visible"
+       id="marker2914">
+      <path
+         id="path2"
+         stroke-width="1pt"
+         stroke="#005f87"
+         fill-rule="evenodd"
+         fill="#005f87"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         transform="matrix(-0.2,0,0,-0.2,-1.2,0)" />
+    </marker>
+    <marker
+       orient="auto"
+       overflow="visible"
+       id="marker2850">
+      <path
+         id="path5"
+         stroke-width="1pt"
+         stroke="#5f8700"
+         fill-rule="evenodd"
+         fill="#5f8700"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         transform="matrix(-0.2,0,0,-0.2,-1.2,0)" />
+    </marker>
+    <marker
+       orient="auto"
+       overflow="visible"
+       id="marker2786">
+      <path
+         id="path8"
+         stroke-width="1pt"
+         stroke="#e03030"
+         fill-rule="evenodd"
+         fill="#e03030"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         transform="matrix(-0.2,0,0,-0.2,-1.2,0)" />
+    </marker>
+    <marker
+       id="marker2786-3"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="matrix(-0.2,0,0,-0.2,-1.2,0)"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         fill="#e03030"
+         fill-rule="evenodd"
+         stroke="#e03030"
+         stroke-width="1pt"
+         id="path8-6" />
+    </marker>
+    <marker
+       id="marker2850-7"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="matrix(-0.2,0,0,-0.2,-1.2,0)"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         fill="#5f8700"
+         fill-rule="evenodd"
+         stroke="#5f8700"
+         stroke-width="1pt"
+         id="path5-5" />
+    </marker>
+    <marker
+       id="marker2914-1"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="matrix(-0.2,0,0,-0.2,-1.2,0)"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         fill="#005f87"
+         fill-rule="evenodd"
+         stroke="#005f87"
+         stroke-width="1pt"
+         id="path2-2" />
+    </marker>
+    <marker
+       orient="auto"
+       overflow="visible"
+       id="marker2914-1-3">
+      <path
+         id="path2-2-6"
+         stroke-width="1pt"
+         stroke="#005f87"
+         fill-rule="evenodd"
+         fill="#005f87"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         transform="matrix(-0.2,0,0,-0.2,-1.2,0)" />
+    </marker>
+    <marker
+       orient="auto"
+       overflow="visible"
+       id="marker2914-1-6">
+      <path
+         id="path2-2-2"
+         stroke-width="1pt"
+         stroke="#005f87"
+         fill-rule="evenodd"
+         fill="#005f87"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         transform="matrix(-0.2,0,0,-0.2,-1.2,0)" />
+    </marker>
+    <marker
+       id="marker2914-8"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="matrix(-0.2,0,0,-0.2,-1.2,0)"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         fill="#005f87"
+         fill-rule="evenodd"
+         stroke="#005f87"
+         stroke-width="1pt"
+         id="path2-7" />
+    </marker>
+    <marker
+       id="marker2786-9"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="matrix(-0.2,0,0,-0.2,-1.2,0)"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         fill="#e03030"
+         fill-rule="evenodd"
+         stroke="#e03030"
+         stroke-width="1pt"
+         id="path8-2" />
+    </marker>
+    <marker
+       id="marker2850-0"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="matrix(-0.2,0,0,-0.2,-1.2,0)"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         fill="#5f8700"
+         fill-rule="evenodd"
+         stroke="#5f8700"
+         stroke-width="1pt"
+         id="path5-2" />
+    </marker>
+    <marker
+       orient="auto"
+       overflow="visible"
+       id="marker2786-3-3">
+      <path
+         id="path8-6-6"
+         stroke-width="1pt"
+         stroke="#e03030"
+         fill-rule="evenodd"
+         fill="#e03030"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         transform="matrix(-0.2,0,0,-0.2,-1.2,0)" />
+    </marker>
+    <marker
+       orient="auto"
+       overflow="visible"
+       id="marker2850-7-1">
+      <path
+         id="path5-5-2"
+         stroke-width="1pt"
+         stroke="#5f8700"
+         fill-rule="evenodd"
+         fill="#5f8700"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         transform="matrix(-0.2,0,0,-0.2,-1.2,0)" />
+    </marker>
+    <marker
+       orient="auto"
+       overflow="visible"
+       id="marker2914-1-9">
+      <path
+         id="path2-2-3"
+         stroke-width="1pt"
+         stroke="#005f87"
+         fill-rule="evenodd"
+         fill="#005f87"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         transform="matrix(-0.2,0,0,-0.2,-1.2,0)" />
+    </marker>
+    <marker
+       id="marker2914-1-3-1"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="matrix(-0.2,0,0,-0.2,-1.2,0)"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         fill="#005f87"
+         fill-rule="evenodd"
+         stroke="#005f87"
+         stroke-width="1pt"
+         id="path2-2-6-9" />
+    </marker>
+    <marker
+       id="marker2914-1-6-4"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="matrix(-0.2,0,0,-0.2,-1.2,0)"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         fill="#005f87"
+         fill-rule="evenodd"
+         stroke="#005f87"
+         stroke-width="1pt"
+         id="path2-2-2-7" />
+    </marker>
+  </defs>
+  <rect
+     x="19.86875"
+     y="20.397875"
+     width="101.07"
+     height="13.331"
+     stroke-width="0.1395"
+     id="rect13"
+     style="fill:#f5faff;fill-rule:evenodd;stroke:#91c8fa;stroke-linecap:square;stroke-linejoin:bevel" />
+  <rect
+     id="rect15"
+     height="9.3690996"
+     width="24.597"
+     y="38.912872"
+     x="58.105747"
+     style="fill:#f5faff;fill-rule:evenodd;stroke:#91c8fa;stroke-width:0.1395;stroke-linecap:square;stroke-linejoin:bevel" />
+  <rect
+     id="rect17"
+     height="9.3690996"
+     width="24.597"
+     y="52.641872"
+     x="7.5697498"
+     style="fill:#f5faff;fill-rule:evenodd;stroke:#91c8fa;stroke-width:0.1395;stroke-linecap:square;stroke-linejoin:bevel" />
+  <rect
+     id="rect19"
+     height="9.3690996"
+     width="24.597"
+     y="52.641872"
+     x="108.64275"
+     style="fill:#f5faff;fill-rule:evenodd;stroke:#91c8fa;stroke-width:0.1395;stroke-linecap:square;stroke-linejoin:bevel" />
+  <path
+     d="m 70.404751,33.721873 v 5.2398"
+     marker-end="url(#marker2914)"
+     stroke="#005f87"
+     stroke-width="0.75px"
+     id="path25"
+     style="fill:none" />
+  <path
+     d="m 68.750751,48.243873 v 1.8828 h -48.882 v 2.5231"
+     marker-end="url(#marker2786)"
+     stop-color="#000000"
+     stroke="#e03030"
+     stroke-miterlimit="2"
+     stroke-width="0.75"
+     style="font-variation-settings:normal;fill:none"
+     id="path27" />
+  <path
+     d="m 71.872751,48.256873 v 1.8696 h 49.067999 v 3.2324"
+     marker-end="url(#marker2850)"
+     stroke="#5f8700"
+     stroke-width="0.75px"
+     id="path29"
+     style="fill:none" />
+  <rect
+     style="fill:#f5faff;fill-rule:evenodd;stroke:#91c8fa;stroke-width:0.1395;stroke-linecap:square;stroke-linejoin:bevel"
+     x="206.91023"
+     y="7.5697498"
+     width="24.596998"
+     height="9.3690987"
+     id="rect15-3" />
+  <rect
+     style="fill:#f5faff;fill-rule:evenodd;stroke:#91c8fa;stroke-width:0.1395;stroke-linecap:square;stroke-linejoin:bevel"
+     x="181.84999"
+     y="20.957253"
+     width="24.596998"
+     height="28.024694"
+     id="rect17-5" />
+  <rect
+     style="fill:#f5faff;fill-rule:evenodd;stroke:#91c8fa;stroke-width:0.1395;stroke-linecap:square;stroke-linejoin:bevel"
+     x="234.49074"
+     y="21.999752"
+     width="24.596998"
+     height="9.3690987"
+     id="rect19-6" />
+  <path
+     sodipodi:nodetypes="cccc"
+     id="path27-2"
+     style="font-variation-settings:normal;fill:none;marker-end:url(#marker2786-3)"
+     stroke-width="0.75"
+     stroke-miterlimit="2"
+     stroke="#e03030"
+     stop-color="#000000"
+     marker-end="url(#marker2786-3)"
+     d="m 217.55525,16.90075 v 1.8828 h -24.43006 v 2.5231" />
+  <path
+     sodipodi:nodetypes="cccc"
+     style="fill:none;marker-end:url(#marker2850-7)"
+     id="path29-9"
+     stroke-width="0.75px"
+     stroke="#5f8700"
+     marker-end="url(#marker2850-7)"
+     d="m 220.67725,16.91375 v 1.8696 h 26.11198 v 3.2324" />
+  <rect
+     id="rect19-6-0"
+     height="9.3690987"
+     width="24.596998"
+     y="54.221745"
+     x="181.84999"
+     style="fill:#f5faff;fill-rule:evenodd;stroke:#91c8fa;stroke-width:0.1395;stroke-linecap:square;stroke-linejoin:bevel" />
+  <path
+     style="fill:none;marker-end:url(#marker2914-1)"
+     id="path25-7"
+     stroke-width="0.75px"
+     stroke="#005f87"
+     marker-end="url(#marker2914-1)"
+     d="m 194.14849,48.981943 v 5.2398" />
+  <rect
+     style="fill:#f5faff;fill-rule:evenodd;stroke:#91c8fa;stroke-width:0.1395;stroke-linecap:square;stroke-linejoin:bevel"
+     x="234.49074"
+     y="54.221745"
+     width="24.596998"
+     height="9.3690987"
+     id="rect19-6-0-9" />
+  <path
+     sodipodi:nodetypes="cc"
+     d="M 246.78923,31.368849 V 54.148584"
+     marker-end="url(#marker2914-1-3)"
+     stroke="#005f87"
+     stroke-width="0.75px"
+     id="path25-7-0"
+     style="fill:none;marker-end:url(#marker2914-1-3)" />
+  <rect
+     style="fill:#f5faff;fill-rule:evenodd;stroke:#91c8fa;stroke-width:0.1395;stroke-linecap:square;stroke-linejoin:bevel"
+     x="234.49074"
+     y="68.830635"
+     width="24.596998"
+     height="9.3690987"
+     id="rect19-6-0-6" />
+  <path
+     d="m 246.78923,63.590837 v 5.2398"
+     marker-end="url(#marker2914-1-6)"
+     stroke="#005f87"
+     stroke-width="0.75px"
+     id="path25-7-1"
+     style="fill:none;marker-end:url(#marker2914-1-6)" />
+  <rect
+     style="fill:#f5faff;fill-rule:evenodd;stroke:#91c8fa;stroke-linecap:square;stroke-linejoin:bevel"
+     id="rect13-3"
+     stroke-width="0.1395"
+     height="13.330999"
+     width="101.06999"
+     y="86.583054"
+     x="21.267822" />
+  <rect
+     style="fill:#f5faff;fill-rule:evenodd;stroke:#91c8fa;stroke-width:0.1395;stroke-linecap:square;stroke-linejoin:bevel"
+     x="59.50481"
+     y="105.09805"
+     width="24.596998"
+     height="9.3690987"
+     id="rect15-7" />
+  <rect
+     style="fill:#f5faff;fill-rule:evenodd;stroke:#91c8fa;stroke-width:0.1395;stroke-linecap:square;stroke-linejoin:bevel"
+     x="45.492069"
+     y="120.35294"
+     width="24.596998"
+     height="9.3690987"
+     id="rect17-59" />
+  <rect
+     style="fill:#f5faff;fill-rule:evenodd;stroke:#91c8fa;stroke-width:0.1395;stroke-linecap:square;stroke-linejoin:bevel"
+     x="73.206848"
+     y="120.35294"
+     width="24.596998"
+     height="9.3690987"
+     id="rect19-2" />
+  <path
+     style="fill:none;marker-end:url(#marker2914-8)"
+     id="path25-2"
+     stroke-width="0.75px"
+     stroke="#005f87"
+     marker-end="url(#marker2914-8)"
+     d="m 71.803816,99.907053 v 5.239787" />
+  <path
+     sodipodi:nodetypes="cccc"
+     id="path27-8"
+     style="font-variation-settings:normal;fill:none;marker-end:url(#marker2786-9)"
+     stroke-width="0.75"
+     stroke-miterlimit="2"
+     stroke="#e03030"
+     stop-color="#000000"
+     marker-end="url(#marker2786-9)"
+     d="m 70.149816,114.42904 v 1.8828 H 57.91528 v 3.82797" />
+  <path
+     sodipodi:nodetypes="cccc"
+     style="fill:none;marker-end:url(#marker2850-0)"
+     id="path29-97"
+     stroke-width="0.75px"
+     stroke="#5f8700"
+     marker-end="url(#marker2850-0)"
+     d="m 73.271816,114.44204 v 1.8696 h 12.721232 v 3.23241" />
+  <g
+     transform="translate(-35.90579,-13.250133)"
+     id="g1598">
+    <rect
+       style="fill:#f5faff;fill-rule:evenodd;stroke:#91c8fa;stroke-width:0.1395;stroke-linecap:square;stroke-linejoin:bevel"
+       x="241.84329"
+       y="102.58134"
+       width="24.596998"
+       height="9.3690987"
+       id="rect15-3-8" />
+    <rect
+       style="fill:#f5faff;fill-rule:evenodd;stroke:#91c8fa;stroke-width:0.1395;stroke-linecap:square;stroke-linejoin:bevel"
+       x="216.78305"
+       y="115.96884"
+       width="24.596998"
+       height="28.024693"
+       id="rect17-5-4" />
+    <rect
+       style="fill:#f5faff;fill-rule:evenodd;stroke:#91c8fa;stroke-width:0.1395;stroke-linecap:square;stroke-linejoin:bevel"
+       x="269.4238"
+       y="117.01134"
+       width="24.596998"
+       height="9.3690987"
+       id="rect19-6-5" />
+    <path
+       sodipodi:nodetypes="cccc"
+       id="path27-2-0"
+       style="font-variation-settings:normal;fill:none;marker-end:url(#marker2786-3-3)"
+       stroke-width="0.75"
+       stroke-miterlimit="2"
+       stroke="#e03030"
+       stop-color="#000000"
+       marker-end="url(#marker2786-3-3)"
+       d="m 252.48832,111.91234 v 1.8828 h -24.43006 v 2.5231" />
+    <path
+       sodipodi:nodetypes="cccc"
+       style="fill:none;marker-end:url(#marker2850-7-1)"
+       id="path29-9-3"
+       stroke-width="0.75px"
+       stroke="#5f8700"
+       marker-end="url(#marker2850-7-1)"
+       d="m 255.61032,111.92534 v 1.8696 h 26.11198 v 3.2324" />
+    <rect
+       id="rect19-6-0-61"
+       height="9.3690987"
+       width="24.596998"
+       y="149.23332"
+       x="216.78305"
+       style="fill:#f5faff;fill-rule:evenodd;stroke:#91c8fa;stroke-width:0.1395;stroke-linecap:square;stroke-linejoin:bevel" />
+    <path
+       style="fill:none;marker-end:url(#marker2914-1-9)"
+       id="path25-7-06"
+       stroke-width="0.75px"
+       stroke="#005f87"
+       marker-end="url(#marker2914-1-9)"
+       d="m 229.08156,143.99353 v 5.2398" />
+    <rect
+       style="fill:#f5faff;fill-rule:evenodd;stroke:#91c8fa;stroke-width:0.1395;stroke-linecap:square;stroke-linejoin:bevel"
+       x="269.4238"
+       y="130.94421"
+       width="24.596998"
+       height="9.3690987"
+       id="rect19-6-0-9-3" />
+    <path
+       sodipodi:nodetypes="cc"
+       d="m 281.7223,126.38044 v 4.19969"
+       marker-end="url(#marker2914-1-3-1)"
+       stroke="#005f87"
+       stroke-width="0.75px"
+       id="path25-7-0-2"
+       style="fill:none;marker-end:url(#marker2914-1-3-1)" />
+    <rect
+       style="fill:#f5faff;fill-rule:evenodd;stroke:#91c8fa;stroke-width:0.1395;stroke-linecap:square;stroke-linejoin:bevel"
+       x="269.4238"
+       y="145.55312"
+       width="24.596998"
+       height="9.3690987"
+       id="rect19-6-0-6-0" />
+    <path
+       d="m 281.7223,140.31331 v 5.2398"
+       marker-end="url(#marker2914-1-6-4)"
+       stroke="#005f87"
+       stroke-width="0.75px"
+       id="path25-7-1-6"
+       style="fill:none;marker-end:url(#marker2914-1-6-4)" />
+  </g>
+</svg>

--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -752,7 +752,7 @@ void Configuration::setGraphSpacing(QPoint blockSpacing, QPoint edgeSpacing)
 
 QPoint Configuration::getGraphBlockSpacing()
 {
-    return s.value("graph.blockSpacing", QPoint(10, 40)).value<QPoint>();
+    return s.value("graph.blockSpacing", QPoint(20, 40)).value<QPoint>();
 }
 
 QPoint Configuration::getGraphEdgeSpacing()

--- a/src/common/LinkedListPool.h
+++ b/src/common/LinkedListPool.h
@@ -150,7 +150,7 @@ public:
      * @brief Split list and return first half.
      *
      * @param list The list that needs to be split.
-     * @param last Iterator to the first item that should not be included in returned list. Needs to be within \a list .
+     * @param end Iterator to the first item that should not be included in returned list. Needs to be within \a list .
      * @return Returns prefix of \a list.
      */
     List splitHead(const List &list, const ListIterator &end)

--- a/src/common/LinkedListPool.h
+++ b/src/common/LinkedListPool.h
@@ -24,30 +24,6 @@ class LinkedListPool
     };
 public:
     /**
-     * @brief Single list within LinkedListPool.
-     *
-     * List only refers to chain of elements. Copying it doesn't copy any element. Item data is owned by
-     * LinkedListPool.
-     *
-     * Use LinkedListPool::makeList to create non-empty list.
-     */
-    class List
-    {
-        IndexType head = 0;
-        IndexType tail = 0;
-        friend class LinkedListPool;
-        List(IndexType head, IndexType tail)
-            : head(head)
-            , tail(tail)
-        {}
-    public:
-        /**
-         * @brief Create an empty list
-         */
-        List() = default;
-    };
-
-    /**
      * @brief List iterator.
      *
      * Iterators don't get invalidated by adding items to list, but the items may be relocated.
@@ -73,6 +49,11 @@ public:
         {
             return pool->data[index].value;
         }
+        pointer operator->()
+        {
+            return &pool->data[index].value;
+        }
+
         ListIterator &operator++()
         {
             index = pool->data[index].next;
@@ -91,9 +72,38 @@ public:
         /**
          * @brief Test if iterator points to valid value.
          */
-        operator bool() const
+        explicit operator bool() const
         {
             return index;
+        }
+    };
+
+    /**
+     * @brief Single list within LinkedListPool.
+     *
+     * List only refers to chain of elements. Copying it doesn't copy any element. Item data is owned by
+     * LinkedListPool.
+     *
+     * Use LinkedListPool::makeList to create non-empty list.
+     */
+    class List
+    {
+        IndexType head = 0;
+        IndexType tail = 0;
+        friend class LinkedListPool;
+        List(IndexType head, IndexType tail)
+            : head(head)
+            , tail(tail)
+        {}
+    public:
+        /**
+         * @brief Create an empty list
+         */
+        List() = default;
+
+        bool isEmpty() const
+        {
+            return head == 0;
         }
     };
 
@@ -137,6 +147,29 @@ public:
     }
 
     /**
+     * @brief Split list and return first half.
+     *
+     * @param list The list that needs to be split.
+     * @param last Iterator to the first item that should not be included in returned list. Needs to be within \a list .
+     * @return Returns prefix of \a list.
+     */
+    List splitHead(const List &list, const ListIterator &end)
+    {
+        if (!end) {
+            return list;
+        }
+        if (end.index == list.head) {
+            return {};
+        }
+        auto last = list.head;
+        while (data[last].next != end.index) {
+            last = data[last].next;
+        }
+        data[last].next = 0;
+        return List {list.head, last};
+    }
+
+    /**
      * @brief Create list iterator from list.
      * @param list
      * @return Iterator pointing to the first item in the list.
@@ -153,6 +186,12 @@ public:
 
     List append(const List &head, const List &tail)
     {
+        if (head.isEmpty()) {
+            return tail;
+        }
+        if (tail.isEmpty()) {
+            return head;
+        }
         List result{head.head, tail.tail};
         data[head.tail].next = tail.head;
         return result;

--- a/src/dialogs/preferences/GraphOptionsWidget.cpp
+++ b/src/dialogs/preferences/GraphOptionsWidget.cpp
@@ -41,6 +41,12 @@ void GraphOptionsWidget::updateOptionsFromVars()
     ui->maxColsSpinBox->blockSignals(true);
     ui->maxColsSpinBox->setValue(Config()->getGraphBlockMaxChars());
     ui->maxColsSpinBox->blockSignals(false);
+    auto blockSpacing = Config()->getGraphBlockSpacing();
+    ui->horizontalBlockSpacing->setValue(blockSpacing.x());
+    ui->verticalBlockSpacing->setValue(blockSpacing.y());
+    auto edgeSpacing = Config()->getGraphEdgeSpacing();
+    ui->horizontalEdgeSpacing->setValue(edgeSpacing.x());
+    ui->verticalEdgeSpacing->setValue(edgeSpacing.y());
 }
 
 

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -38,6 +38,12 @@ const int DisassemblerGraphView::KEY_ZOOM_IN = Qt::Key_Plus + Qt::ControlModifie
 const int DisassemblerGraphView::KEY_ZOOM_OUT = Qt::Key_Minus + Qt::ControlModifier;
 const int DisassemblerGraphView::KEY_ZOOM_RESET = Qt::Key_Equal + Qt::ControlModifier;
 
+#ifndef NDEBUG
+#define GRAPH_GRID_DEBUG_MODES true
+#else
+#define GRAPH_GRID_DEBUG_MODES false
+#endif
+
 DisassemblerGraphView::DisassemblerGraphView(QWidget *parent, CutterSeekable *seekable,
                                              MainWindow *mainWindow, QList<QAction *> additionalMenuActions)
     : GraphView(parent),
@@ -104,15 +110,16 @@ DisassemblerGraphView::DisassemblerGraphView(QWidget *parent, CutterSeekable *se
         , {tr("Grid medium"), GraphView::Layout::GridMedium}
         , {tr("Grid wide"), GraphView::Layout::GridWide}
 
-        , {tr("AAA"), GraphView::Layout::AAA}
-        , {tr("AAB"), GraphView::Layout::AAB}
-        , {tr("ABA"), GraphView::Layout::ABA}
-        , {tr("ABB"), GraphView::Layout::ABB}
-        , {tr("BAA"), GraphView::Layout::BAA}
-        , {tr("BAB"), GraphView::Layout::BAB}
-        , {tr("BBA"), GraphView::Layout::BBA}
-        , {tr("BBB"), GraphView::Layout::BBB}
-
+#if GRAPH_GRID_DEBUG_MODES
+        , {"GridAAA", GraphView::Layout::GridAAA}
+        , {"GridAAB", GraphView::Layout::GridAAB}
+        , {"GridABA", GraphView::Layout::GridABA}
+        , {"GridABB", GraphView::Layout::GridABB}
+        , {"GridBAA", GraphView::Layout::GridBAA}
+        , {"GridBAB", GraphView::Layout::GridBAB}
+        , {"GridBBA", GraphView::Layout::GridBBA}
+        , {"GridBBB", GraphView::Layout::GridBBB}
+#endif
 
 #ifdef CUTTER_ENABLE_GRAPHVIZ
         , {tr("Graphviz polyline"), GraphView::Layout::GraphvizPolyline}

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -103,6 +103,17 @@ DisassemblerGraphView::DisassemblerGraphView(QWidget *parent, CutterSeekable *se
         {tr("Grid narrow"), GraphView::Layout::GridNarrow}
         , {tr("Grid medium"), GraphView::Layout::GridMedium}
         , {tr("Grid wide"), GraphView::Layout::GridWide}
+
+        , {tr("AAA"), GraphView::Layout::AAA}
+        , {tr("AAB"), GraphView::Layout::AAB}
+        , {tr("ABA"), GraphView::Layout::ABA}
+        , {tr("ABB"), GraphView::Layout::ABB}
+        , {tr("BAA"), GraphView::Layout::BAA}
+        , {tr("BAB"), GraphView::Layout::BAB}
+        , {tr("BBA"), GraphView::Layout::BBA}
+        , {tr("BBB"), GraphView::Layout::BBB}
+
+
 #ifdef CUTTER_ENABLE_GRAPHVIZ
         , {tr("Graphviz polyline"), GraphView::Layout::GraphvizPolyline}
         , {tr("Graphviz ortho"), GraphView::Layout::GraphvizOrtho}

--- a/src/widgets/GraphGridLayout.cpp
+++ b/src/widgets/GraphGridLayout.cpp
@@ -975,7 +975,7 @@ void GraphGridLayout::elaborateEdgePlacement(GraphGridLayout::LayoutState &state
     edgeOffsets.resize(edgeIndex);
     calculateSegmentOffsets(segments, edgeOffsets, state.edgeColumnWidth, rightSides, leftSides,
                             state.columnWidth, 2 * state.rows + 1, layoutConfig.edgeHorizontalSpacing);
-    centerEdges(edgeOffsets, state.edgeColumnWidth, segments, layoutConfig.blockHorizontalSpacing);
+    centerEdges(edgeOffsets, state.edgeColumnWidth, segments, layoutConfig.edgeHorizontalSpacing);
     edgeIndex = 0;
 
     auto copySegmentsToEdges = [&](bool col) {

--- a/src/widgets/GraphGridLayout.cpp
+++ b/src/widgets/GraphGridLayout.cpp
@@ -162,14 +162,17 @@ GraphGridLayout::GraphGridLayout(GraphGridLayout::LayoutType layoutType)
     case LayoutType::Narrow:
         tightSubtreePlacement = true;
         parentBetweenDirectChild = false;
+        useLayoutOptimization = true;
         break;
     case LayoutType::Medium:
         tightSubtreePlacement = false;
-        parentBetweenDirectChild = false;
+        parentBetweenDirectChild = true;
+        useLayoutOptimization = true;
         break;
     case LayoutType::Wide:
         tightSubtreePlacement = false;
         parentBetweenDirectChild = true;
+        useLayoutOptimization = false;
         break;
     }
 }

--- a/src/widgets/GraphGridLayout.cpp
+++ b/src/widgets/GraphGridLayout.cpp
@@ -157,7 +157,6 @@ variables are grouped and changed together.
 
 GraphGridLayout::GraphGridLayout(GraphGridLayout::LayoutType layoutType)
     : GraphLayout({})
-    , layoutType(layoutType)
 {
     switch (layoutType) {
     case LayoutType::Narrow:

--- a/src/widgets/GraphGridLayout.cpp
+++ b/src/widgets/GraphGridLayout.cpp
@@ -274,6 +274,7 @@ void GraphGridLayout::CalculateLayout(GraphLayout::Graph &blocks, ut64 entry, in
         layoutState.edge[blockIt.first].resize(blockIt.second.edges.size());
         for (size_t i = 0; i < blockIt.second.edges.size(); i++) {
             layoutState.edge[blockIt.first][i].dest = blockIt.second.edges[i].target;
+            blockIt.second.edges[i].arrow = GraphEdge::Down;
         }
     }
     for (const auto &edgeList : layoutState.edge) {

--- a/src/widgets/GraphGridLayout.cpp
+++ b/src/widgets/GraphGridLayout.cpp
@@ -1203,7 +1203,7 @@ static void optimizeLinearProgram(
         if (direction == 0) {
             continue;
         }
-
+        processed[g] = 1;
         int limitingGroup = -1;
         if (direction < 0) {
             int minMove = INT_MAX;
@@ -1247,7 +1247,7 @@ static void optimizeLinearProgram(
             continue;;
         }
         joinSegmentGroups(limitingGroup, g);
-        queue.push({limitingGroup, edgeCount[limitingGroup]});
+        queue.push({edgeCount[limitingGroup], limitingGroup});
         equalities.push_back({{g, limitingGroup}, solution[g] - solution[limitingGroup]});
     }
     for (auto it = equalities.rbegin(), end = equalities.rend(); it != end; ++it) {
@@ -1344,7 +1344,7 @@ void GraphGridLayout::optimizeLayout(GraphGridLayout::LayoutState &state) const
        return a.x < b.x;
     });
     for (auto &segment : segments) {
-        auto startPos = lastSegments.upper_bound(segment.y0);
+        auto startPos = lastSegments.lower_bound(segment.y0);
         --startPos; // should never be lastSegment.begin() because map is initialized with segment at pos -1
         auto lastSegment = startPos->second;
         auto it = startPos;
@@ -1378,7 +1378,7 @@ void GraphGridLayout::optimizeLayout(GraphGridLayout::LayoutState &state) const
 
     optimizeLinearProgram(solution.size(), std::move(objectiveFunction), std::move(inequalities), std::move(equalities), solution);
 
-        variableIndex = segmentIndexOffset;
+    variableIndex = segmentIndexOffset;
     for (auto &blockIt : *state.blocks) {
         auto &block = blockIt.second;
         for (auto &edge : blockIt.second.edges) {

--- a/src/widgets/GraphGridLayout.h
+++ b/src/widgets/GraphGridLayout.h
@@ -19,7 +19,7 @@ public:
     };
 
     GraphGridLayout(LayoutType layoutType = LayoutType::Medium);
-    virtual void CalculateLayout(std::unordered_map<ut64, GraphBlock> &blocks,
+    virtual void CalculateLayout(Graph &blocks,
                                  ut64 entry,
                                  int &width,
                                  int &height) const override;
@@ -35,7 +35,7 @@ private:
     bool parentBetweenDirectChild = false;
     /// false if blocks in rows should be aligned at top, true for middle alignment
     bool verticalBlockAlignmentMiddle = false;
-    bool useLayoutOptimization = false;
+    bool useLayoutOptimization = true;
 
     struct GridBlock {
         ut64 id;
@@ -172,6 +172,13 @@ private:
      * @param height image height output argument
      */
     void convertToPixelCoordinates(LayoutState &state, int &width, int &height) const;
+    /**
+     * @brief Move the graph content to top left corner and update dimensions.
+     * @param graph
+     * @param width width after cropping
+     * @param height height after cropping
+     */
+    void cropToContent(Graph &graph, int &width, int &height) const;
     /**
      * @brief Connect edge ends to blocks by changing y.
      * @param graph

--- a/src/widgets/GraphGridLayout.h
+++ b/src/widgets/GraphGridLayout.h
@@ -47,6 +47,8 @@ private:
         /// Row in which the block is
         int row = 0;
 
+        ut64 mergeBlock = 0;
+
         int lastRowLeft; //!< left side of subtree last row
         int lastRowRight; //!< right side of subtree last row
         int leftPosition; //!< left side of subtree

--- a/src/widgets/GraphGridLayout.h
+++ b/src/widgets/GraphGridLayout.h
@@ -28,7 +28,6 @@ public:
     void setverticalBlockAlignmentMiddle(bool enabled) { verticalBlockAlignmentMiddle = enabled; }
     void setLayoutOptimization(bool enabled) { useLayoutOptimization = enabled; }
 private:
-    LayoutType layoutType;
     /// false - use bounding box for smallest subtree when placing them side by side
     bool tightSubtreePlacement = false;
     /// true if code should try to place parent between direct children as much as possible

--- a/src/widgets/GraphGridLayout.h
+++ b/src/widgets/GraphGridLayout.h
@@ -167,6 +167,11 @@ private:
      * @param height image height output argument
      */
     void convertToPixelCoordinates(LayoutState &state, int &width, int &height) const;
+    /**
+     * @brief Connect edge ends to blocks by changing y.
+     * @param graph
+     */
+    void connectEdgeEnds(Graph &graph) const;
     void optimizeLayout(LayoutState &state) const;
 };
 

--- a/src/widgets/GraphGridLayout.h
+++ b/src/widgets/GraphGridLayout.h
@@ -23,6 +23,10 @@ public:
                                  ut64 entry,
                                  int &width,
                                  int &height) const override;
+    void setTightSubtreePlacement(bool enabled) { tightSubtreePlacement = enabled; }
+    void setParentBetweenDirectChild(bool enabled) { parentBetweenDirectChild = enabled; }
+    void setverticalBlockAlignmentMiddle(bool enabled) { verticalBlockAlignmentMiddle = enabled; }
+    void setLayoutOptimization(bool enabled) { useLayoutOptimization = enabled; }
 private:
     LayoutType layoutType;
     /// false - use bounding box for smallest subtree when placing them side by side
@@ -31,6 +35,7 @@ private:
     bool parentBetweenDirectChild = false;
     /// false if blocks in rows should be aligned at top, true for middle alignment
     bool verticalBlockAlignmentMiddle = false;
+    bool useLayoutOptimization = false;
 
     struct GridBlock {
         ut64 id;
@@ -172,6 +177,10 @@ private:
      * @param graph
      */
     void connectEdgeEnds(Graph &graph) const;
+    /**
+     * @brief Reduce spacing between nodes and edges by pushing everything together ignoring the grid.
+     * @param state
+     */
     void optimizeLayout(LayoutState &state) const;
 };
 

--- a/src/widgets/GraphGridLayout.h
+++ b/src/widgets/GraphGridLayout.h
@@ -165,6 +165,7 @@ private:
      * @param height image height output argument
      */
     void convertToPixelCoordinates(LayoutState &state, int &width, int &height) const;
+    void optimizeLayout(LayoutState &state) const;
 };
 
 #endif // GRAPHGRIDLAYOUT_H

--- a/src/widgets/GraphLayout.h
+++ b/src/widgets/GraphLayout.h
@@ -33,7 +33,7 @@ public:
 
     struct LayoutConfig {
         int blockVerticalSpacing = 40;
-        int blockHorizontalSpacing = 10;
+        int blockHorizontalSpacing = 20;
         int edgeVerticalSpacing = 10;
         int edgeHorizontalSpacing = 10;
     };

--- a/src/widgets/GraphView.cpp
+++ b/src/widgets/GraphView.cpp
@@ -539,6 +539,23 @@ std::unique_ptr<GraphLayout> GraphView::makeGraphLayout(GraphView::Layout layout
     case Layout::GridWide:
         result.reset(new GraphGridLayout(GraphGridLayout::LayoutType::Wide));
         break;
+    case Layout::AAA:
+    case Layout::AAB:
+    case Layout::ABA:
+    case Layout::ABB:
+    case Layout::BAA:
+    case Layout::BAB:
+    case Layout::BBA:
+    case Layout::BBB:
+    {
+        int v = static_cast<int>(layout) - static_cast<int>(Layout::AAA);
+        std::unique_ptr<GraphGridLayout> gridLayout(new GraphGridLayout());
+        gridLayout->setTightSubtreePlacement((v & 1) == 0);
+        gridLayout->setParentBetweenDirectChild((v & 2));
+        gridLayout->setLayoutOptimization((v & 4));
+        result = std::move(gridLayout);
+        break;
+    }
 #ifdef CUTTER_ENABLE_GRAPHVIZ
     case Layout::GraphvizOrtho:
         result.reset(new GraphvizLayout(GraphvizLayout::LineType::Ortho,

--- a/src/widgets/GraphView.cpp
+++ b/src/widgets/GraphView.cpp
@@ -539,20 +539,20 @@ std::unique_ptr<GraphLayout> GraphView::makeGraphLayout(GraphView::Layout layout
     case Layout::GridWide:
         result.reset(new GraphGridLayout(GraphGridLayout::LayoutType::Wide));
         break;
-    case Layout::AAA:
-    case Layout::AAB:
-    case Layout::ABA:
-    case Layout::ABB:
-    case Layout::BAA:
-    case Layout::BAB:
-    case Layout::BBA:
-    case Layout::BBB:
+    case Layout::GridAAA:
+    case Layout::GridAAB:
+    case Layout::GridABA:
+    case Layout::GridABB:
+    case Layout::GridBAA:
+    case Layout::GridBAB:
+    case Layout::GridBBA:
+    case Layout::GridBBB:
     {
-        int v = static_cast<int>(layout) - static_cast<int>(Layout::AAA);
+        int options = static_cast<int>(layout) - static_cast<int>(Layout::GridAAA);
         std::unique_ptr<GraphGridLayout> gridLayout(new GraphGridLayout());
-        gridLayout->setTightSubtreePlacement((v & 1) == 0);
-        gridLayout->setParentBetweenDirectChild((v & 2));
-        gridLayout->setLayoutOptimization((v & 4));
+        gridLayout->setTightSubtreePlacement((options & 1) == 0);
+        gridLayout->setParentBetweenDirectChild((options & 2));
+        gridLayout->setLayoutOptimization((options & 4));
         result = std::move(gridLayout);
         break;
     }

--- a/src/widgets/GraphView.h
+++ b/src/widgets/GraphView.h
@@ -42,6 +42,14 @@ public:
         GridNarrow
         , GridMedium
         , GridWide
+        , AAA
+        , AAB
+        , ABA
+        , ABB
+        , BAA
+        , BAB
+        , BBA
+        , BBB
 #ifdef CUTTER_ENABLE_GRAPHVIZ
         , GraphvizOrtho
         , GraphvizPolyline

--- a/src/widgets/GraphView.h
+++ b/src/widgets/GraphView.h
@@ -42,14 +42,14 @@ public:
         GridNarrow
         , GridMedium
         , GridWide
-        , AAA
-        , AAB
-        , ABA
-        , ABB
-        , BAA
-        , BAB
-        , BBA
-        , BBB
+        , GridAAA
+        , GridAAB
+        , GridABA
+        , GridABB
+        , GridBAA
+        , GridBAB
+        , GridBBA
+        , GridBBB
 #ifdef CUTTER_ENABLE_GRAPHVIZ
         , GraphvizOrtho
         , GraphvizPolyline


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/developers-docs/first-time.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/developers-docs.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Add optional placement   optimization pass which tries to push everything together and ignores the grid after.  See details in the code documentation. It gets applied to wide narrow and medium modes.

The gridAAA, gridAAB, gridABA, ... modes were added mostly for preparing the comparison shots and choosing which configurations to expose as narrrow, medium, wide. They are not shown in release mode.

**Test plan (required)**


* Look at a bunch of different functions in graph view using . 
* Switch between horizontal and vertical layout 4 times, make sure arrow direction is correct
* Open graph options, change each spacing to unique value, reopen settings make sure values are correctly restored

Here are some before and after comparison.

![row_align](https://user-images.githubusercontent.com/7101031/85402071-be75c380-b563-11ea-9d2d-715f96d5572b.png)
![wide_column](https://user-images.githubusercontent.com/7101031/85402079-c2094a80-b563-11ea-8f7a-9e35afad6698.png)



<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
