### PR TITLE
Reset last seen memory widget during layout switching.

### DIFF
--- a/src/widgets/AddressableDockWidget.cpp
+++ b/src/widgets/AddressableDockWidget.cpp
@@ -20,13 +20,6 @@ AddressableDockWidget::AddressableDockWidget(MainWindow *parent)
     setContextMenuPolicy(Qt::ContextMenuPolicy::DefaultContextMenu);
 }
 
-void AddressableDockWidget::raiseMemoryWidget()
-{
-    show();
-    raise();
-    widgetToFocusOnRaise()->setFocus(Qt::FocusReason::TabFocusReason);
-}
-
 QVariantMap AddressableDockWidget::serializeViewProprties()
 {
     auto result = CutterDockWidget::serializeViewProprties();

--- a/src/widgets/AddressableDockWidget.h
+++ b/src/widgets/AddressableDockWidget.h
@@ -17,8 +17,6 @@ public:
 
     CutterSeekable *getSeekable() const;
 
-    void raiseMemoryWidget();
-
     QVariantMap serializeViewProprties() override;
     void deserializeViewProperties(const QVariantMap &properties) override;
 public slots:

--- a/src/widgets/CutterDockWidget.cpp
+++ b/src/widgets/CutterDockWidget.cpp
@@ -49,6 +49,13 @@ void CutterDockWidget::ignoreVisibilityStatus(bool ignore)
     updateIsVisibleToUser();
 }
 
+void CutterDockWidget::raiseMemoryWidget()
+{
+    show();
+    raise();
+    widgetToFocusOnRaise()->setFocus(Qt::FocusReason::TabFocusReason);
+}
+
 void CutterDockWidget::toggleDockWidget(bool show)
 {
     if (!show) {

--- a/src/widgets/CutterDockWidget.h
+++ b/src/widgets/CutterDockWidget.h
@@ -92,6 +92,8 @@ public:
      * @param ignored - set to true for enabling ignoring mode
      */
     void ignoreVisibilityStatus(bool ignored);
+
+    void raiseMemoryWidget();
 signals:
     void becameVisibleToUser();
     void closed();


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)

**Detailed description**

Fix a bug causing incorrectly choosing the memory widget to raise. It probably got broken during layout rework.


**Test plan (required)**

* Test the focus bug
    * Open Cutter, reset layout, make sure dashboard is on top  and hexwidget is last widget in the tab bar
    * Restart Cutter
    * Double click a function in function widget, make sure disassembly widget is shown (before fix it would show hexwidget)
* Test that in case there is a widget to use it is used instead of disassembly
    * Switch to graph widget
    * Restart cutter
    * double click a function in function widget, make sure it is shown in graph widget
    * switch to disassembly, double click function widget, make sure function is shown in disassembly widget

Test default focus logic:
a) single disassembly  widget
* Switch to disassembly widget
* Restart cutter, and don't click anything after opening executable
* Use j/k or arrow keys to verify that disassembly widget has focus

b) single graph widget
* Same steps a case a) but with graph widget

c) graph widget next to disassembly widget
* open graph widget side by side with disassembly widget
* restart cutter
* make sure graph widget has focus by using keyboard

d) dashboard
* switch to dashboard
* restart cutter
* make sure the focus logic didn't try to raise a memory widget

**Closing issues**
