### PR TITLE
Use fixed meson version. Latest causing problems for r2.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -42,7 +42,7 @@ install:
   - cmd: if "%USE_APPVEYOR_QT%" == "false" ( set "QTPATH=%APPVEYOR_BUILD_FOLDER%\%QTPATH%" )
   - cmd: set "PATH=%QTPATH%\bin;%PATH%"
   - cmd: echo %PATH%
-  - cmd: python -m pip install meson
+  - cmd: python -m pip install meson==0.52
   - cmd: powershell -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; wget %NINJA_URL% -OutFile ninja.zip; Expand-Archive .\ninja.zip -DestinationPath ."
   # Artifacts
   - cmd: set "ARTIFACT_NAME=Cutter-v1.10.3-%ARCH%.Windows"


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/developers-docs/first-time.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/developers-docs.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Latest meson 0.55.0 is currently causing build failures on Travis. For example see  https://ci.appveyor.com/project/radareorg/cutter/builds/34065693/job/rfgxu4we3efu1b8t

```
The Meson build system
Version: 0.55.0
Source dir: C:\projects\cutter\src
Build dir: C:\projects\cutter\build
Build type: native build
Project name: Cutter
Project version: undefined
C++ compiler for the host machine: cl (msvc 19.26.28806)
C++ linker for the host machine: link link 14.26.28806.0
Host machine cpu family: x86_64
Host machine cpu: x86_64
WARNING: rcc dependencies will not work reliably until this upstream issue is fixed: https://bugreports.qt.io/browse/QTBUG-45460
Program C:\Python38-x64\python found: YES (C:\Python38-x64\python.exe)
Message: Python is enabled
Configuring CutterConfig.h with command
src\meson.build:57: WARNING: Dependency radare2 not found but it is available in a sub-subproject.
To use it in the current project, promote it by going in the project source
root and issuing the following command: 
meson wrap promote subprojects\radare2
src\meson.build:57:0: ERROR: Subproject directory not found and radare2.wrap file not found
A full log can be found at C:\projects\cutter\build\meson-logs\meson-log.txt
[r2-meson][ERROR]: Meson error. Exiting.
Command exited with code 1
```

As a temporary solution use fixed meson version. Proper fix can be done later by cutter developers who use meson.

**Test plan (required)**

Make sure appveyor meson test is green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
