### PR TITLE
Right-click updates cursor and opens context menu

### DIFF
--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -435,9 +435,7 @@ bool DecompilerWidget::eventFilter(QObject *obj, QEvent *event)
     if (event->type() == QEvent::MouseButtonDblClick
             && (obj == ui->textEdit || obj == ui->textEdit->viewport())) {
         QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
-
-        const QTextCursor &cursor = ui->textEdit->cursorForPosition(QPoint(mouseEvent->x(),
-                                                                           mouseEvent->y()));
+        ui->textEdit->cursorForPosition(mouseEvent->pos());
         seekToReference();
         return true;
     }
@@ -445,9 +443,7 @@ bool DecompilerWidget::eventFilter(QObject *obj, QEvent *event)
             && (obj == ui->textEdit || obj == ui->textEdit->viewport())) {
         QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
         if (mouseEvent->button() == Qt::RightButton) {
-            const QTextCursor &cursor = ui->textEdit->cursorForPosition(QPoint(mouseEvent->x(),
-                                                                               mouseEvent->y()));
-            ui->textEdit->setTextCursor(cursor);
+            ui->textEdit->setTextCursor(ui->textEdit->cursorForPosition(mouseEvent->pos()));
             return true;
         }
     }

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -441,7 +441,16 @@ bool DecompilerWidget::eventFilter(QObject *obj, QEvent *event)
         seekToReference();
         return true;
     }
-
+    if (event->type() == QEvent::MouseButtonPress
+            && (obj == ui->textEdit || obj == ui->textEdit->viewport())) {
+        QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
+        if (mouseEvent->button() == Qt::RightButton) {
+            const QTextCursor &cursor = ui->textEdit->cursorForPosition(QPoint(mouseEvent->x(),
+                                                                               mouseEvent->y()));
+            ui->textEdit->setTextCursor(cursor);
+            return true;
+        }
+    }
     return MemoryDockWidget::eventFilter(obj, event);
 }
 

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -435,7 +435,7 @@ bool DecompilerWidget::eventFilter(QObject *obj, QEvent *event)
     if (event->type() == QEvent::MouseButtonDblClick
             && (obj == ui->textEdit || obj == ui->textEdit->viewport())) {
         QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
-        ui->textEdit->cursorForPosition(mouseEvent->pos());
+        ui->textEdit->setTextCursor(ui->textEdit->cursorForPosition(mouseEvent->pos()));
         seekToReference();
         return true;
     }


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/developers-docs/first-time.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/developers-docs.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**
Earlier right-clicking did not change cursor position and it opened context menu for the location of the non-updated cursor. This PR fixes this and makes right-click update cursor and open context menu for the new cursor.
Before
![before_right_click](https://user-images.githubusercontent.com/18501167/86794169-d1bb7f80-c089-11ea-8715-0220a9373a06.gif)
After
![after_right_click](https://user-images.githubusercontent.com/18501167/86794205-dd0eab00-c089-11ea-9024-14186d4a6269.gif)


<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

**Test plan (required)**

- [ ] Make sure the left-click or double-click is not broken because of this PR.
- [ ] Check if right-click is working as expected.

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->


<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**
closes #2276 
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
