### PR TITLE
Implemented No Results Found warning when search result is empty, now the user k…

### DIFF
--- a/src/widgets/SearchWidget.cpp
+++ b/src/widgets/SearchWidget.cpp
@@ -270,7 +270,7 @@ void SearchWidget::refreshSearch()
     search_model->beginResetModel();
     search = Core()->getAllSearch(search_for, searchspace);
     search_model->endResetModel();
-
+    
     qhelpers::adjustColumns(ui->searchTreeView, 3, 0);
 }
 

--- a/src/widgets/SearchWidget.cpp
+++ b/src/widgets/SearchWidget.cpp
@@ -261,6 +261,19 @@ void SearchWidget::refreshSearch()
     search_model->beginResetModel();
     search = Core()->getAllSearch(search_for, searchspace);
     search_model->endResetModel();
+    
+    // No Results Found Warning when search returns empty
+    // Warning Displays in the middle of the screen as a message box
+    // Warning also includes the searched phrase that resulted into an empyy search
+    if(search.isEmpty() && !search_for.isEmpty()){ 
+        QMessageBox msgBox;
+        QString warning="<b>";
+        warning.append("No Results Found:");
+        warning.append("</b><br>");
+        warning.append(search_for);
+        msgBox.setText(warning);
+        msgBox.exec();
+    }
 
     qhelpers::adjustColumns(ui->searchTreeView, 3, 0);
 }

--- a/src/widgets/SearchWidget.cpp
+++ b/src/widgets/SearchWidget.cpp
@@ -272,11 +272,11 @@ void SearchWidget::refreshSearch()
 void SearchWidget::checkSearchResultEmpty()
 {
     if (search.isEmpty()){ 
-        QString no_results_message="<b>";
-        no_results_message.append(tr("No results found for:"));
-        no_results_message.append("</b><br>");
-        no_results_message.append(ui->filterLineEdit->text().toHtmlEscaped());
-        QMessageBox::information(this, tr("No Results Found"), no_results_message);
+        QString noResultsMessage="<b>";
+        noResultsMessage.append(tr("No results found for:"));
+        noResultsMessage.append("</b><br>");
+        noResultsMessage.append(ui->filterLineEdit->text().toHtmlEscaped());
+        QMessageBox::information(this, tr("No Results Found"), noResultsMessage);
     }
 }
 

--- a/src/widgets/SearchWidget.cpp
+++ b/src/widgets/SearchWidget.cpp
@@ -263,7 +263,7 @@ void SearchWidget::refreshSearch()
     search_model->beginResetModel();
     search = Core()->getAllSearch(search_for, searchspace);
     search_model->endResetModel();
-    
+
     qhelpers::adjustColumns(ui->searchTreeView, 3, 0);
 }
 

--- a/src/widgets/SearchWidget.cpp
+++ b/src/widgets/SearchWidget.cpp
@@ -8,8 +8,6 @@
 #include <QComboBox>
 #include <QShortcut>
 
-#include <iostream>
-
 namespace {
 
 static const int kMaxTooltipWidth = 500;
@@ -51,9 +49,6 @@ int SearchModel::columnCount(const QModelIndex &) const
     return Columns::COUNT;
 }
 
-// Used for search result display
-// Data is for string, hexstring, 32-bit value
-// Code is for asm code and ROP Gadgets
 QVariant SearchModel::data(const QModelIndex &index, int role) const
 {
     if (index.row() >= search->count())
@@ -107,7 +102,6 @@ QVariant SearchModel::data(const QModelIndex &index, int role) const
     }
 }
 
