### PR TITLE
Fix sorting resources by index, vaddr and size

### DIFF
--- a/src/widgets/ResourcesWidget.cpp
+++ b/src/widgets/ResourcesWidget.cpp
@@ -1,5 +1,6 @@
 #include "common/Helpers.h"
 #include "ResourcesWidget.h"
+#include "ui_ListDockWidget.h"
 #include "core/MainWindow.h"
 #include <QVBoxLayout>
 
@@ -105,6 +106,8 @@ ResourcesWidget::ResourcesWidget(MainWindow *main, QAction *action) :
     filterModel = new AddressableFilterProxyModel(model, this);
     filterModel->setSortRole(Qt::EditRole);
     setModels(filterModel);
+
+    ui->treeView->sortByColumn(0, Qt::AscendingOrder);
 
     showCount(false);
 

--- a/src/widgets/ResourcesWidget.cpp
+++ b/src/widgets/ResourcesWidget.cpp
@@ -41,6 +41,23 @@ QVariant ResourcesModel::data(const QModelIndex &index, int role) const
         default:
             return QVariant();
         }
+    case Qt::EditRole:
+        switch (index.column()) {
+        case NAME:
+            return res.name;
+        case VADDR:
+            return res.vaddr;
+        case INDEX:
+            return res.index;
+        case TYPE:
+            return res.type;
+        case SIZE:
+            return res.size;
+        case LANG:
+            return res.lang;
+        default:
+            return QVariant();
+        }
     case Qt::UserRole:
         return QVariant::fromValue(res);
     default:
@@ -86,6 +103,7 @@ ResourcesWidget::ResourcesWidget(MainWindow *main, QAction *action) :
 
     model = new ResourcesModel(&resources, this);
     filterModel = new AddressableFilterProxyModel(model, this);
+    filterModel->setSortRole(Qt::EditRole);
     setModels(filterModel);
 
     showCount(false);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->
This is supposed to be a fix for issue #2272 . The problem was that sorting was done using a "byte-count" formatted string which should be only used for displaying (`Qt::DisplayRole`). This fix uses `Qt::EditRole` as the sorting role. `ResourcesModel::data()` returns the correct value depending on the parameter `role`:

* a byte-count formatted string in case of `Qt::DisplayRole`
* the numerical byte count in case of `Qt::EditRole`

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->

1. Launch Cutter and load a PE32 file
2. Go to 'Resources' tab
3. Sort by "Size"

Sorting is done by numerical order and not string.

<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

Closes #2272