### PR TITLE
Reorganize R2GraphWidget UI.

### DIFF
--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -1351,6 +1351,7 @@ void MainWindow::setViewLayout(const CutterLayout &layout)
             dock->deserializeViewProperties({}); // call with empty properties to reset the widget
             newDocks.push_back(dock);
         }
+        dock->ignoreVisibilityStatus(true);
     }
 
     if (!isDefault) {
@@ -1372,6 +1373,10 @@ void MainWindow::setViewLayout(const CutterLayout &layout)
         } else {
             showZenDocks();
         }
+    }
+
+    for (auto dock : dockWidgets) {
+        dock->ignoreVisibilityStatus(false);
     }
 }
 

--- a/src/widgets/CutterDockWidget.cpp
+++ b/src/widgets/CutterDockWidget.cpp
@@ -43,6 +43,12 @@ void CutterDockWidget::deserializeViewProperties(const QVariantMap &)
 {
 }
 
+void CutterDockWidget::ignoreVisibilityStatus(bool ignore)
+{
+    this->ignoreVisibility = ignore;
+    updateIsVisibleToUser();
+}
+
 void CutterDockWidget::toggleDockWidget(bool show)
 {
     if (!show) {
@@ -61,7 +67,7 @@ QWidget *CutterDockWidget::widgetToFocusOnRaise()
 void CutterDockWidget::updateIsVisibleToUser()
 {
     // Check if the user can actually see the widget.
-    bool visibleToUser = isVisible() && !visibleRegion().isEmpty();
+    bool visibleToUser = isVisible() && !visibleRegion().isEmpty() && !ignoreVisibility;
     if (visibleToUser == isVisibleToUserCurrent) {
         return;
     }

--- a/src/widgets/CutterDockWidget.h
+++ b/src/widgets/CutterDockWidget.h
@@ -86,6 +86,12 @@ public:
      * @see CutterDockWidget#serializeViewProprties
      */
     virtual void deserializeViewProperties(const QVariantMap &properties);
+    /**
+     * @brief Ignore visibility status.
+     * Useful for temporary ignoring visibility changes while this information is unreliable.
+     * @param ignored - set to true for enabling ignoring mode
+     */
+    void ignoreVisibilityStatus(bool ignored);
 signals:
     void becameVisibleToUser();
     void closed();
@@ -105,6 +111,7 @@ private:
     bool isTransient = false;
 
     bool isVisibleToUserCurrent = false;
+    bool ignoreVisibility = false;
     void updateIsVisibleToUser();
 };
 

--- a/src/widgets/R2GraphWidget.cpp
+++ b/src/widgets/R2GraphWidget.cpp
@@ -19,16 +19,16 @@ R2GraphWidget::R2GraphWidget(MainWindow *main)
         QChar commandChar;
         QString label;
     } types[] = {
-        {'a', tr("aga - Data reference graph")},
-        {'A', tr("agA - Global data references graph")},
+        {'a', tr("Data reference graph (aga)")},
+        {'A', tr("Global data references graph (agA)")},
         // {'c', tr("c - Function callgraph")},
         // {'C', tr("C - Global callgraph")},
         // {'f', tr("f - Basic blocks function graph")},
-        {'i', tr("agi - Imports graph")},
-        {'r', tr("agr - References graph")},
-        {'R', tr("agR - Global references graph")},
-        {'x', tr("agx - Cross references graph")},
-        {'g', tr("agg - Custom graph")},
+        {'i', tr("Imports graph (agi)")},
+        {'r', tr("References graph (agr)")},
+        {'R', tr("Global references graph (agR)")},
+        {'x', tr("Cross references graph (agx)")},
+        {'g', tr("Custom graph (agg)")},
         {' ', tr("User command")},
     };
     for (auto &graphType : types) {
@@ -47,6 +47,8 @@ R2GraphWidget::R2GraphWidget(MainWindow *main)
         graphView->setGraphCommand(ui->customCommand->text());
         graphView->refreshView();
     });
+    ui->customCommand->hide();
+    typeChanged();
 }
 
 R2GraphWidget::~R2GraphWidget()
@@ -57,14 +59,12 @@ void R2GraphWidget::typeChanged()
 {
     auto currentData = ui->graphType->currentData();
     if (currentData.isNull()) {
-        ui->customCommand->setEnabled(true);
-        ui->customCommand->clear();
+        ui->customCommand->setVisible(true);
         graphView->setGraphCommand(ui->customCommand->text());
         ui->customCommand->setFocus();
     } else {
-        ui->customCommand->setEnabled(false);
+        ui->customCommand->setVisible(false);
         auto command = QString("ag%1").arg(currentData.toChar());
-        ui->customCommand->setText(command);
         graphView->setGraphCommand(command);
         graphView->refreshView();
     }

--- a/src/widgets/R2GraphWidget.cpp
+++ b/src/widgets/R2GraphWidget.cpp
@@ -47,7 +47,6 @@ R2GraphWidget::R2GraphWidget(MainWindow *main)
         graphView->setGraphCommand(ui->customCommand->text());
         graphView->refreshView();
     });
