### PR TITLE
Non-C string handling was a usability nightmare

### DIFF
--- a/src/dialogs/EditStringDialog.cpp
+++ b/src/dialogs/EditStringDialog.cpp
@@ -8,7 +8,6 @@ EditStringDialog::EditStringDialog(QWidget *parent)
     ui->setupUi(this);
     ui->spinBox_size->setMinimum(0);
     ui->lineEdit_address->setMinimumWidth(150);
-    ui->pushButton_ok->setDefault(true);
     ui->spinBox_size->setFocus();
     ui->comboBox_type->addItems({"Auto", "ASCII/Latin1", "UTF-8"});
     connect(ui->checkBox_autoSize, &QCheckBox::toggled, ui->spinBox_size, &QSpinBox::setDisabled);

--- a/src/dialogs/EditStringDialog.cpp
+++ b/src/dialogs/EditStringDialog.cpp
@@ -8,8 +8,8 @@ EditStringDialog::EditStringDialog(QWidget *parent)
     ui->setupUi(this);
     ui->spinBox_size->setMinimum(0);
     ui->lineEdit_address->setMinimumWidth(150);
-    ui->pushButton_ok->setFocus();
     ui->pushButton_ok->setDefault(true);
+    ui->spinBox_size->setFocus();
     ui->comboBox_type->addItems({"Auto", "ASCII/Latin1", "UTF-8"});
     connect(ui->checkBox_autoSize, &QCheckBox::toggled, ui->spinBox_size, &QSpinBox::setDisabled);
 }

--- a/src/dialogs/EditStringDialog.cpp
+++ b/src/dialogs/EditStringDialog.cpp
@@ -9,6 +9,7 @@ EditStringDialog::EditStringDialog(QWidget *parent)
     ui->spinBox_size->setMinimum(0);
     ui->lineEdit_address->setMinimumWidth(150);
     ui->pushButton_ok->setFocus();
+    ui->pushButton_ok->setDefault(true);
     ui->comboBox_type->addItems({"Auto", "ASCII/Latin1", "UTF-8"});
     connect(ui->checkBox_autoSize, &QCheckBox::toggled, ui->spinBox_size, &QSpinBox::setDisabled);
 }

--- a/src/dialogs/EditStringDialog.cpp
+++ b/src/dialogs/EditStringDialog.cpp
@@ -3,7 +3,7 @@
 
 EditStringDialog::EditStringDialog(QWidget *parent)
     :   QDialog(parent)
-    ,   ui(new Ui::EditStringDialog)
+    ,   ui(new Ui::EditStringDialog{})
 {
     ui->setupUi(this);
     ui->spinBox_size->setMinimum(0);
@@ -13,10 +13,7 @@ EditStringDialog::EditStringDialog(QWidget *parent)
     connect(ui->checkBox_autoSize, &QCheckBox::toggled, ui->spinBox_size, &QSpinBox::setDisabled);
 }
 
