### PR TITLE
Show in action and refactoring

### DIFF
--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -923,12 +923,18 @@ void MainWindow::showMemoryWidget(MemoryWidgetType type)
     memoryDockWidget->raiseMemoryWidget();
 }
 
-QMenu *MainWindow::createShowInMenu(QWidget *parent, RVA address)
+QMenu *MainWindow::createShowInMenu(QWidget *parent, RVA address, RCodeAnnotationType typeOfAnnotation)
 {
     QMenu *menu = new QMenu(parent);
     // Memory dock widgets
     for (auto &dock : dockWidgets) {
         if (auto memoryWidget = qobject_cast<MemoryDockWidget *>(dock)) {
+            if ((typeOfAnnotation == R_CODE_ANNOTATION_TYPE_CONSTANT_VARIABLE
+                    || typeOfAnnotation == R_CODE_ANNOTATION_TYPE_GLOBAL_VARIABLE)
+                    && (memoryWidget->getType() == MemoryWidgetType::Graph
+                        || memoryWidget->getType() == MemoryWidgetType::Decompiler)) {
+                continue;
+            }
             QAction *action = new QAction(memoryWidget->windowTitle(), menu);
             connect(action, &QAction::triggered, this, [memoryWidget, address]() {
                 memoryWidget->getSeekable()->seek(address);
@@ -961,7 +967,10 @@ QMenu *MainWindow::createShowInMenu(QWidget *parent, RVA address)
         menu->addAction(action);
     };
     createAddNewWidgetAction(tr("New disassembly"), MemoryWidgetType::Disassembly);
-    createAddNewWidgetAction(tr("New graph"), MemoryWidgetType::Graph);
+    if (typeOfAnnotation != R_CODE_ANNOTATION_TYPE_CONSTANT_VARIABLE
+            && typeOfAnnotation != R_CODE_ANNOTATION_TYPE_GLOBAL_VARIABLE) {
+        createAddNewWidgetAction(tr("New graph"), MemoryWidgetType::Graph);
+    }
     createAddNewWidgetAction(tr("New hexdump"), MemoryWidgetType::Hexdump);
 
     return menu;

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -923,17 +923,18 @@ void MainWindow::showMemoryWidget(MemoryWidgetType type)
     memoryDockWidget->raiseMemoryWidget();
 }
 
-QMenu *MainWindow::createShowInMenu(QWidget *parent, RVA address, RCodeAnnotationType typeOfAnnotation)
+QMenu *MainWindow::createShowInMenu(QWidget *parent, RVA address,  AddressTypeHint addressType)
 {
     QMenu *menu = new QMenu(parent);
     // Memory dock widgets
     for (auto &dock : dockWidgets) {
         if (auto memoryWidget = qobject_cast<MemoryDockWidget *>(dock)) {
-            if ((typeOfAnnotation == R_CODE_ANNOTATION_TYPE_CONSTANT_VARIABLE
-                    || typeOfAnnotation == R_CODE_ANNOTATION_TYPE_GLOBAL_VARIABLE)
-                    && (memoryWidget->getType() == MemoryWidgetType::Graph
-                        || memoryWidget->getType() == MemoryWidgetType::Decompiler)) {
-                continue;
+            if (memoryWidget->getType() == MemoryWidgetType::Graph
+                    || memoryWidget->getType() == MemoryWidgetType::Decompiler)
+            {
+                if (addressType == AddressTypeHint::Data) {
+                    continue;
+                }
             }
             QAction *action = new QAction(memoryWidget->windowTitle(), menu);
             connect(action, &QAction::triggered, this, [memoryWidget, address]() {
@@ -967,8 +968,7 @@ QMenu *MainWindow::createShowInMenu(QWidget *parent, RVA address, RCodeAnnotatio
         menu->addAction(action);
     };
     createAddNewWidgetAction(tr("New disassembly"), MemoryWidgetType::Disassembly);
-    if (typeOfAnnotation != R_CODE_ANNOTATION_TYPE_CONSTANT_VARIABLE
-            && typeOfAnnotation != R_CODE_ANNOTATION_TYPE_GLOBAL_VARIABLE) {
+    if (addressType != AddressTypeHint::Data) {
         createAddNewWidgetAction(tr("New graph"), MemoryWidgetType::Graph);
     }
     createAddNewWidgetAction(tr("New hexdump"), MemoryWidgetType::Hexdump);

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -122,7 +122,7 @@ public:
     void showMemoryWidget();
     void showMemoryWidget(MemoryWidgetType type);
 
-    QMenu *createShowInMenu(QWidget *parent, RVA address);
+    QMenu *createShowInMenu(QWidget *parent, RVA address, RCodeAnnotationType typeOfAnnotation = R_CODE_ANNOTATION_TYPE_SYNTAX_HIGHLIGHT);
     void setCurrentMemoryWidget(MemoryDockWidget* memoryWidget);
     MemoryDockWidget* getLastMemoryWidget();
 

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -122,7 +122,7 @@ public:
     void showMemoryWidget();
     void showMemoryWidget(MemoryWidgetType type);
     enum class AddressTypeHint { Function, Data, Unknown };
-    QMenu *createShowInMenu(QWidget *parent, RVA address, AddressTypeHint addressType = AddressTypeHint::Function);
+    QMenu *createShowInMenu(QWidget *parent, RVA address, AddressTypeHint addressType = AddressTypeHint::Unknown);
     void setCurrentMemoryWidget(MemoryDockWidget* memoryWidget);
     MemoryDockWidget* getLastMemoryWidget();
 

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -121,8 +121,8 @@ public:
     QString getUniqueObjectName(const QString &widgetType) const;
     void showMemoryWidget();
     void showMemoryWidget(MemoryWidgetType type);
-
-    QMenu *createShowInMenu(QWidget *parent, RVA address, RCodeAnnotationType typeOfAnnotation = R_CODE_ANNOTATION_TYPE_SYNTAX_HIGHLIGHT);
+    enum class AddressTypeHint { Function, Data, Unknown };
+    QMenu *createShowInMenu(QWidget *parent, RVA address, AddressTypeHint addressType = AddressTypeHint::Function);
     void setCurrentMemoryWidget(MemoryDockWidget* memoryWidget);
     MemoryDockWidget* getLastMemoryWidget();
 

--- a/src/dialogs/XrefsDialog.h
+++ b/src/dialogs/XrefsDialog.h
@@ -7,7 +7,7 @@
 #include "common/Highlighter.h"
 #include "core/Cutter.h"
 #include "common/AddressableItemModel.h"
-
+ 
 class XrefModel: public AddressableItemModel<QAbstractListModel>
 {
 private:

--- a/src/dialogs/XrefsDialog.h
+++ b/src/dialogs/XrefsDialog.h
@@ -7,7 +7,7 @@
 #include "common/Highlighter.h"
 #include "core/Cutter.h"
 #include "common/AddressableItemModel.h"
- 
+
 class XrefModel: public AddressableItemModel<QAbstractListModel>
 {
 private:

--- a/src/menus/DecompilerContextMenu.cpp
+++ b/src/menus/DecompilerContextMenu.cpp
@@ -201,11 +201,12 @@ void DecompilerContextMenu::aboutToShowSlot()
     actionCopyInstructionAddress.setText(tr("Copy instruction address %1").arg(RAddressString(offset)));
     bool isReference = false;
     if (annotationHere) {
-        isReference == (R_CODE_ANNOTATION_TYPE_GLOBAL_VARIABLE
-                        || annotationHere->type == R_CODE_ANNOTATION_TYPE_CONSTANT_VARIABLE
-                        || annotationHere->type == R_CODE_ANNOTATION_TYPE_FUNCTION_NAME);
+        isReference = (annotationHere->type == R_CODE_ANNOTATION_TYPE_GLOBAL_VARIABLE
+                       || annotationHere->type == R_CODE_ANNOTATION_TYPE_CONSTANT_VARIABLE
+                       || annotationHere->type == R_CODE_ANNOTATION_TYPE_FUNCTION_NAME);
     }
     if (isReference) {
+        actionCopyReferenceAddress.setVisible(true);
         RVA referenceAddr = annotationHere->reference.offset;
         RFlagItem *flagDetails = r_flag_get_i(Core()->core()->flags, referenceAddr);
         if (flagDetails) {

--- a/src/menus/DecompilerContextMenu.cpp
+++ b/src/menus/DecompilerContextMenu.cpp
@@ -19,8 +19,8 @@ DecompilerContextMenu::DecompilerContextMenu(QWidget *parent, MainWindow *mainWi
         mainWindow(mainWindow),
         annotationHere(nullptr),
         actionCopy(tr("Copy"), this),
-        actionCopyInstructionAddress(tr("Copy instruction address <address>"), this),
-        actionCopyReferenceAddress(tr("Copy address of [flag] <address>"), this),
+        actionCopyInstructionAddress(tr("Copy instruction address (<address>)"), this),
+        actionCopyReferenceAddress(tr("Copy address of [flag] (<address>)"), this),
         actionShowInSubmenu(tr("Show in"), this),
         actionAddComment(tr("Add Comment"), this),
         actionDeleteComment(tr("Delete comment"), this),
@@ -199,7 +199,7 @@ void DecompilerContextMenu::aboutToShowSlot()
             }
         }
     }
-    actionCopyInstructionAddress.setText(tr("Copy instruction address %1").arg(RAddressString(offset)));
+    actionCopyInstructionAddress.setText(tr("Copy instruction address (%1)").arg(RAddressString(offset)));
     bool isReference = false;
     if (annotationHere) {
         isReference = (annotationHere->type == R_CODE_ANNOTATION_TYPE_GLOBAL_VARIABLE
@@ -214,7 +214,7 @@ void DecompilerContextMenu::aboutToShowSlot()
             actionCopyReferenceAddress.setText(tr("Copy address of %1 (%2)").arg(flagDetails->name,
                                                                                  RAddressString(referenceAddr)));
         } else {
-            actionCopyReferenceAddress.setText(tr("Copy address %1").arg(RAddressString(referenceAddr)));
+            actionCopyReferenceAddress.setText(tr("Copy address (%1)").arg(RAddressString(referenceAddr)));
         }
     } else {
         actionCopyReferenceAddress.setVisible(false);

--- a/src/menus/DecompilerContextMenu.cpp
+++ b/src/menus/DecompilerContextMenu.cpp
@@ -19,6 +19,7 @@ DecompilerContextMenu::DecompilerContextMenu(QWidget *parent, MainWindow *mainWi
         mainWindow(mainWindow),
         annotationHere(nullptr),
         actionCopy(tr("Copy"), this),
+        actionShowInSubmenu(tr("Show in"), this),
         actionAddComment(tr("Add Comment"), this),
         actionDeleteComment(tr("Delete comment"), this),
         actionRenameThingHere(tr("Rename function at cursor"), this),
@@ -30,6 +31,8 @@ DecompilerContextMenu::DecompilerContextMenu(QWidget *parent, MainWindow *mainWi
 {
     setActionCopy();
     addSeparator();
+
+    setActionShowInSubmenu();
 
     setActionAddComment();
     setActionDeleteComment();
@@ -172,6 +175,11 @@ void DecompilerContextMenu::aboutToShowSlot()
                                                             annotationHere->reference.name)));
         }
     }
+
+    if (actionShowInSubmenu.menu() != nullptr) {
+        actionShowInSubmenu.menu()->deleteLater();
+    }
+    actionShowInSubmenu.setMenu(mainWindow->createShowInMenu(this, offset));
 }
 
 // Set up actions
@@ -181,6 +189,11 @@ void DecompilerContextMenu::setActionCopy()
     connect(&actionCopy, &QAction::triggered, this, &DecompilerContextMenu::actionCopyTriggered);
     addAction(&actionCopy);
     actionCopy.setShortcut(QKeySequence::Copy);
+}
+
+void DecompilerContextMenu::setActionShowInSubmenu()
+{
+    addAction(&actionShowInSubmenu);
 }
 
 void DecompilerContextMenu::setActionAddComment()

--- a/src/menus/DecompilerContextMenu.cpp
+++ b/src/menus/DecompilerContextMenu.cpp
@@ -130,6 +130,7 @@ void DecompilerContextMenu::aboutToHideSlot()
 void DecompilerContextMenu::aboutToShowSlot()
 {
     if (this->firstOffsetInLine != RVA_MAX) {
+        actionShowInSubmenu.setVisible(true);
         QString comment = Core()->cmdRawAt("CC.", this->firstOffsetInLine);
         actionAddComment.setVisible(true);
         if (comment.isEmpty()) {
@@ -140,6 +141,7 @@ void DecompilerContextMenu::aboutToShowSlot()
             actionAddComment.setText(tr("Edit Comment"));
         }
     } else {
+        actionShowInSubmenu.setVisible(false);
         actionAddComment.setVisible(false);
         actionDeleteComment.setVisible(false);
     }
@@ -170,10 +172,12 @@ void DecompilerContextMenu::aboutToShowSlot()
 
     QString progCounterName = Core()->getRegisterName("PC").toUpper();
     actionSetPC.setText(tr("Set %1 here").arg(progCounterName));
-    copySeparator->setVisible(true);
+    
     if (!annotationHere) { // To be considered as invalid
         actionRenameThingHere.setVisible(false);
+        copySeparator->setVisible(false);
     } else {
+        copySeparator->setVisible(true);
         if (annotationHere->type == R_CODE_ANNOTATION_TYPE_FUNCTION_NAME) {
             actionRenameThingHere.setVisible(true);
             actionRenameThingHere.setText(tr("Rename function %1").arg(QString(

--- a/src/menus/DecompilerContextMenu.cpp
+++ b/src/menus/DecompilerContextMenu.cpp
@@ -97,6 +97,7 @@ void DecompilerContextMenu::setupBreakpointsInLineMenu()
 void DecompilerContextMenu::setCanCopy(bool enabled)
 {
     actionCopy.setVisible(enabled);
+    actionCopyInstructionAddress.setVisible(!enabled);
 }
 
 void DecompilerContextMenu::setShortcutContextInActions(QMenu *menu)
@@ -237,10 +238,12 @@ void DecompilerContextMenu::setActionCopy() // Set all three copy actions
     connect(&actionCopyInstructionAddress, &QAction::triggered, this,
             &DecompilerContextMenu::actionCopyInstructionAddressTriggered);
     addAction(&actionCopyInstructionAddress);
+    actionCopyInstructionAddress.setShortcut(QKeySequence::Copy);
 
     connect(&actionCopyReferenceAddress, &QAction::triggered, this,
             &DecompilerContextMenu::actionCopyReferenceAddressTriggered);
     addAction(&actionCopyReferenceAddress);
+    actionCopyReferenceAddress.setShortcut({Qt::CTRL + Qt::SHIFT + Qt::Key_C});
 }
 
 void DecompilerContextMenu::setActionShowInSubmenu()

--- a/src/menus/DecompilerContextMenu.cpp
+++ b/src/menus/DecompilerContextMenu.cpp
@@ -201,7 +201,11 @@ void DecompilerContextMenu::aboutToShowSlot()
                 actionDeleteName.setText(tr("Remove %1").arg(QString(flagDetails->name)));
                 actionDeleteName.setVisible(true);
             } else {
-                actionRenameThingHere.setText(tr("Add name"));
+                if (QString(r_config_get(Core()->core()->config, "r2ghidra.rawptr")) == tr("true")) {
+                    actionRenameThingHere.setText(tr("Add name"));
+                } else {
+                    actionRenameThingHere.setText(tr("Rename %1").arg(curHighlightedWord));
+                }
             }
         }
     }
@@ -383,10 +387,18 @@ void DecompilerContextMenu::actionRenameThingHereTriggered()
                 Core()->renameFlag(flagDetails->name, newName);
             }
         } else {
-            QString newName = QInputDialog::getText(this, tr("Add name"), tr("Enter name"), QLineEdit::Normal,
-                                                    QString(), &ok);
-            if (ok && !newName.isEmpty()) {
-                Core()->addFlag(var_addr, newName, 1);
+            if (QString(r_config_get(Core()->core()->config, "r2ghidra.rawptr")) == tr("true")) {
+                QString newName = QInputDialog::getText(this, tr("Add name"), tr("Enter name"), QLineEdit::Normal,
+                                                        QString(), &ok);
+                if (ok && !newName.isEmpty()) {
+                    Core()->addFlag(var_addr, newName, 1);
+                }
+            } else {
+            QString newName = QInputDialog::getText(this, tr("Rename %2").arg(curHighlightedWord),
+                                                    tr("Enter name"), QLineEdit::Normal, curHighlightedWord, &ok);
+                if (ok && !newName.isEmpty()) {
+                    Core()->addFlag(var_addr, newName, 1);
+                }
             }
         }
 

--- a/src/menus/DecompilerContextMenu.cpp
+++ b/src/menus/DecompilerContextMenu.cpp
@@ -199,7 +199,8 @@ void DecompilerContextMenu::aboutToShowSlot()
             }
         }
     }
-    actionCopyInstructionAddress.setText(tr("Copy instruction address (%1)").arg(RAddressString(offset)));
+    actionCopyInstructionAddress.setText(tr("Copy instruction address (%1)").arg(RAddressString(
+                                                                                     offset)));
     bool isReference = false;
     if (annotationHere) {
         isReference = (annotationHere->type == R_CODE_ANNOTATION_TYPE_GLOBAL_VARIABLE
@@ -210,9 +211,12 @@ void DecompilerContextMenu::aboutToShowSlot()
         actionCopyReferenceAddress.setVisible(true);
         RVA referenceAddr = annotationHere->reference.offset;
         RFlagItem *flagDetails = r_flag_get_i(Core()->core()->flags, referenceAddr);
-        if (flagDetails) {
-            actionCopyReferenceAddress.setText(tr("Copy address of %1 (%2)").arg(flagDetails->name,
-                                                                                 RAddressString(referenceAddr)));
+        if (annotationHere->type == R_CODE_ANNOTATION_TYPE_FUNCTION_NAME) {
+            actionCopyReferenceAddress.setText(tr("Copy address of %1 (%2)").arg
+                                               (QString(annotationHere->reference.name), RAddressString(referenceAddr)));
+        } else if (flagDetails) {
+            actionCopyReferenceAddress.setText(tr("Copy address of %1 (%2)").arg
+                                               (flagDetails->name, RAddressString(referenceAddr)));
         } else {
             actionCopyReferenceAddress.setText(tr("Copy address (%1)").arg(RAddressString(referenceAddr)));
         }

--- a/src/menus/DecompilerContextMenu.cpp
+++ b/src/menus/DecompilerContextMenu.cpp
@@ -295,7 +295,7 @@ void DecompilerContextMenu::actionRenameThingHereTriggered()
     if (!annotationHere) {
         return;
     }
-    RCore *core = Core()->core();
+    RCoreLocked core = Core()->core();
     bool ok;
     auto type = annotationHere->type;
     if (type == R_CODE_ANNOTATION_TYPE_FUNCTION_NAME) {

--- a/src/menus/DecompilerContextMenu.cpp
+++ b/src/menus/DecompilerContextMenu.cpp
@@ -233,7 +233,7 @@ void DecompilerContextMenu::setActionDeleteComment()
 
 void DecompilerContextMenu::setActionRenameThingHere()
 {
-    actionRenameThingHere.setShortcut({Qt::SHIFT + Qt::Key_N});
+    actionRenameThingHere.setShortcut({Qt::Key_N});
     connect(&actionRenameThingHere, &QAction::triggered, this,
             &DecompilerContextMenu::actionRenameThingHereTriggered);
     addAction(&actionRenameThingHere);

--- a/src/menus/DecompilerContextMenu.cpp
+++ b/src/menus/DecompilerContextMenu.cpp
@@ -23,8 +23,7 @@ DecompilerContextMenu::DecompilerContextMenu(QWidget *parent, MainWindow *mainWi
         actionAddComment(tr("Add Comment"), this),
         actionDeleteComment(tr("Delete comment"), this),
         actionRenameThingHere(tr("Rename function at cursor"), this),
-        actionAddFlag(tr("Add flag"), this),
-        actionDeleteFlag(tr("Delete flag"), this),
+        actionDeleteName(tr("Delete <name>"), this),
         actionToggleBreakpoint(tr("Add/remove breakpoint"), this),
         actionAdvancedBreakpoint(tr("Advanced breakpoint"), this),
         breakpointsInLineMenu(new QMenu(this)),
@@ -41,6 +40,7 @@ DecompilerContextMenu::DecompilerContextMenu(QWidget *parent, MainWindow *mainWi
     setActionDeleteComment();
 
     setActionRenameThingHere();
+    setActionDeleteName();
 
     addSeparator();
     addBreakpointMenu();
@@ -124,6 +124,7 @@ void DecompilerContextMenu::aboutToHideSlot()
 {
     actionAddComment.setVisible(true);
     actionRenameThingHere.setVisible(true);
+    actionDeleteName.setVisible(false);
 }
 
 void DecompilerContextMenu::aboutToShowSlot()
@@ -182,8 +183,8 @@ void DecompilerContextMenu::aboutToShowSlot()
             RFlagItem *flagDetails = r_flag_get_i(Core()->core()->flags, annotationHere->reference.offset);
             if (flagDetails) {
                 actionRenameThingHere.setText(tr("Rename %1").arg(QString(flagDetails->name)));
-                // actionDeleteFlag.setText("Remove %1".arg(QString(flagDetails->name)))
-                // actionDeleteFlag.setVisible(true);
+                actionDeleteName.setText(tr("Remove %1").arg(QString(flagDetails->name)));
+                actionDeleteName.setVisible(true);
             } else {
                 actionRenameThingHere.setText(tr("Add name"));
             }
@@ -232,6 +233,13 @@ void DecompilerContextMenu::setActionRenameThingHere()
     connect(&actionRenameThingHere, &QAction::triggered, this,
             &DecompilerContextMenu::actionRenameThingHereTriggered);
     addAction(&actionRenameThingHere);
+}
+
+void DecompilerContextMenu::setActionDeleteName()
+{
+    connect(&actionDeleteName, &QAction::triggered, this, &DecompilerContextMenu::actionDeleteNameTriggered);
+    addAction(&actionDeleteName);
+    actionDeleteName.setVisible(false);
 }
 
 void DecompilerContextMenu::setActionToggleBreakpoint()
@@ -307,18 +315,23 @@ void DecompilerContextMenu::actionRenameThingHereTriggered()
         RFlagItem *flagDetails = r_flag_get_i(core->flags, var_addr);
         if (flagDetails) {
             QString newName = QInputDialog::getText(this, tr("Rename %2").arg(flagDetails->name),
-                                            tr("Flag name:"), QLineEdit::Normal, flagDetails->name, &ok);
+                                            tr("Enter name"), QLineEdit::Normal, flagDetails->name, &ok);
             if (ok && !newName.isEmpty()) {
                 Core()->renameFlag(flagDetails->name, newName);
             }
         } else {
-            QString newName = QInputDialog::getText(this, tr("Add name"), tr("Flag name:"), QLineEdit::Normal, QString(), &ok);
+            QString newName = QInputDialog::getText(this, tr("Add name"), tr("Enter name"), QLineEdit::Normal, QString(), &ok);
             if (ok && !newName.isEmpty()) {
                 Core()->addFlag(var_addr, newName, newName.length());
             }
         }
         
     }
+}
+
+void DecompilerContextMenu::actionDeleteNameTriggered()
+{
+    Core()->delFlag(annotationHere->reference.offset);
 }
 
 void DecompilerContextMenu::actionToggleBreakpointTriggered()

--- a/src/menus/DecompilerContextMenu.cpp
+++ b/src/menus/DecompilerContextMenu.cpp
@@ -432,7 +432,7 @@ void DecompilerContextMenu::updateTargetMenuActions()
         }
         auto action = new QAction(name, this);
         showTargetMenuActions.append(action);
-        auto menu = mainWindow->createShowInMenu(this, annotationHere->reference.offset);
+        auto menu = mainWindow->createShowInMenu(this, annotationHere->reference.offset, annotationHere->type);
         action->setMenu(menu);
         QAction *copyAddress = new QAction(tr("Copy address"), menu);
         RVA offsetHere = annotationHere->reference.offset;

--- a/src/menus/DecompilerContextMenu.cpp
+++ b/src/menus/DecompilerContextMenu.cpp
@@ -167,8 +167,10 @@ void DecompilerContextMenu::aboutToShowSlot()
         actionRenameThingHere.setVisible(false);
     } else {
         actionRenameThingHere.setVisible(true);
-        actionRenameThingHere.setText(tr("Rename function %1").arg(QString(
-                                                                       annotationHere->function_name.name)));
+        if (annotationHere->type == R_CODE_ANNOTATION_TYPE_FUNCTION_NAME) {
+            actionRenameThingHere.setText(tr("Rename function %1").arg(QString(
+                                                            annotationHere->reference.name)));
+        }
     }
 }
 
@@ -254,8 +256,8 @@ void DecompilerContextMenu::actionRenameThingHereTriggered()
     bool ok;
     auto type = annotationHere->type;
     if (type == R_CODE_ANNOTATION_TYPE_FUNCTION_NAME) {
-        QString currentName(annotationHere->function_name.name);
-        RVA func_addr = annotationHere->function_name.offset;
+        QString currentName(annotationHere->reference.name);
+        RVA func_addr = annotationHere->reference.offset;
         RAnalFunction *func = Core()->functionAt(func_addr);
         if (func == NULL) {
             QString function_name = QInputDialog::getText(this, tr("Define this function at %2").arg(RAddressString(func_addr)),

--- a/src/menus/DecompilerContextMenu.cpp
+++ b/src/menus/DecompilerContextMenu.cpp
@@ -14,6 +14,7 @@
 
 DecompilerContextMenu::DecompilerContextMenu(QWidget *parent, MainWindow *mainWindow)
     :   QMenu(parent),
+        curHighlightedWord(QString()),
         offset(0),
         isTogglingBreakpoints(false),
         mainWindow(mainWindow),
@@ -63,6 +64,11 @@ DecompilerContextMenu::~DecompilerContextMenu()
 void DecompilerContextMenu::setAnnotationHere(RCodeAnnotation *annotation)
 {
     this->annotationHere = annotation;
+}
+
+void DecompilerContextMenu::setCurHighlightedWord(QString word)
+{
+    this->curHighlightedWord = word;
 }
 
 void DecompilerContextMenu::setOffset(RVA offset)

--- a/src/menus/DecompilerContextMenu.cpp
+++ b/src/menus/DecompilerContextMenu.cpp
@@ -424,7 +424,7 @@ void DecompilerContextMenu::updateTargetMenuActions()
             if (flagDetails) {
                 name = tr("Show %1 in").arg(flagDetails->name);
             } else {
-                name = tr("Show %1 (addr here)").arg(RAddressString(annotationHere->reference.offset));
+                name = tr("Show %1 in").arg(RAddressString(annotationHere->reference.offset));
             }
         } else if (annotationHere->type == R_CODE_ANNOTATION_TYPE_FUNCTION_NAME) {
             name = tr("%1 (%2)").arg(QString(annotationHere->reference.name),

--- a/src/menus/DecompilerContextMenu.cpp
+++ b/src/menus/DecompilerContextMenu.cpp
@@ -172,7 +172,7 @@ void DecompilerContextMenu::aboutToShowSlot()
 
     QString progCounterName = Core()->getRegisterName("PC").toUpper();
     actionSetPC.setText(tr("Set %1 here").arg(progCounterName));
-    
+
     if (!annotationHere) { // To be considered as invalid
         actionRenameThingHere.setVisible(false);
         copySeparator->setVisible(false);
@@ -181,9 +181,10 @@ void DecompilerContextMenu::aboutToShowSlot()
         if (annotationHere->type == R_CODE_ANNOTATION_TYPE_FUNCTION_NAME) {
             actionRenameThingHere.setVisible(true);
             actionRenameThingHere.setText(tr("Rename function %1").arg(QString(
-                                                            annotationHere->reference.name)));
+                                                                           annotationHere->reference.name)));
         }
-        if (annotationHere->type == R_CODE_ANNOTATION_TYPE_GLOBAL_VARIABLE || annotationHere->type == R_CODE_ANNOTATION_TYPE_CONSTANT_VARIABLE) {
+        if (annotationHere->type == R_CODE_ANNOTATION_TYPE_GLOBAL_VARIABLE
+                || annotationHere->type == R_CODE_ANNOTATION_TYPE_CONSTANT_VARIABLE) {
             RFlagItem *flagDetails = r_flag_get_i(Core()->core()->flags, annotationHere->reference.offset);
             if (flagDetails) {
                 actionRenameThingHere.setText(tr("Rename %1").arg(QString(flagDetails->name)));
@@ -241,7 +242,8 @@ void DecompilerContextMenu::setActionRenameThingHere()
 
 void DecompilerContextMenu::setActionDeleteName()
 {
-    connect(&actionDeleteName, &QAction::triggered, this, &DecompilerContextMenu::actionDeleteNameTriggered);
+    connect(&actionDeleteName, &QAction::triggered, this,
+            &DecompilerContextMenu::actionDeleteNameTriggered);
     addAction(&actionDeleteName);
     actionDeleteName.setVisible(false);
 }
@@ -301,35 +303,38 @@ void DecompilerContextMenu::actionRenameThingHereTriggered()
         RVA func_addr = annotationHere->reference.offset;
         RAnalFunction *func = Core()->functionAt(func_addr);
         if (func == NULL) {
-            QString function_name = QInputDialog::getText(this, tr("Define this function at %2").arg(RAddressString(func_addr)),
-                                            tr("Function name:"), QLineEdit::Normal, currentName, &ok);
+            QString function_name = QInputDialog::getText(this,
+                                                          tr("Define this function at %2").arg(RAddressString(func_addr)),
+                                                          tr("Function name:"), QLineEdit::Normal, currentName, &ok);
             if (ok && !function_name.isEmpty()) {
                 Core()->createFunctionAt(func_addr, function_name);
             }
         } else {
             QString newName = QInputDialog::getText(this, tr("Rename function %2").arg(currentName),
-                                                tr("Function name:"), QLineEdit::Normal, currentName, &ok);
+                                                    tr("Function name:"), QLineEdit::Normal, currentName, &ok);
             if (ok && !newName.isEmpty()) {
-               Core()->renameFunction(func_addr, newName);
-            }    
+                Core()->renameFunction(func_addr, newName);
+            }
         }
-        
-    } else if (type == R_CODE_ANNOTATION_TYPE_GLOBAL_VARIABLE || type == R_CODE_ANNOTATION_TYPE_CONSTANT_VARIABLE) {
+
+    } else if (type == R_CODE_ANNOTATION_TYPE_GLOBAL_VARIABLE
+               || type == R_CODE_ANNOTATION_TYPE_CONSTANT_VARIABLE) {
         RVA var_addr = annotationHere->reference.offset;
         RFlagItem *flagDetails = r_flag_get_i(core->flags, var_addr);
         if (flagDetails) {
             QString newName = QInputDialog::getText(this, tr("Rename %2").arg(flagDetails->name),
-                                            tr("Enter name"), QLineEdit::Normal, flagDetails->name, &ok);
+                                                    tr("Enter name"), QLineEdit::Normal, flagDetails->name, &ok);
             if (ok && !newName.isEmpty()) {
                 Core()->renameFlag(flagDetails->name, newName);
             }
         } else {
-            QString newName = QInputDialog::getText(this, tr("Add name"), tr("Enter name"), QLineEdit::Normal, QString(), &ok);
+            QString newName = QInputDialog::getText(this, tr("Add name"), tr("Enter name"), QLineEdit::Normal,
+                                                    QString(), &ok);
             if (ok && !newName.isEmpty()) {
                 Core()->addFlag(var_addr, newName, newName.length());
             }
         }
-        
+
     }
 }
 
@@ -411,12 +416,14 @@ void DecompilerContextMenu::updateTargetMenuActions()
         action->deleteLater();
     }
     showTargetMenuActions.clear();
-    if(annotationHere){
+    if (annotationHere) {
         QString name;
-        if (annotationHere->type == R_CODE_ANNOTATION_TYPE_GLOBAL_VARIABLE || annotationHere->type == R_CODE_ANNOTATION_TYPE_CONSTANT_VARIABLE) {
+        if (annotationHere->type == R_CODE_ANNOTATION_TYPE_GLOBAL_VARIABLE
+                || annotationHere->type == R_CODE_ANNOTATION_TYPE_CONSTANT_VARIABLE) {
             name = tr("%1 (used here)").arg(RAddressString(annotationHere->reference.offset));
-        } else if(annotationHere->type == R_CODE_ANNOTATION_TYPE_FUNCTION_NAME) {
-            name = tr("%1 (%2)").arg(QString(annotationHere->reference.name), RAddressString(annotationHere->reference.offset));
+        } else if (annotationHere->type == R_CODE_ANNOTATION_TYPE_FUNCTION_NAME) {
+            name = tr("%1 (%2)").arg(QString(annotationHere->reference.name),
+                                     RAddressString(annotationHere->reference.offset));
         }
         auto action = new QAction(name, this);
         showTargetMenuActions.append(action);

--- a/src/menus/DecompilerContextMenu.cpp
+++ b/src/menus/DecompilerContextMenu.cpp
@@ -252,7 +252,6 @@ void DecompilerContextMenu::setActionCopy() // Set all three copy actions
     connect(&actionCopyInstructionAddress, &QAction::triggered, this,
             &DecompilerContextMenu::actionCopyInstructionAddressTriggered);
     addAction(&actionCopyInstructionAddress);
-    // actionCopyInstructionAddress.setShortcut(QKeySequence::Copy);
 
     connect(&actionCopyReferenceAddress, &QAction::triggered, this,
             &DecompilerContextMenu::actionCopyReferenceAddressTriggered);
@@ -495,8 +494,10 @@ void DecompilerContextMenu::updateTargetMenuActions()
                            || annotationHere->type == R_CODE_ANNOTATION_TYPE_CONSTANT_VARIABLE
                            || annotationHere->type == R_CODE_ANNOTATION_TYPE_FUNCTION_NAME)) {
         QString name;
+        QMenu *menu;
         if (annotationHere->type == R_CODE_ANNOTATION_TYPE_GLOBAL_VARIABLE
                 || annotationHere->type == R_CODE_ANNOTATION_TYPE_CONSTANT_VARIABLE) {
+            menu = mainWindow->createShowInMenu(this, annotationHere->reference.offset, MainWindow::AddressTypeHint::Data);
             RVA var_addr = annotationHere->reference.offset;
             RFlagItem *flagDetails = r_flag_get_i(core->flags, var_addr);
             if (flagDetails) {
@@ -505,13 +506,13 @@ void DecompilerContextMenu::updateTargetMenuActions()
                 name = tr("Show %1 in").arg(RAddressString(annotationHere->reference.offset));
             }
         } else if (annotationHere->type == R_CODE_ANNOTATION_TYPE_FUNCTION_NAME) {
+            menu = mainWindow->createShowInMenu(this, annotationHere->reference.offset,
+                                                MainWindow::AddressTypeHint::Function);
             name = tr("%1 (%2)").arg(QString(annotationHere->reference.name),
                                      RAddressString(annotationHere->reference.offset));
         }
         auto action = new QAction(name, this);
         showTargetMenuActions.append(action);
-        auto menu = mainWindow->createShowInMenu(this, annotationHere->reference.offset,
-                                                 annotationHere->type);
         action->setMenu(menu);
         insertActions(copySeparator, showTargetMenuActions);
     }

--- a/src/menus/DecompilerContextMenu.cpp
+++ b/src/menus/DecompilerContextMenu.cpp
@@ -20,7 +20,6 @@ DecompilerContextMenu::DecompilerContextMenu(QWidget *parent, MainWindow *mainWi
         isTogglingBreakpoints(false),
         mainWindow(mainWindow),
         annotationHere(nullptr),
-        canCopy(false),
         actionCopy(tr("Copy"), this),
         actionCopyInstructionAddress(tr("Copy instruction address (<address>)"), this),
         actionCopyReferenceAddress(tr("Copy address of [flag] (<address>)"), this),
@@ -100,11 +99,6 @@ void DecompilerContextMenu::setupBreakpointsInLineMenu()
                                               this);
         });
     }
-}
-
-void DecompilerContextMenu::setCanCopy(bool enabled)
-{
-    canCopy = enabled;
 }
 
 void DecompilerContextMenu::setShortcutContextInActions(QMenu *menu)

--- a/src/menus/DecompilerContextMenu.cpp
+++ b/src/menus/DecompilerContextMenu.cpp
@@ -102,8 +102,13 @@ void DecompilerContextMenu::setupBreakpointsInLineMenu()
 
 void DecompilerContextMenu::setCanCopy(bool enabled)
 {
-    actionCopy.setVisible(enabled);
-    actionCopyInstructionAddress.setVisible(!enabled);
+    // actionCopy.setVisible(enabled);
+    // actionCopyInstructionAddress.setVisible(!enabled);
+    if (enabled) {
+        actionCopy.setText("Copy");
+    } else {
+        actionCopy.setText("Copy this line");
+    }
 }
 
 void DecompilerContextMenu::setShortcutContextInActions(QMenu *menu)
@@ -252,7 +257,7 @@ void DecompilerContextMenu::setActionCopy() // Set all three copy actions
     connect(&actionCopyInstructionAddress, &QAction::triggered, this,
             &DecompilerContextMenu::actionCopyInstructionAddressTriggered);
     addAction(&actionCopyInstructionAddress);
-    actionCopyInstructionAddress.setShortcut(QKeySequence::Copy);
+    // actionCopyInstructionAddress.setShortcut(QKeySequence::Copy);
 
     connect(&actionCopyReferenceAddress, &QAction::triggered, this,
             &DecompilerContextMenu::actionCopyReferenceAddressTriggered);

--- a/src/menus/DecompilerContextMenu.cpp
+++ b/src/menus/DecompilerContextMenu.cpp
@@ -201,7 +201,7 @@ void DecompilerContextMenu::aboutToShowSlot()
                 actionDeleteName.setText(tr("Remove %1").arg(QString(flagDetails->name)));
                 actionDeleteName.setVisible(true);
             } else {
-                if (QString(r_config_get(Core()->core()->config, "r2ghidra.rawptr")) == tr("true")) {
+                if (Core()->getConfig("r2ghidra.rawptr")== "true") {
                     actionRenameThingHere.setText(tr("Add name"));
                 } else {
                     actionRenameThingHere.setText(tr("Rename %1").arg(curHighlightedWord));
@@ -387,7 +387,7 @@ void DecompilerContextMenu::actionRenameThingHereTriggered()
                 Core()->renameFlag(flagDetails->name, newName);
             }
         } else {
-            if (QString(r_config_get(Core()->core()->config, "r2ghidra.rawptr")) == tr("true")) {
+            if (Core()->getConfig("r2ghidra.rawptr") == "true") {
                 QString newName = QInputDialog::getText(this, tr("Add name"), tr("Enter name"), QLineEdit::Normal,
                                                         QString(), &ok);
                 if (ok && !newName.isEmpty()) {

--- a/src/menus/DecompilerContextMenu.cpp
+++ b/src/menus/DecompilerContextMenu.cpp
@@ -103,14 +103,7 @@ void DecompilerContextMenu::setupBreakpointsInLineMenu()
 
 void DecompilerContextMenu::setCanCopy(bool enabled)
 {
-    // actionCopy.setVisible(enabled);
-    // actionCopyInstructionAddress.setVisible(!enabled);
     canCopy = enabled;
-    if (enabled) {
-        actionCopy.setText("Copy");
-    } else {
-        actionCopy.setText("Copy this line");
-    }
 }
 
 void DecompilerContextMenu::setShortcutContextInActions(QMenu *menu)
@@ -334,8 +327,10 @@ void DecompilerContextMenu::actionCopyTriggered()
 {
     if (canCopy) {
         emit copy();
+    } else if(!curHighlightedWord.isEmpty()) {
+        QClipboard *clipboard = QApplication::clipboard();
+        clipboard->setText(curHighlightedWord);
     } else {
-        // return;
         emit copyLine();
     }
 }

--- a/src/menus/DecompilerContextMenu.cpp
+++ b/src/menus/DecompilerContextMenu.cpp
@@ -19,6 +19,7 @@ DecompilerContextMenu::DecompilerContextMenu(QWidget *parent, MainWindow *mainWi
         isTogglingBreakpoints(false),
         mainWindow(mainWindow),
         annotationHere(nullptr),
+        canCopy(false),
         actionCopy(tr("Copy"), this),
         actionCopyInstructionAddress(tr("Copy instruction address (<address>)"), this),
         actionCopyReferenceAddress(tr("Copy address of [flag] (<address>)"), this),
@@ -104,6 +105,7 @@ void DecompilerContextMenu::setCanCopy(bool enabled)
 {
     // actionCopy.setVisible(enabled);
     // actionCopyInstructionAddress.setVisible(!enabled);
+    canCopy = enabled;
     if (enabled) {
         actionCopy.setText("Copy");
     } else {
@@ -330,7 +332,12 @@ void DecompilerContextMenu::setActionSetPC()
 
 void DecompilerContextMenu::actionCopyTriggered()
 {
-    emit copy();
+    if (canCopy) {
+        emit copy();
+    } else {
+        // return;
+        emit copyLine();
+    }
 }
 
 void DecompilerContextMenu::actionCopyInstructionAddressTriggered()

--- a/src/menus/DecompilerContextMenu.cpp
+++ b/src/menus/DecompilerContextMenu.cpp
@@ -3,6 +3,7 @@
 #include "MainWindow.h"
 #include "dialogs/BreakpointsDialog.h"
 #include "dialogs/CommentsDialog.h"
+#include "common/Configuration.h"
 
 #include <QtCore>
 #include <QShortcut>
@@ -201,10 +202,10 @@ void DecompilerContextMenu::aboutToShowSlot()
                 actionDeleteName.setText(tr("Remove %1").arg(QString(flagDetails->name)));
                 actionDeleteName.setVisible(true);
             } else {
-                if (Core()->getConfig("r2ghidra.rawptr") == "true") {
-                    actionRenameThingHere.setText(tr("Add name"));
-                } else {
+                if (Config()->getSelectedDecompiler() == "r2ghidra" && Core()->getConfig("r2ghidra.rawptr") == "false") {
                     actionRenameThingHere.setText(tr("Rename %1").arg(curHighlightedWord));
+                } else {
+                    actionRenameThingHere.setText(tr("Add name"));
                 }
             }
         }
@@ -393,15 +394,16 @@ void DecompilerContextMenu::actionRenameThingHereTriggered()
                 Core()->renameFlag(flagDetails->name, newName);
             }
         } else {
-            if (Core()->getConfig("r2ghidra.rawptr") == "true") {
-                QString newName = QInputDialog::getText(this, tr("Add name"), tr("Enter name"), QLineEdit::Normal,
-                                                        QString(), &ok);
+            if (Config()->getSelectedDecompiler() == "r2ghidra" && Core()->getConfig("r2ghidra.rawptr") == "false") {
+                QString newName = QInputDialog::getText(this, tr("Rename %2").arg(curHighlightedWord),
+                                                        tr("Enter name"), QLineEdit::Normal, curHighlightedWord, &ok);
                 if (ok && !newName.isEmpty()) {
                     Core()->addFlag(var_addr, newName, 1);
                 }
+                
             } else {
-                QString newName = QInputDialog::getText(this, tr("Rename %2").arg(curHighlightedWord),
-                                                        tr("Enter name"), QLineEdit::Normal, curHighlightedWord, &ok);
+                QString newName = QInputDialog::getText(this, tr("Add name"), tr("Enter name"), QLineEdit::Normal,
+                                                        QString(), &ok);
                 if (ok && !newName.isEmpty()) {
                     Core()->addFlag(var_addr, newName, 1);
                 }

--- a/src/menus/DecompilerContextMenu.cpp
+++ b/src/menus/DecompilerContextMenu.cpp
@@ -201,7 +201,7 @@ void DecompilerContextMenu::aboutToShowSlot()
                 actionDeleteName.setText(tr("Remove %1").arg(QString(flagDetails->name)));
                 actionDeleteName.setVisible(true);
             } else {
-                if (Core()->getConfig("r2ghidra.rawptr")== "true") {
+                if (Core()->getConfig("r2ghidra.rawptr") == "true") {
                     actionRenameThingHere.setText(tr("Add name"));
                 } else {
                     actionRenameThingHere.setText(tr("Rename %1").arg(curHighlightedWord));
@@ -327,7 +327,7 @@ void DecompilerContextMenu::actionCopyTriggered()
 {
     if (canCopy) {
         emit copy();
-    } else if(!curHighlightedWord.isEmpty()) {
+    } else if (!curHighlightedWord.isEmpty()) {
         QClipboard *clipboard = QApplication::clipboard();
         clipboard->setText(curHighlightedWord);
     } else {
@@ -401,8 +401,8 @@ void DecompilerContextMenu::actionRenameThingHereTriggered()
                     Core()->addFlag(var_addr, newName, 1);
                 }
             } else {
-            QString newName = QInputDialog::getText(this, tr("Rename %2").arg(curHighlightedWord),
-                                                    tr("Enter name"), QLineEdit::Normal, curHighlightedWord, &ok);
+                QString newName = QInputDialog::getText(this, tr("Rename %2").arg(curHighlightedWord),
+                                                        tr("Enter name"), QLineEdit::Normal, curHighlightedWord, &ok);
                 if (ok && !newName.isEmpty()) {
                     Core()->addFlag(var_addr, newName, 1);
                 }

--- a/src/menus/DecompilerContextMenu.cpp
+++ b/src/menus/DecompilerContextMenu.cpp
@@ -325,14 +325,7 @@ void DecompilerContextMenu::setActionSetPC()
 
 void DecompilerContextMenu::actionCopyTriggered()
 {
-    if (canCopy) {
-        emit copy();
-    } else if (!curHighlightedWord.isEmpty()) {
-        QClipboard *clipboard = QApplication::clipboard();
-        clipboard->setText(curHighlightedWord);
-    } else {
-        emit copyLine();
-    }
+    emit copy();
 }
 
 void DecompilerContextMenu::actionCopyInstructionAddressTriggered()

--- a/src/menus/DecompilerContextMenu.cpp
+++ b/src/menus/DecompilerContextMenu.cpp
@@ -196,11 +196,7 @@ void DecompilerContextMenu::aboutToShowSlot()
                 actionDeleteName.setText(tr("Remove %1").arg(QString(flagDetails->name)));
                 actionDeleteName.setVisible(true);
             } else {
-                if (Config()->getSelectedDecompiler() == "r2ghidra" && Core()->getConfig("r2ghidra.rawptr") == "false") {
-                    actionRenameThingHere.setText(tr("Rename %1").arg(curHighlightedWord));
-                } else {
-                    actionRenameThingHere.setText(tr("Add name"));
-                }
+                actionRenameThingHere.setText(tr("Add name to %1").arg(curHighlightedWord));
             }
         }
     }
@@ -381,19 +377,10 @@ void DecompilerContextMenu::actionRenameThingHereTriggered()
                 Core()->renameFlag(flagDetails->name, newName);
             }
         } else {
-            if (Config()->getSelectedDecompiler() == "r2ghidra" && Core()->getConfig("r2ghidra.rawptr") == "false") {
-                QString newName = QInputDialog::getText(this, tr("Rename %2").arg(curHighlightedWord),
-                                                        tr("Enter name"), QLineEdit::Normal, curHighlightedWord, &ok);
-                if (ok && !newName.isEmpty()) {
-                    Core()->addFlag(var_addr, newName, 1);
-                }
-                
-            } else {
-                QString newName = QInputDialog::getText(this, tr("Add name"), tr("Enter name"), QLineEdit::Normal,
-                                                        QString(), &ok);
-                if (ok && !newName.isEmpty()) {
-                    Core()->addFlag(var_addr, newName, 1);
-                }
+            QString newName = QInputDialog::getText(this, tr("Add name to %2").arg(curHighlightedWord),
+                                                    tr("Enter name"), QLineEdit::Normal, curHighlightedWord, &ok);
+            if (ok && !newName.isEmpty()) {
+                Core()->addFlag(var_addr, newName, 1);
             }
         }
 

--- a/src/menus/DecompilerContextMenu.h
+++ b/src/menus/DecompilerContextMenu.h
@@ -83,6 +83,8 @@ private:
     // Set actions
     void setActionCopy();
 
+    void setActionShowInSubmenu();
+
     void setActionAddComment();
     void setActionDeleteComment();
 

--- a/src/menus/DecompilerContextMenu.h
+++ b/src/menus/DecompilerContextMenu.h
@@ -60,11 +60,13 @@ private:
 
     QAction actionShowInSubmenu;
     QList<QAction*> showTargetMenuActions;
-
+    
     QAction actionAddComment;
     QAction actionDeleteComment;
 
     QAction actionRenameThingHere;
+    QAction actionAddFlag;
+    QAction actionDeleteFlag;
 
     QMenu *breakpointMenu;
     QAction actionToggleBreakpoint;

--- a/src/menus/DecompilerContextMenu.h
+++ b/src/menus/DecompilerContextMenu.h
@@ -58,6 +58,8 @@ private:
     QAction actionCopy;
     QAction *copySeparator;
 
+    QAction actionShowInSubmenu;
+
     QAction actionAddComment;
     QAction actionDeleteComment;
 

--- a/src/menus/DecompilerContextMenu.h
+++ b/src/menus/DecompilerContextMenu.h
@@ -22,6 +22,7 @@ signals:
     void copy();
 
 public slots:
+    void setCurHighlightedWord(QString word);
     void setOffset(RVA offset);
     void setCanCopy(bool enabled);
     void setFirstOffsetInLine(RVA firstOffset);
@@ -50,6 +51,7 @@ private slots:
 
 private:
     // Private variables
+    QString curHighlightedWord;
     RVA offset;
     RVA firstOffsetInLine;
     bool isTogglingBreakpoints;

--- a/src/menus/DecompilerContextMenu.h
+++ b/src/menus/DecompilerContextMenu.h
@@ -33,6 +33,8 @@ private slots:
     void aboutToHideSlot();
 
     void actionCopyTriggered();
+    void actionCopyInstructionAddressTriggered();
+    void actionCopyReferenceAddressTriggered();
 
     void actionAddCommentTriggered();
     void actionDeleteCommentTriggered();
@@ -57,6 +59,8 @@ private:
     RCodeAnnotation *annotationHere;
 
     QAction actionCopy;
+    QAction actionCopyInstructionAddress;
+    QAction actionCopyReferenceAddress;
     QAction *copySeparator;
 
     QAction actionShowInSubmenu;

--- a/src/menus/DecompilerContextMenu.h
+++ b/src/menus/DecompilerContextMenu.h
@@ -38,6 +38,7 @@ private slots:
     void actionDeleteCommentTriggered();
 
     void actionRenameThingHereTriggered();
+    void actionDeleteNameTriggered();
 
     void actionToggleBreakpointTriggered();
     void actionAdvancedBreakpointTriggered();
@@ -65,8 +66,7 @@ private:
     QAction actionDeleteComment;
 
     QAction actionRenameThingHere;
-    QAction actionAddFlag;
-    QAction actionDeleteFlag;
+    QAction actionDeleteName;
 
     QMenu *breakpointMenu;
     QAction actionToggleBreakpoint;
@@ -92,6 +92,7 @@ private:
     void setActionDeleteComment();
 
     void setActionRenameThingHere();
+    void setActionDeleteName();
 
     void setActionToggleBreakpoint();
     void setActionAdvancedBreakpoint();

--- a/src/menus/DecompilerContextMenu.h
+++ b/src/menus/DecompilerContextMenu.h
@@ -59,6 +59,7 @@ private:
     QAction *copySeparator;
 
     QAction actionShowInSubmenu;
+    QList<QAction*> showTargetMenuActions;
 
     QAction actionAddComment;
     QAction actionDeleteComment;
@@ -117,6 +118,7 @@ private:
     // QVector<ThingUsedHere> getThingUsedHere(RVA offset);
 
     // void updateTargetMenuActions(const QVector<ThingUsedHere> &targets);
+    void updateTargetMenuActions();
 };
 
 #endif // DECOMPILERCONTEXTMENU_H

--- a/src/menus/DecompilerContextMenu.h
+++ b/src/menus/DecompilerContextMenu.h
@@ -60,8 +60,8 @@ private:
     QAction *copySeparator;
 
     QAction actionShowInSubmenu;
-    QList<QAction*> showTargetMenuActions;
-    
+    QList<QAction *> showTargetMenuActions;
+
     QAction actionAddComment;
     QAction actionDeleteComment;
 

--- a/src/menus/DecompilerContextMenu.h
+++ b/src/menus/DecompilerContextMenu.h
@@ -24,7 +24,6 @@ signals:
 public slots:
     void setCurHighlightedWord(QString word);
     void setOffset(RVA offset);
-    void setCanCopy(bool enabled);
     void setFirstOffsetInLine(RVA firstOffset);
     void setAvailableBreakpoints(QVector<RVA> offsetList);
 
@@ -60,7 +59,6 @@ private:
 
     RCodeAnnotation *annotationHere;
 
-    bool canCopy;
     QAction actionCopy;
     QAction actionCopyInstructionAddress;
     QAction actionCopyReferenceAddress;

--- a/src/menus/DecompilerContextMenu.h
+++ b/src/menus/DecompilerContextMenu.h
@@ -20,6 +20,7 @@ public:
 
 signals:
     void copy();
+    void copyLine();
 
 public slots:
     void setCurHighlightedWord(QString word);
@@ -60,6 +61,7 @@ private:
 
     RCodeAnnotation *annotationHere;
 
+    bool canCopy;
     QAction actionCopy;
     QAction actionCopyInstructionAddress;
     QAction actionCopyReferenceAddress;

--- a/src/menus/DecompilerContextMenu.h
+++ b/src/menus/DecompilerContextMenu.h
@@ -20,7 +20,6 @@ public:
 
 signals:
     void copy();
-    void copyLine();
 
 public slots:
     void setCurHighlightedWord(QString word);

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -438,7 +438,6 @@ void DecompilerWidget::colorsUpdatedSlot()
 void DecompilerWidget::showDisasContextMenu(const QPoint &pt)
 {
     mCtxMenu->exec(ui->textEdit->mapToGlobal(pt));
-    doRefresh();
 }
 
 void DecompilerWidget::seekToReference()

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -412,6 +412,7 @@ void DecompilerWidget::updateSelection()
     // Highlight all the words in the document same as the current one
     cursor.select(QTextCursor::WordUnderCursor);
     QString searchString = cursor.selectedText();
+    mCtxMenu->setCurHighlightedWord(searchString);
     extraSelections.append(createSameWordsSelections(ui->textEdit, searchString));
 
     ui->textEdit->setExtraSelections(extraSelections);

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -87,8 +87,6 @@ DecompilerWidget::DecompilerWidget(MainWindow *main) :
     connect(ui->textEdit, SIGNAL(customContextMenuRequested(const QPoint &)),
             this, SLOT(showDisasContextMenu(const QPoint &)));
 
-    // refresh the widget when an action in this menu is triggered
-    connect(mCtxMenu, &QMenu::triggered, this, &DecompilerWidget::refreshDecompiler);
     connect(Core(), &CutterCore::breakpointsChanged, this, &DecompilerWidget::setInfoForBreakpoints);
     addActions(mCtxMenu->actions());
 

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -413,6 +413,13 @@ void DecompilerWidget::updateSelection()
     cursor.select(QTextCursor::WordUnderCursor);
     QString searchString = cursor.selectedText();
     mCtxMenu->setCurHighlightedWord(searchString);
+    // if (searchString.empty()) {
+    //     mCtxMenu->setCurHighlightedWord(searchString);
+    // } else {
+    //     cursor.select(QTextCursor::LineUnderCursor);
+    //     mCtxMenu->setCurHighlightedWord(cursor.selectedText());
+    // }
+    
     extraSelections.append(createSameWordsSelections(ui->textEdit, searchString));
 
     ui->textEdit->setExtraSelections(extraSelections);

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -418,13 +418,6 @@ void DecompilerWidget::updateSelection()
     cursor.select(QTextCursor::WordUnderCursor);
     QString searchString = cursor.selectedText();
     mCtxMenu->setCurHighlightedWord(searchString);
-    // if (searchString.empty()) {
-    //     mCtxMenu->setCurHighlightedWord(searchString);
-    // } else {
-    //     cursor.select(QTextCursor::LineUnderCursor);
-    //     mCtxMenu->setCurHighlightedWord(cursor.selectedText());
-    // }
-    
     extraSelections.append(createSameWordsSelections(ui->textEdit, searchString));
 
     ui->textEdit->setExtraSelections(extraSelections);
@@ -435,12 +428,6 @@ void DecompilerWidget::updateSelection()
 QString DecompilerWidget::getWindowTitle() const
 {
     return tr("Decompiler");
-}
-
-void DecompilerWidget::copyLine()
-{
-    QClipboard *clipboard = QApplication::clipboard();
-    clipboard->setText(QString("How Are You???!!!!"));
 }
 
 void DecompilerWidget::fontsUpdatedSlot()
@@ -524,4 +511,12 @@ bool DecompilerWidget::colorLine(QTextEdit::ExtraSelection extraSelection)
     extraSelections.append(extraSelection);
     ui->textEdit->setExtraSelections(extraSelections);
     return true;
+}
+
+void DecompilerWidget::copyLine()
+{
+    QTextCursor cursor = ui->textEdit->textCursor();
+    cursor.select(QTextCursor::LineUnderCursor);
+    QClipboard *clipboard = QApplication::clipboard();
+    clipboard->setText(cursor.selectedText());
 }

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -36,8 +36,7 @@ DecompilerWidget::DecompilerWidget(MainWindow *main) :
     connect(Config(), SIGNAL(fontsUpdated()), this, SLOT(fontsUpdatedSlot()));
     connect(Config(), SIGNAL(colorsUpdated()), this, SLOT(colorsUpdatedSlot()));
     connect(Core(), SIGNAL(registersChanged()), this, SLOT(highlightPC()));
-    connect(mCtxMenu, &DecompilerContextMenu::copy, ui->textEdit, &QPlainTextEdit::copy);
-    connect(mCtxMenu, &DecompilerContextMenu::copyLine, this, &DecompilerWidget::copyLine);
+    connect(mCtxMenu, &DecompilerContextMenu::copy, this, &DecompilerWidget::copy);
     connect(ui->textEdit, &QPlainTextEdit::selectionChanged, this, [this]() {
         mCtxMenu->setCanCopy(ui->textEdit->textCursor().hasSelection());
     });
@@ -513,10 +512,19 @@ bool DecompilerWidget::colorLine(QTextEdit::ExtraSelection extraSelection)
     return true;
 }
 
-void DecompilerWidget::copyLine()
+void DecompilerWidget::copy()
 {
-    QTextCursor cursor = ui->textEdit->textCursor();
-    cursor.select(QTextCursor::LineUnderCursor);
-    QClipboard *clipboard = QApplication::clipboard();
-    clipboard->setText(cursor.selectedText());
+    if (ui->textEdit->textCursor().hasSelection()) {
+        ui->textEdit->copy();
+    } else {
+        QTextCursor cursor = ui->textEdit->textCursor();
+        QClipboard *clipboard = QApplication::clipboard();
+        cursor.select(QTextCursor::WordUnderCursor);
+        if (!cursor.selectedText().isEmpty()) {
+            clipboard->setText(cursor.selectedText());
+        } else {
+            cursor.select(QTextCursor::LineUnderCursor);
+            clipboard->setText(cursor.selectedText());
+        }
+    }
 }

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -37,9 +37,6 @@ DecompilerWidget::DecompilerWidget(MainWindow *main) :
     connect(Config(), SIGNAL(colorsUpdated()), this, SLOT(colorsUpdatedSlot()));
     connect(Core(), SIGNAL(registersChanged()), this, SLOT(highlightPC()));
     connect(mCtxMenu, &DecompilerContextMenu::copy, this, &DecompilerWidget::copy);
-    connect(ui->textEdit, &QPlainTextEdit::selectionChanged, this, [this]() {
-        mCtxMenu->setCanCopy(ui->textEdit->textCursor().hasSelection());
-    });
 
     decompiledFunctionAddr = RVA_INVALID;
     decompilerWasBusy = false;
@@ -346,7 +343,6 @@ void DecompilerWidget::connectCursorPositionChanged(bool disconnect)
 
 void DecompilerWidget::cursorPositionChanged()
 {
-    mCtxMenu->setCanCopy(ui->textEdit->textCursor().hasSelection());
     // Do not perform seeks along with the cursor while selecting multiple lines
     if (!ui->textEdit->textCursor().selectedText().isEmpty()) {
         return;

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -12,6 +12,7 @@
 #include <QTextEdit>
 #include <QPlainTextEdit>
 #include <QTextBlock>
+#include <QClipboard>
 #include <QObject>
 #include <QTextBlockUserData>
 
@@ -36,6 +37,10 @@ DecompilerWidget::DecompilerWidget(MainWindow *main) :
     connect(Config(), SIGNAL(colorsUpdated()), this, SLOT(colorsUpdatedSlot()));
     connect(Core(), SIGNAL(registersChanged()), this, SLOT(highlightPC()));
     connect(mCtxMenu, &DecompilerContextMenu::copy, ui->textEdit, &QPlainTextEdit::copy);
+    connect(mCtxMenu, &DecompilerContextMenu::copyLine, this, &DecompilerWidget::copyLine);
+    connect(ui->textEdit, &QPlainTextEdit::selectionChanged, this, [this]() {
+        mCtxMenu->setCanCopy(ui->textEdit->textCursor().hasSelection());
+    });
 
     decompiledFunctionAddr = RVA_INVALID;
     decompilerWasBusy = false;
@@ -432,6 +437,12 @@ QString DecompilerWidget::getWindowTitle() const
     return tr("Decompiler");
 }
 
+void DecompilerWidget::copyLine()
+{
+    QClipboard *clipboard = QApplication::clipboard();
+    clipboard->setText(QString("How Are You???!!!!"));
+}
+
 void DecompilerWidget::fontsUpdatedSlot()
 {
     setupFonts();
@@ -465,7 +476,7 @@ bool DecompilerWidget::eventFilter(QObject *obj, QEvent *event)
     if (event->type() == QEvent::MouseButtonPress
             && (obj == ui->textEdit || obj == ui->textEdit->viewport())) {
         QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
-        if (mouseEvent->button() == Qt::RightButton) {
+        if (mouseEvent->button() == Qt::RightButton && !ui->textEdit->textCursor().hasSelection()) {
             ui->textEdit->setTextCursor(ui->textEdit->cursorForPosition(mouseEvent->pos()));
             return true;
         }

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -287,7 +287,7 @@ void DecompilerWidget::decompilationFinished(RAnnotatedCode *codeDecompiled)
     ui->progressLabel->setVisible(false);
     ui->decompilerComboBox->setEnabled(decompilerSelectionEnabled);
     updateRefreshButton();
-    
+
     mCtxMenu->setAnnotationHere(nullptr);
     this->code.reset(codeDecompiled);
     QString codeString = QString::fromUtf8(this->code->code);

--- a/src/widgets/DecompilerWidget.h
+++ b/src/widgets/DecompilerWidget.h
@@ -32,6 +32,7 @@ public slots:
 
     void highlightPC();
 private slots:
+    void copyLine();
     void fontsUpdatedSlot();
     void colorsUpdatedSlot();
     void refreshDecompiler();

--- a/src/widgets/DecompilerWidget.h
+++ b/src/widgets/DecompilerWidget.h
@@ -32,7 +32,7 @@ public slots:
 
     void highlightPC();
 private slots:
-    void copyLine();
+    void copy();
     void fontsUpdatedSlot();
     void colorsUpdatedSlot();
     void refreshDecompiler();


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/developers-docs/first-time.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/developers-docs.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**
This PR implements the following
1. Refactor `actionRenameThingHere` for using the refactored `RCodeAnnotation`. (It now contains one struct inside union named `reference` for annotations of type constant variable, global variable, and function name
2. Implement the basic show in action that shows the decompiled line in other widgets(disassembly, graph, ..)
3. Implement targeted show in menu for functions, global variables, and constant variables
4. Implement add name, rename name, remove name actions for global and constant variables

Actions for global and constant variables 
![renameaddremovename](https://user-images.githubusercontent.com/18501167/87765466-792c7500-c835-11ea-84f1-4271bb493ebb.gif)
Show in action
![showinaction](https://user-images.githubusercontent.com/18501167/87765487-7f225600-c835-11ea-9086-6e7d8dbcfced.gif)

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

**Test plan (required)**
**Note**: CI will fail because the corresponding PRs in r2 and r2ghidra-dec haven't been merged yet.
<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->

1. Fetch PR [#124](https://github.com/radareorg/r2ghidra-dec/pull/124) from r2ghidra-dec before compiling this PR.
2. Check if the rename function action is working as expected after refactoring.
3. Check if the show in action and targeted show in action are working as expected. Suggest a _better text_ for the `targeted show in` action that's shown.
4. Check if `add name,` `remove name`, and `rename name` actions are working perfectly.
5. Check code.

**Detailed Test Plan For actions with annotations for variables**
Download this binary: 
[dectest32.zip](https://github.com/radareorg/cutter/files/4960680/dectest32.zip)
Load in Cutter
Go to function `sym.get_global_array_entry`
You shall see an unnamed global variable that's used there.

_Test for add name/rename/remove name actions for global variables_

- [ ] Right-click on the address(that refer to the global variable) -> Add name -> Give a name. It should now show the name that you gave instead of `*(undefined4 *)0x804c034`
- [ ] Click on that variable -> Shift+N (shortcut) -> It should now show the rename dialog, give a new name and see if it's changing as it should.
- [ ] Right-click on the variable -> Click on `Remove name` -> The name should get removed and you should be seeing `*(undefined4 *)0x804c034`.

_Test for show-in action for global variables_

- [ ] Right-click on the variable -> You should be seeing a menu with text: `Show 0x804c034(addr here)`.
- [ ] Go to that menu and click various options and make sure they are opening new widgets for the offset `0x804c034`.
- [ ] Go back to the decompiler and add a name to the variable.
- [ ] Right-click on the variable -> You should be seeing a menu with text `Show <name of variable> in` instead of `Show 0x804c034(addr here)`.
- [ ] Go to the menu and click on the different actions and make sure all of them are working like how the corresponding `show at address` in the disassembly works.

_Test for show-in action for constant variables that are annotated_

- [ ] Go to function `sym.PrintAmbassador`
- [ ] Right-click `pure` in the line `sym.imp.printf("pure");`.
- [ ] You should not be seeing any rename/add/remove name actions.
- [ ] You should be seeing a menu named `Show str.pure in`
- [ ] Go into the menu and test all the actions and make sure they are working like how you tested show-in menu actions for the global variables.

<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
