### PR TITLE
Fix the "all green" navbar

### DIFF
--- a/src/common/TempConfig.cpp
+++ b/src/common/TempConfig.cpp
@@ -34,6 +34,16 @@ TempConfig &TempConfig::set(const QString &key, const QString &value)
     return *this;
 }
 
+TempConfig &TempConfig::set(const QString &key, const char *value)
+{
+    if (!resetValues.contains(key)) {
+        resetValues[key] = Core()->getConfig(key);
+    }
+
+    Core()->setConfig(key, value);
+    return *this;
+}
+
 TempConfig &TempConfig::set(const QString &key, int value)
 {
     if (!resetValues.contains(key)) {

--- a/src/common/TempConfig.h
+++ b/src/common/TempConfig.h
@@ -29,6 +29,7 @@ public:
     ~TempConfig();
 
     TempConfig &set(const QString &key, const QString &value);
+    TempConfig &set(const QString &key, const char *value);
     TempConfig &set(const QString &key, int value);
     TempConfig &set(const QString &key, bool value);
 

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -956,6 +956,18 @@ QString CutterCore::itoa(ut64 num, int rdx)
     return QString::number(num, rdx);
 }
 
+void CutterCore::setConfig(const char *k, const char *v)
+{
+    CORE_LOCK();
+    r_config_set(core->config, k, v);
+}
+
+void CutterCore::setConfig(const QString &k, const char *v)
+{
+    CORE_LOCK();
+    r_config_set(core->config, k.toUtf8().constData(), v);
+}
+
 void CutterCore::setConfig(const char *k, const QString &v)
 {
     CORE_LOCK();

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -3409,7 +3409,15 @@ BlockStatistics CutterCore::getBlockStatistics(unsigned int blocksCount)
         return blockStats;
     }
 
-    QJsonObject statsObj = cmdj("p-j " + QString::number(blocksCount)).object();
+    QJsonObject statsObj;
+
+    // User TempConfig here to set the search boundaries to all sections. This makes sure
+    // that the Visual Navbar will show all the relevant addresses.
+    {
+        TempConfig tempConfig;
+        tempConfig.set("search.in", "bin.sections");
+        statsObj = cmdj("p-j " + QString::number(blocksCount)).object();
+    }
 
     blockStats.from = statsObj[RJsonKey::from].toVariant().toULongLong();
     blockStats.to = statsObj[RJsonKey::to].toVariant().toULongLong();

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -287,6 +287,8 @@ public:
     QString itoa(ut64 num, int rdx = 16);
 
     /* Config functions */
+    void setConfig(const char *k, const char *v);
+    void setConfig(const QString &k, const char *v);
     void setConfig(const char *k, const QString &v);
     void setConfig(const QString &k, const QString &v) { setConfig(k.toUtf8().constData(), v); }
     void setConfig(const char *k, int v);


### PR DESCRIPTION
**Detailed description**
To fix this issue I had to add several overloads. And then, temporarily set `bin.sections` for `search.in` via TempConfig.
This makes Cutter to show data from all relevant addresses and not only current map.

![image](https://user-images.githubusercontent.com/20182642/87973370-122aec80-cad1-11ea-973a-85f9dec2d099.png)

That said, I noticed a strange behavior with `megabeets_0x1` (attached). It shows everything empty

[megabeets_0x1.zip](https://github.com/radareorg/cutter/files/4949469/megabeets_0x1.zip)

**Closing issues**

closes #2195 