-    ui->customCommand->setVisible(false);
 }
 
 R2GraphWidget::~R2GraphWidget()
@@ -58,12 +57,14 @@ void R2GraphWidget::typeChanged()
 {
     auto currentData = ui->graphType->currentData();
     if (currentData.isNull()) {
-        ui->customCommand->setVisible(true);
+        ui->customCommand->setEnabled(true);
+        ui->customCommand->clear();
         graphView->setGraphCommand(ui->customCommand->text());
         ui->customCommand->setFocus();
     } else {
-        ui->customCommand->setVisible(false);
+        ui->customCommand->setEnabled(false);
         auto command = QString("ag%1").arg(currentData.toChar());
+        ui->customCommand->setText(command);
         graphView->setGraphCommand(command);
         graphView->refreshView();
     }

--- a/src/widgets/R2GraphWidget.ui
+++ b/src/widgets/R2GraphWidget.ui
@@ -59,6 +59,22 @@
        </widget>
       </item>
       <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::MinimumExpanding</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>0</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
        <widget class="QPushButton" name="refreshButton">
         <property name="text">
          <string/>

--- a/src/widgets/R2GraphWidget.ui
+++ b/src/widgets/R2GraphWidget.ui
@@ -30,29 +30,58 @@
     <item>
      <layout class="QHBoxLayout" name="horizontalLayout_2">
       <item>
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>ag</string>
-        </property>
-       </widget>
-      </item>
-      <item>
        <widget class="QComboBox" name="graphType">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
         <property name="editable">
-         <bool>true</bool>
+         <bool>false</bool>
         </property>
        </widget>
       </item>
       <item>
+       <widget class="QLineEdit" name="customCommand">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>1</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="placeholderText">
+         <string>ag...</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::MinimumExpanding</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
        <widget class="QPushButton" name="refreshButton">
         <property name="text">
-         <string>Refresh</string>
+         <string/>
+        </property>
+        <property name="icon">
+         <iconset resource="../resources.qrc">
+          <normaloff>:/img/icons/arrow_right.svg</normaloff>:/img/icons/arrow_right.svg</iconset>
         </property>
        </widget>
       </item>
@@ -61,6 +90,8 @@
    </layout>
   </widget>
  </widget>
- <resources/>
+ <resources>
+  <include location="../resources.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/src/widgets/R2GraphWidget.ui
+++ b/src/widgets/R2GraphWidget.ui
@@ -59,6 +59,17 @@
        </widget>
       </item>
       <item>
+       <widget class="QPushButton" name="refreshButton">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="icon">
+         <iconset resource="../resources.qrc">
+          <normaloff>:/img/icons/arrow_right.svg</normaloff>:/img/icons/arrow_right.svg</iconset>
+        </property>
+       </widget>
+      </item>
+      <item>
        <spacer name="horizontalSpacer">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
@@ -73,17 +84,6 @@
          </size>
         </property>
        </spacer>
-      </item>
-      <item>
-       <widget class="QPushButton" name="refreshButton">
-        <property name="text">
-         <string/>
-        </property>
-        <property name="icon">
-         <iconset resource="../resources.qrc">
-          <normaloff>:/img/icons/arrow_right.svg</normaloff>:/img/icons/arrow_right.svg</iconset>
-        </property>
-       </widget>
       </item>
      </layout>
     </item>

--- a/src/widgets/R2GraphWidget.ui
+++ b/src/widgets/R2GraphWidget.ui
@@ -59,22 +59,6 @@
        </widget>
       </item>
       <item>
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::MinimumExpanding</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>0</width>
-          <height>0</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
        <widget class="QPushButton" name="refreshButton">
         <property name="text">
          <string/>


### PR DESCRIPTION

<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/developers-docs/first-time.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/developers-docs.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

* Move custom command input to separate input field. It wasn't obvious that you can enter text in combobox and it also didn't allow easily reacting to enter key.
* Refresh graph on index change and enter key.


**Test plan (required)**

![Screenshot from 2020-07-18 18-33-02](https://user-images.githubusercontent.com/7101031/87856116-7315c180-c925-11ea-91c9-1e219dac4fb4.png)
![Screenshot from 2020-07-18 18-34-48](https://user-images.githubusercontent.com/7101031/87856117-7610b200-c925-11ea-8b45-c7c0e83d4cf0.png)
![Screenshot from 2020-07-18 18-34-56](https://user-images.githubusercontent.com/7101031/87856118-77da7580-c925-11ea-913d-2869a4698349.png)


**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
