### PR TITLE
Test if latest appveyor image update broke shibokken

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,5 @@
 version: '1.11.0-git-{build}'
-image: 'Visual Studio 2019'
+image: 'Previous Visual Studio 2019'
 clone_depth: 1
 
 # Build configuration


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Latest appveyor image update caused shibokken executable to fail with error
```
NMAKE : fatal error U1077: 'C:\projects\cutter\cutter-deps\pyside\bin\shiboken2.exe' : return code '0xc0000139'
```
[Microsoft documentation](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/596a1078-e883-4972-9bbc-49e60bebca55) mentions dll loading problems. Since cutter deps which contain shibboken executable weren't modified maybe some of the system or vcruntime dlls got downgraded. I hope that this will not be a problem with next Appveyor update after which the current nonworking VM image will become previous. An alternative approach that might help would be rebuilding Qt using older Visual Studio, but I don't want to do it right now.

No need to create a reminder for this as once the next update happens we will see it.

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->


<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