-EditStringDialog::~EditStringDialog()
-{
-    delete ui;
-}
+EditStringDialog::~EditStringDialog() { }
 
 void EditStringDialog::setStringStartAddress(uint64_t address)
 {

--- a/src/dialogs/EditStringDialog.h
+++ b/src/dialogs/EditStringDialog.h
@@ -1,6 +1,7 @@
 #ifndef EDITSTRINGDIALOG_H
 #define EDITSTRINGDIALOG_H
 
+#include <memory>
 #include <QDialog>
 
 namespace Ui {
@@ -52,7 +53,7 @@ public:
     StringType getStringType() const;
 
 private:
-    Ui::EditStringDialog *ui;
+    std::unique_ptr<Ui::EditStringDialog> ui;
 };
 
 #endif // EDITSTRINGDIALOG_H

--- a/src/dialogs/EditStringDialog.ui
+++ b/src/dialogs/EditStringDialog.ui
@@ -23,6 +23,19 @@
    <string>Edit string</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <item row="1" column="0">
+    <widget class="QDialogButtonBox" name="dialogButtonBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
    <item row="0" column="0" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
@@ -89,20 +102,6 @@
      </item>
     </layout>
    </item>
-   <item row="1" column="0">
-    <widget class="QPushButton" name="pushButton_cancel">
-     <property name="text">
-      <string>Cancel</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QPushButton" name="pushButton_ok">
-     <property name="text">
-      <string>OK</string>
-     </property>
-    </widget>
-   </item>
   </layout>
  </widget>
  <tabstops>
@@ -110,16 +109,14 @@
   <tabstop>checkBox_autoSize</tabstop>
   <tabstop>comboBox_type</tabstop>
   <tabstop>lineEdit_address</tabstop>
-  <tabstop>pushButton_ok</tabstop>
-  <tabstop>pushButton_cancel</tabstop>
  </tabstops>
  <resources/>
  <connections>
   <connection>
-   <sender>pushButton_cancel</sender>
-   <signal>clicked()</signal>
+   <sender>dialogButtonBox</sender>
+   <signal>accepted()</signal>
    <receiver>EditStringDialog</receiver>
-   <slot>reject()</slot>
+   <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>51</x>
@@ -132,10 +129,10 @@
    </hints>
   </connection>
   <connection>
-   <sender>pushButton_ok</sender>
-   <signal>clicked()</signal>
+   <sender>dialogButtonBox</sender>
+   <signal>rejected()</signal>
    <receiver>EditStringDialog</receiver>
-   <slot>accept()</slot>
+   <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>143</x>

--- a/src/dialogs/EditStringDialog.ui
+++ b/src/dialogs/EditStringDialog.ui
@@ -41,13 +41,6 @@
      <item>
       <layout class="QVBoxLayout" name="verticalLayout_2">
        <item>
-        <widget class="QLabel" name="label_address">
-         <property name="text">
-          <string>Address:</string>
-         </property>
-        </widget>
-       </item>
-       <item>
         <widget class="QLabel" name="label_size">
          <property name="minimumSize">
           <size>
@@ -67,23 +60,23 @@
          </property>
         </widget>
        </item>
+       <item>
+        <widget class="QLabel" name="label_address">
+         <property name="text">
+          <string>Address:</string>
+         </property>
+        </widget>
+       </item>
       </layout>
      </item>
      <item>
       <layout class="QVBoxLayout" name="verticalLayout">
        <item>
-        <widget class="QLineEdit" name="lineEdit_address">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item>
         <widget class="QSpinBox" name="spinBox_size">
          <property name="minimumSize">
           <size>
            <width>150</width>
-           <height>0</height>
+           <height>24</height>
           </size>
          </property>
         </widget>
@@ -91,9 +84,16 @@
        <item>
         <widget class="QComboBox" name="comboBox_type"/>
        </item>
+       <item>
+        <widget class="QLineEdit" name="lineEdit_address">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
       </layout>
      </item>
-     <item>
+     <item alignment="Qt::AlignTop">
       <widget class="QCheckBox" name="checkBox_autoSize">
        <property name="text">
         <string>Auto</string>

--- a/src/dialogs/EditStringDialog.ui
+++ b/src/dialogs/EditStringDialog.ui
@@ -109,6 +109,7 @@
   <tabstop>checkBox_autoSize</tabstop>
   <tabstop>comboBox_type</tabstop>
   <tabstop>lineEdit_address</tabstop>
+  <tabstop>dialogButtonBox</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/dialogs/EditStringDialog.ui
+++ b/src/dialogs/EditStringDialog.ui
@@ -105,6 +105,14 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>spinBox_size</tabstop>
+  <tabstop>checkBox_autoSize</tabstop>
+  <tabstop>comboBox_type</tabstop>
+  <tabstop>lineEdit_address</tabstop>
+  <tabstop>pushButton_ok</tabstop>
+  <tabstop>pushButton_cancel</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -248,7 +248,7 @@ void DisassemblyContextMenu::addSetAsMenu()
     initAction(&actionSetAsStringRemove, tr("Remove"),
                SLOT(on_actionSetAsStringRemove_triggered()));
     initAction(&actionSetAsStringAdvanced, tr("Advanced"),
-               SLOT(on_actionSetAsStringAdvanced_triggered()));
+               SLOT(on_actionSetAsStringAdvanced_triggered()), getSetAsStringAdvanced());
 
 
     setAsString->addAction(&actionSetAsStringAuto);
@@ -604,6 +604,10 @@ QKeySequence DisassemblyContextMenu::getSetAsStringSequence() const
     return {Qt::Key_A};
 }
 
+QKeySequence DisassemblyContextMenu::getSetAsStringAdvanced() const
+{
+	return {Qt::SHIFT + Qt::Key_A};
+}
 
 QKeySequence DisassemblyContextMenu::getSetToDataSequence() const
 {

--- a/src/menus/DisassemblyContextMenu.h
+++ b/src/menus/DisassemblyContextMenu.h
@@ -89,6 +89,7 @@ private:
     QKeySequence getCopyAddressSequence() const;
     QKeySequence getSetToCodeSequence() const;
     QKeySequence getSetAsStringSequence() const;
+    QKeySequence getSetAsStringAdvanced() const;
     QKeySequence getSetToDataSequence() const;
     QKeySequence getSetToDataExSequence() const;
     QKeySequence getAddFlagSequence() const;


### PR DESCRIPTION
**Your checklist for this pull request**

- [🗸] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [🗸] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [🗸] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)

**Detailed description**

I'm trying to handle multiple Pascal (8-bit length) strings in a binary m68k dump which, as they are not C-string and have no null termination, the automatic string parsing barfs on.. so, till I can figure out how to write a pascal string parser for Cutter, I have opted to improve the usability of the advanced string definition dialog as it was bad.

I'm having to convert hundreds of strings by hand, so the workflow of having to open the menu, navigate to the correct submenu, open the string dialog, click into the size field, and then click ok, was starting to mess up my wrist as well as being very error-prone. This converts all these actions to keyboard usage.

My original plan was to bind this workflow to the 'S' key (or rebind normal string handling to S and bind this to A for "Advanced string", however I could not get this to work.

**Test plan (required)**

 * Open a binary dump that has a non-C string in it (for example, https://github.com/lethalbit/IBM-9348-002-Microcode/blob/main/bins_modified/88780-12427-U502-5X4-Rev.6.81-board0-PROM.elf)
 * Go to the string address (0x104 in the example)
 * Use the shortcut Shift + A to open the advanced string dialog
 * Enter the length of the string (now the default focused item, 60 characters in my example file)
 * Use the Enter key to confirm the entry instead of using the OK button

If all is working as it should, you should now see the string properly and have not had to touch the mouse to get to that point.

**Closing issues**

None