-// Used for header of search results
 QVariant SearchModel::headerData(int section, Qt::Orientation, int role) const
 {
     switch (role) {
@@ -141,13 +135,11 @@ SearchSortFilterProxyModel::SearchSortFilterProxyModel(SearchModel *source_model
 {
 }
 
-// if return false doesn't display actually found results
 bool SearchSortFilterProxyModel::filterAcceptsRow(int row, const QModelIndex &parent) const
 {
     QModelIndex index = sourceModel()->index(row, 0, parent);
     SearchDescription search = index.data(
                                    SearchModel::SearchDescriptionRole).value<SearchDescription>();
-    //return false;
     return search.code.contains(filterRegExp());
 }
 
@@ -170,6 +162,7 @@ bool SearchSortFilterProxyModel::lessThan(const QModelIndex &left, const QModelI
     default:
         break;
     }
+
     return left_search.offset < right_search.offset;
 }
 

--- a/src/widgets/SearchWidget.cpp
+++ b/src/widgets/SearchWidget.cpp
@@ -270,7 +270,7 @@ void SearchWidget::refreshSearch()
     search_model->beginResetModel();
     search = Core()->getAllSearch(search_for, searchspace);
     search_model->endResetModel();
-    
+
     qhelpers::adjustColumns(ui->searchTreeView, 3, 0);
 }
 

--- a/src/widgets/SearchWidget.cpp
+++ b/src/widgets/SearchWidget.cpp
@@ -190,11 +190,13 @@ SearchWidget::SearchWidget(MainWindow *main) :
     QShortcut *enter_press = new QShortcut(QKeySequence(Qt::Key_Return), this);
     connect(enter_press, &QShortcut::activated, this, [this]() {
         refreshSearch();
+        checkSearchResultEmpty();
     });
     enter_press->setContext(Qt::WidgetWithChildrenShortcut);
 
     connect(ui->searchButton, &QAbstractButton::clicked, this, [this]() {
         refreshSearch();
+        checkSearchResultEmpty();
     });
 
     connect(ui->searchspaceCombo, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
@@ -262,20 +264,20 @@ void SearchWidget::refreshSearch()
     search = Core()->getAllSearch(search_for, searchspace);
     search_model->endResetModel();
     
-    // No Results Found Warning when search returns empty
-    // Warning Displays in the middle of the screen as a message box
-    // Warning also includes the searched phrase that resulted into an empyy search
-    if(search.isEmpty() && !search_for.isEmpty()){ 
-        QMessageBox msgBox;
-        QString warning="<b>";
-        warning.append("No Results Found:");
-        warning.append("</b><br>");
-        warning.append(search_for);
-        msgBox.setText(warning);
-        msgBox.exec();
-    }
-
     qhelpers::adjustColumns(ui->searchTreeView, 3, 0);
+}
+
+// No Results Found information message when search returns empty
+// Called by &QShortcut::activated and &QAbstractButton::clicked signals
+void SearchWidget::checkSearchResultEmpty()
+{
+    if (search.isEmpty()){ 
+        QString no_results_message="<b>";
+        no_results_message.append(tr("No results found for:"));
+        no_results_message.append("</b><br>");
+        no_results_message.append(CutterCore::ansiEscapeToHtml(ui->filterLineEdit->text()));
+        QMessageBox::information(this, tr("No Results Found"), no_results_message);
+    }
 }
 
 void SearchWidget::setScrollMode()

--- a/src/widgets/SearchWidget.h
+++ b/src/widgets/SearchWidget.h
@@ -81,6 +81,7 @@ private:
     QList<SearchDescription> search;
 
     void refreshSearch();
+    void checkSearchResultEmpty();
     void setScrollMode();
     void updatePlaceholderText(int index);
 };

--- a/src/widgets/SearchWidget.ui
+++ b/src/widgets/SearchWidget.ui
@@ -35,7 +35,7 @@
       <property name="styleSheet">
        <string notr="true">CutterTreeView::item
 {
-    padding-top: 1px;s
+    padding-top: 1px;
     padding-bottom: 1px;
 }</string>
       </property>
@@ -78,7 +78,6 @@
        </widget>
       </item>
       <item>
-<!--Change the string of this button from Search to Searching when searching-->
        <widget class="QPushButton" name="searchButton">
         <property name="text">
          <string>Search</string>


### PR DESCRIPTION
…nows the search is finished and no results are found instead of thinking search is still going on.



- [x]  I've read the [guidelines for contributing](https://cutter.re/docs/developers-docs/first-time.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/developers-docs.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)



**Detailed description**

Contributes to Issue #2161

The following issue was posted before: Indicate that search is in progress #2161. @ITAYC0HEN  had suggested that the search button should be converted to searching when the searching is being performed and users should get a warning message when no results are found to understand the search has been completed. I have implemented a warning message for the no results found situation, when the search returns empty. However, I was not able to convert the search button to searching when the search was being performed as suggested by @ITAYC0HEN. The reason for this is that async refactoring is needed, as mentioned by @karliss. I have tried many different ways to tackle the issue, however the results were the same, because the search and ui updates were performing on the same thread, the user couldn't observe the ui updates before the search finished.

**Test plan (required)**

The search behaviour is similar before except that when the search result is not found a warning message pops up in the middle of the screen. This warning message states that no results were found and also includes information about the search phrase that resulted in a no results found search, so that the user knows better what corresponded to an empty search. To test the warning message one can search a code or data string that is not contained in the open file, when the usser does so they will be able to see the no results found warning message in the middle of the screen. Below you can find screenshots of the screen.

<a href="https://ibb.co/PMGkM5T"><img src="https://i.ibb.co/Nr2RrL1/Screen-Shot-2020-06-19-at-6-53-18-PM.png" alt="Screen-Shot-2020-06-19-at-6-53-18-PM" border="0"></a>
**No Results Found Warning when the search returns empty**

<a href="https://ibb.co/G7V1V5x"><img src="https://i.ibb.co/p23s3L0/Screen-Shot-2020-06-19-at-6-52-45-PM.png" alt="Screen-Shot-2020-06-19-at-6-52-45-PM" border="0"></a><br /><a target='_blank' href='https://imgbb.com/'>kasa dolu</a><br />
**Regular search when the search returns non-empty. The warning message is not displayed because results are found**


**Closing issues**
Does not close Issue #2161, because search button conversion from search to searching is not yet implemented, still need async refactoring.
