### PR TITLE
Display jumping fix useless decompilation

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -2069,14 +2069,14 @@ void CutterCore::toggleBreakpoint(RVA addr)
 {
     cmdRaw(QString("dbs %1").arg(addr));
     emit instructionChanged(addr);
-    emit breakpointsChanged();
+    emit breakpointsChanged(addr);
 }
 
 void CutterCore::toggleBreakpoint(QString addr)
 {
     cmdRaw("dbs " + addr);
     emit instructionChanged(addr.toULongLong());
-    emit breakpointsChanged();
+    emit breakpointsChanged(addr.toULongLong());
 }
 
 
@@ -2084,7 +2084,7 @@ void CutterCore::addBreakpoint(QString addr)
 {
     cmdRaw("db " + addr);
     emit instructionChanged(addr.toULongLong());
-    emit breakpointsChanged();
+    emit breakpointsChanged(addr.toULongLong());
 }
 
 void CutterCore::addBreakpoint(const BreakpointDescription &config)
@@ -2139,7 +2139,7 @@ void CutterCore::addBreakpoint(const BreakpointDescription &config)
         updateOwnedCharPtr(breakpoint->data, config.command);
     }
     emit instructionChanged(breakpoint->addr);
-    emit breakpointsChanged();
+    emit breakpointsChanged(breakpoint->addr);
 }
 
 void CutterCore::updateBreakpoint(int index, const BreakpointDescription &config)
@@ -2158,7 +2158,7 @@ void CutterCore::delBreakpoint(RVA addr)
 {
     cmdRaw("db- " + RAddressString(addr));
     emit instructionChanged(addr);
-    emit breakpointsChanged();
+    emit breakpointsChanged(addr);
 }
 
 void CutterCore::delAllBreakpoints()
@@ -2171,14 +2171,14 @@ void CutterCore::enableBreakpoint(RVA addr)
 {
     cmdRaw("dbe " + RAddressString(addr));
     emit instructionChanged(addr);
-    emit breakpointsChanged();
+    emit breakpointsChanged(addr);
 }
 
 void CutterCore::disableBreakpoint(RVA addr)
 {
     cmdRaw("dbd " + RAddressString(addr));
     emit instructionChanged(addr);
-    emit breakpointsChanged();
+    emit breakpointsChanged(addr);
 }
 
 void CutterCore::setBreakpointTrace(int index, bool enabled)

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -2073,15 +2073,7 @@ void CutterCore::toggleBreakpoint(RVA addr)
 
 void CutterCore::toggleBreakpoint(QString addr)
 {
-    cmdRaw("dbs " + addr);
-    emit breakpointsChanged(addr.toULongLong());
-}
-
-
-void CutterCore::addBreakpoint(QString addr)
-{
-    cmdRaw("db " + addr);
-    emit breakpointsChanged(addr.toULongLong());
+    toggleBreakpoint(addr.toULongLong());
 }
 
 void CutterCore::addBreakpoint(const BreakpointDescription &config)

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -2068,14 +2068,12 @@ void CutterCore::setDebugPlugin(QString plugin)
 void CutterCore::toggleBreakpoint(RVA addr)
 {
     cmdRaw(QString("dbs %1").arg(addr));
-    emit instructionChanged(addr);
     emit breakpointsChanged(addr);
 }
 
 void CutterCore::toggleBreakpoint(QString addr)
 {
     cmdRaw("dbs " + addr);
-    emit instructionChanged(addr.toULongLong());
     emit breakpointsChanged(addr.toULongLong());
 }
 
@@ -2083,7 +2081,6 @@ void CutterCore::toggleBreakpoint(QString addr)
 void CutterCore::addBreakpoint(QString addr)
 {
     cmdRaw("db " + addr);
-    emit instructionChanged(addr.toULongLong());
     emit breakpointsChanged(addr.toULongLong());
 }
 
@@ -2138,7 +2135,6 @@ void CutterCore::addBreakpoint(const BreakpointDescription &config)
     if (!config.command.isEmpty()) {
         updateOwnedCharPtr(breakpoint->data, config.command);
     }
-    emit instructionChanged(breakpoint->addr);
     emit breakpointsChanged(breakpoint->addr);
 }
 
@@ -2157,7 +2153,6 @@ void CutterCore::updateBreakpoint(int index, const BreakpointDescription &config
 void CutterCore::delBreakpoint(RVA addr)
 {
     cmdRaw("db- " + RAddressString(addr));
-    emit instructionChanged(addr);
     emit breakpointsChanged(addr);
 }
 
@@ -2170,14 +2165,12 @@ void CutterCore::delAllBreakpoints()
 void CutterCore::enableBreakpoint(RVA addr)
 {
     cmdRaw("dbe " + RAddressString(addr));
-    emit instructionChanged(addr);
     emit breakpointsChanged(addr);
 }
 
 void CutterCore::disableBreakpoint(RVA addr)
 {
     cmdRaw("dbd " + RAddressString(addr));
-    emit instructionChanged(addr);
     emit breakpointsChanged(addr);
 }
 

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -2071,11 +2071,6 @@ void CutterCore::toggleBreakpoint(RVA addr)
     emit breakpointsChanged(addr);
 }
 
-void CutterCore::toggleBreakpoint(QString addr)
-{
-    toggleBreakpoint(addr.toULongLong());
-}
-
 void CutterCore::addBreakpoint(const BreakpointDescription &config)
 {
     CORE_LOCK();

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -644,7 +644,7 @@ signals:
     void commentsChanged();
     void registersChanged();
     void instructionChanged(RVA offset);
-    void breakpointsChanged();
+    void breakpointsChanged(RVA offset);
     void refreshCodeViews();
     void stackChanged();
     /**

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -395,7 +395,6 @@ public:
     void addBreakpoint(const BreakpointDescription &config);
     void updateBreakpoint(int index, const BreakpointDescription &config);
     void toggleBreakpoint(RVA addr);
-    void toggleBreakpoint(QString addr);
     void delBreakpoint(RVA addr);
     void delAllBreakpoints();
     void enableBreakpoint(RVA addr);

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -392,7 +392,6 @@ public:
     void stepOverDebug();
     void stepOutDebug();
 
-    void addBreakpoint(QString addr);
     void addBreakpoint(const BreakpointDescription &config);
     void updateBreakpoint(int index, const BreakpointDescription &config);
     void toggleBreakpoint(RVA addr);

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -21,7 +21,12 @@ DecompilerWidget::DecompilerWidget(MainWindow *main) :
     mCtxMenu(new DecompilerContextMenu(this, main)),
     ui(new Ui::DecompilerWidget),
     code(Decompiler::makeWarning(tr("Choose an offset and refresh to get decompiled code")),
-         &r_annotated_code_free)
+         &r_annotated_code_free),
+    scrollerHorizontal(0),
+    scrollerVertical(0),
+    previousFunctionAddr(RVA_INVALID),
+    decompiledFunctionAddr(RVA_INVALID),
+    decompilerWasBusy(false)
 {
     ui->setupUi(this);
 
@@ -37,9 +42,6 @@ DecompilerWidget::DecompilerWidget(MainWindow *main) :
     connect(Config(), SIGNAL(colorsUpdated()), this, SLOT(colorsUpdatedSlot()));
     connect(Core(), SIGNAL(registersChanged()), this, SLOT(highlightPC()));
     connect(mCtxMenu, &DecompilerContextMenu::copy, this, &DecompilerWidget::copy);
-
-    decompiledFunctionAddr = RVA_INVALID;
-    decompilerWasBusy = false;
 
     connect(ui->refreshButton, &QAbstractButton::clicked, this, [this]() {
         doRefresh();

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -92,8 +92,9 @@ DecompilerWidget::DecompilerWidget(MainWindow *main) :
     connect(ui->textEdit, SIGNAL(customContextMenuRequested(const QPoint &)),
             this, SLOT(showDisasContextMenu(const QPoint &)));
 
-    connect(Core(), &CutterCore::breakpointsChanged, this, &DecompilerWidget::setInfoForBreakpoints);
+    // connect(Core(), &CutterCore::breakpointsChanged, this, &DecompilerWidget::setInfoForBreakpoints);
     connect(Core(), &CutterCore::breakpointsChanged, this, [this] {
+        setInfoForBreakpoints();
         QTextCursor cursor = ui->textEdit->textCursor();
         cursor.select(QTextCursor::Document);
         cursor.setCharFormat(QTextCharFormat());
@@ -115,7 +116,7 @@ DecompilerWidget::DecompilerWidget(MainWindow *main) :
     connect(Core(), &CutterCore::functionsChanged, this, &DecompilerWidget::doAutoRefresh);
     connect(Core(), &CutterCore::flagsChanged, this, &DecompilerWidget::doAutoRefresh);
     connect(Core(), &CutterCore::commentsChanged, this, &DecompilerWidget::doAutoRefresh);
-    // connect(Core(), &CutterCore::instructionChanged, this, &DecompilerWidget::doAutoRefresh);
+    connect(Core(), &CutterCore::instructionChanged, this, &DecompilerWidget::doAutoRefresh);
     connect(Core(), &CutterCore::refreshCodeViews, this, &DecompilerWidget::doAutoRefresh);
 
     // Esc to seek backward

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -93,6 +93,58 @@ DecompilerWidget::DecompilerWidget(MainWindow *main) :
             this, SLOT(showDisasContextMenu(const QPoint &)));
 
     connect(Core(), &CutterCore::breakpointsChanged, this, &DecompilerWidget::setInfoForBreakpoints);
+    connect(Core(), &CutterCore::breakpointsChanged, this, [this] {
+        // ui->textEdit->setPlainText(this->code->code);
+        // highlightPC();
+        // highlightBreakpoints();
+        // connectCursorPositionChanged(true);
+        // ui->textEdit->setPlainText(this->code->code);
+        // connectCursorPositionChanged(false);
+
+
+        QTextCursor cursor = ui->textEdit->textCursor();
+        cursor.select(QTextCursor::Document);
+        cursor.setCharFormat(QTextCharFormat());
+        cursor.setBlockFormat(QTextBlockFormat());
+        cursor.clearSelection();
+        // ui->textEdit->setTextCursor(cursor);
+        ui->textEdit->setExtraSelections({});
+        // updateCursorPosition();
+        highlightPC();
+        highlightBreakpoints();
+        // ui->textEdit->setCurrentCharFormat(QTextCharFormat());
+
+
+        // if (!cursor.isNull()) {
+        //     // Use a Block formatting since these lines are not updated frequently as selections and PC
+        //     QTextBlockFormat f;
+        //     f.setBackground(ConfigColor("gui.breakpoint_background"));
+        //     cursor.setBlockFormat(f);
+        // }
+        // cursor.select(QTextCursor::Document);
+        // cursor.setCharFormat(QTextCharFormat());
+        // cursor.clearSelection();
+        // ui->textEdit->setTextCursor(cursor);
+        // // ui->textE
+        // // ui->textEdit->clear
+        // ui->textEdit->setExtraSelections({});
+        // // updateCursorPosition();
+        // highlightPC();
+        // highlightBreakpoints();
+
+        /* Working code. Probably not what we want.
+        scrollerHorizontal = ui->textEdit->horizontalScrollBar()->sliderPosition();
+        scrollerVertical = ui->textEdit->verticalScrollBar()->sliderPosition();
+        connectCursorPositionChanged(true);
+        ui->textEdit->setPlainText(QString::fromUtf8(this->code->code));
+        connectCursorPositionChanged(false);
+        updateCursorPosition();
+        highlightPC();
+        highlightBreakpoints();
+        ui->textEdit->horizontalScrollBar()->setSliderPosition(scrollerHorizontal);
+        ui->textEdit->verticalScrollBar()->setSliderPosition(scrollerVertical);
+        */
+    });
     addActions(mCtxMenu->actions());
 
     ui->progressLabel->setVisible(false);
@@ -104,7 +156,7 @@ DecompilerWidget::DecompilerWidget(MainWindow *main) :
     connect(Core(), &CutterCore::functionsChanged, this, &DecompilerWidget::doAutoRefresh);
     connect(Core(), &CutterCore::flagsChanged, this, &DecompilerWidget::doAutoRefresh);
     connect(Core(), &CutterCore::commentsChanged, this, &DecompilerWidget::doAutoRefresh);
-    connect(Core(), &CutterCore::instructionChanged, this, &DecompilerWidget::doAutoRefresh);
+    // connect(Core(), &CutterCore::instructionChanged, this, &DecompilerWidget::doAutoRefresh);
     connect(Core(), &CutterCore::refreshCodeViews, this, &DecompilerWidget::doAutoRefresh);
 
     // Esc to seek backward
@@ -317,8 +369,8 @@ void DecompilerWidget::decompilationFinished(RAnnotatedCode *codeDecompiled)
     }
 
     if (isDisplayReset) {
-        ui->textEdit->horizontalScrollBar()->setSliderPosition(scrollerHorizontal);
-        ui->textEdit->verticalScrollBar()->setSliderPosition(scrollerVertical);
+        // ui->textEdit->horizontalScrollBar()->setSliderPosition(scrollerHorizontal);
+        // ui->textEdit->verticalScrollBar()->setSliderPosition(scrollerVertical);
     }
 }
 

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -93,18 +93,6 @@ DecompilerWidget::DecompilerWidget(MainWindow *main) :
             this, SLOT(showDisasContextMenu(const QPoint &)));
 
     connect(Core(), &CutterCore::breakpointsChanged, this, &DecompilerWidget::updateBreakpoints);
-    // connect(Core(), &CutterCore::breakpointsChanged, this, [this] {
-    //     setInfoForBreakpoints();
-    //     QTextCursor cursor = ui->textEdit->textCursor();
-    //     cursor.select(QTextCursor::Document);
-    //     cursor.setCharFormat(QTextCharFormat());
-    //     cursor.setBlockFormat(QTextBlockFormat());
-    //     cursor.clearSelection();
-    //     ui->textEdit->setExtraSelections({});
-    //     highlightPC();
-    //     highlightBreakpoints();
-    //     updateSelection();
-    // });
     addActions(mCtxMenu->actions());
 
     ui->progressLabel->setVisible(false);

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -94,56 +94,15 @@ DecompilerWidget::DecompilerWidget(MainWindow *main) :
 
     connect(Core(), &CutterCore::breakpointsChanged, this, &DecompilerWidget::setInfoForBreakpoints);
     connect(Core(), &CutterCore::breakpointsChanged, this, [this] {
-        // ui->textEdit->setPlainText(this->code->code);
-        // highlightPC();
-        // highlightBreakpoints();
-        // connectCursorPositionChanged(true);
-        // ui->textEdit->setPlainText(this->code->code);
-        // connectCursorPositionChanged(false);
-
-
         QTextCursor cursor = ui->textEdit->textCursor();
         cursor.select(QTextCursor::Document);
         cursor.setCharFormat(QTextCharFormat());
         cursor.setBlockFormat(QTextBlockFormat());
         cursor.clearSelection();
-        // ui->textEdit->setTextCursor(cursor);
         ui->textEdit->setExtraSelections({});
-        // updateCursorPosition();
         highlightPC();
         highlightBreakpoints();
-        // ui->textEdit->setCurrentCharFormat(QTextCharFormat());
-
-
-        // if (!cursor.isNull()) {
-        //     // Use a Block formatting since these lines are not updated frequently as selections and PC
-        //     QTextBlockFormat f;
-        //     f.setBackground(ConfigColor("gui.breakpoint_background"));
-        //     cursor.setBlockFormat(f);
-        // }
-        // cursor.select(QTextCursor::Document);
-        // cursor.setCharFormat(QTextCharFormat());
-        // cursor.clearSelection();
-        // ui->textEdit->setTextCursor(cursor);
-        // // ui->textE
-        // // ui->textEdit->clear
-        // ui->textEdit->setExtraSelections({});
-        // // updateCursorPosition();
-        // highlightPC();
-        // highlightBreakpoints();
-
-        /* Working code. Probably not what we want.
-        scrollerHorizontal = ui->textEdit->horizontalScrollBar()->sliderPosition();
-        scrollerVertical = ui->textEdit->verticalScrollBar()->sliderPosition();
-        connectCursorPositionChanged(true);
-        ui->textEdit->setPlainText(QString::fromUtf8(this->code->code));
-        connectCursorPositionChanged(false);
-        updateCursorPosition();
-        highlightPC();
-        highlightBreakpoints();
-        ui->textEdit->horizontalScrollBar()->setSliderPosition(scrollerHorizontal);
-        ui->textEdit->verticalScrollBar()->setSliderPosition(scrollerVertical);
-        */
+        updateSelection();
     });
     addActions(mCtxMenu->actions());
 

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -193,7 +193,6 @@ void DecompilerWidget::updateBreakpoints()
     cursor.select(QTextCursor::Document);
     cursor.setCharFormat(QTextCharFormat());
     cursor.setBlockFormat(QTextBlockFormat());
-    cursor.clearSelection();
     ui->textEdit->setExtraSelections({});
     highlightPC();
     highlightBreakpoints();

--- a/src/widgets/DecompilerWidget.h
+++ b/src/widgets/DecompilerWidget.h
@@ -116,6 +116,7 @@ private:
      */
     void gatherBreakpointInfo(RAnnotatedCode &codeDecompiled, size_t startPos, size_t endPos);
 
+    void updateBreakpoints();
     void setInfoForBreakpoints();
 
     void setAnnotationsAtCursor(size_t pos);

--- a/src/widgets/DecompilerWidget.h
+++ b/src/widgets/DecompilerWidget.h
@@ -56,6 +56,9 @@ private:
      */
     bool decompilerWasBusy;
 
+    int scrollerHorizontal;
+    int scrollerVertical;
+    RVA previousFunctionAddr;
     RVA decompiledFunctionAddr;
     std::unique_ptr<RAnnotatedCode, void (*)(RAnnotatedCode *)> code;
     bool seekFromCursor = false;

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -47,6 +47,7 @@ DisassemblerGraphView::DisassemblerGraphView(QWidget *parent, CutterSeekable *se
     connect(Core(), SIGNAL(flagsChanged()), this, SLOT(refreshView()));
     connect(Core(), SIGNAL(varsChanged()), this, SLOT(refreshView()));
     connect(Core(), SIGNAL(instructionChanged(RVA)), this, SLOT(refreshView()));
+    connect(Core(), &CutterCore::breakpointsChanged, this, &DisassemblerGraphView::refreshView);
     connect(Core(), SIGNAL(functionsChanged()), this, SLOT(refreshView()));
     connect(Core(), SIGNAL(asmOptionsChanged()), this, SLOT(refreshView()));
     connect(Core(), SIGNAL(refreshCodeViews()), this, SLOT(refreshView()));

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -156,6 +156,11 @@ DisassemblyWidget::DisassemblyWidget(MainWindow *main)
             refreshDisasm();
         }
     });
+    connect(Core(), &CutterCore::breakpointsChanged, this, [this](RVA offset) {
+        if (offset >= topOffset && offset <= bottomOffset) {
+            refreshDisasm();
+        }
+    });
     connect(Core(), SIGNAL(refreshCodeViews()), this, SLOT(refreshDisasm()));
 
     connect(Config(), SIGNAL(fontsUpdated()), this, SLOT(fontsUpdatedSlot()));

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -151,16 +151,18 @@ DisassemblyWidget::DisassemblyWidget(MainWindow *main)
     connect(Core(), &CutterCore::functionRenamed, this, [this]() {refreshDisasm();});
     connect(Core(), SIGNAL(varsChanged()), this, SLOT(refreshDisasm()));
     connect(Core(), SIGNAL(asmOptionsChanged()), this, SLOT(refreshDisasm()));
-    connect(Core(), &CutterCore::instructionChanged, this, [this](RVA offset) {
-        if (offset >= topOffset && offset <= bottomOffset) {
-            refreshDisasm();
-        }
-    });
-    connect(Core(), &CutterCore::breakpointsChanged, this, [this](RVA offset) {
-        if (offset >= topOffset && offset <= bottomOffset) {
-            refreshDisasm();
-        }
-    });
+    connect(Core(), &CutterCore::instructionChanged, this, &DisassemblyWidget::refreshIfInRange);
+    connect(Core(), &CutterCore::breakpointsChanged, this, &DisassemblyWidget::refreshIfInRange);
+    // connect(Core(), &CutterCore::instructionChanged, this, [this](RVA offset) {
+    //     if (offset >= topOffset && offset <= bottomOffset) {
+    //         refreshDisasm();
+    //     }
+    // });
+    // connect(Core(), &CutterCore::breakpointsChanged, this, [this](RVA offset) {
+    //     if (offset >= topOffset && offset <= bottomOffset) {
+    //         refreshDisasm();
+    //     }
+    // });
     connect(Core(), SIGNAL(refreshCodeViews()), this, SLOT(refreshDisasm()));
 
     connect(Config(), SIGNAL(fontsUpdated()), this, SLOT(fontsUpdatedSlot()));
@@ -252,6 +254,13 @@ QFontMetrics DisassemblyWidget::getFontMetrics()
 QList<DisassemblyLine> DisassemblyWidget::getLines()
 {
     return lines;
+}
+
+void DisassemblyWidget::refreshIfInRange(RVA offset)
+{
+    if (offset >= topOffset && offset <= bottomOffset) {
+        refreshDisasm();
+    }
 }
 
 void DisassemblyWidget::refreshDisasm(RVA offset)

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -153,16 +153,6 @@ DisassemblyWidget::DisassemblyWidget(MainWindow *main)
     connect(Core(), SIGNAL(asmOptionsChanged()), this, SLOT(refreshDisasm()));
     connect(Core(), &CutterCore::instructionChanged, this, &DisassemblyWidget::refreshIfInRange);
     connect(Core(), &CutterCore::breakpointsChanged, this, &DisassemblyWidget::refreshIfInRange);
-    // connect(Core(), &CutterCore::instructionChanged, this, [this](RVA offset) {
-    //     if (offset >= topOffset && offset <= bottomOffset) {
-    //         refreshDisasm();
-    //     }
-    // });
-    // connect(Core(), &CutterCore::breakpointsChanged, this, [this](RVA offset) {
-    //     if (offset >= topOffset && offset <= bottomOffset) {
-    //         refreshDisasm();
-    //     }
-    // });
     connect(Core(), SIGNAL(refreshCodeViews()), this, SLOT(refreshDisasm()));
 
     connect(Config(), SIGNAL(fontsUpdated()), this, SLOT(fontsUpdatedSlot()));

--- a/src/widgets/DisassemblyWidget.h
+++ b/src/widgets/DisassemblyWidget.h
@@ -40,6 +40,7 @@ public slots:
 
 protected slots:
     void on_seekChanged(RVA offset);
+    void refreshIfInRange(RVA offset);
     void refreshDisasm(RVA offset = RVA_INVALID);
 
     bool updateMaxLines();

--- a/src/widgets/HexdumpWidget.cpp
+++ b/src/widgets/HexdumpWidget.cpp
@@ -88,6 +88,7 @@ HexdumpWidget::HexdumpWidget(MainWindow *main) :
     connect(Core(), &CutterCore::refreshAll, this, [this]() { refresh(); });
     connect(Core(), &CutterCore::refreshCodeViews, this, [this]() { refresh(); });
     connect(Core(), &CutterCore::instructionChanged, this, [this]() { refresh(); });
+    connect(Core(), &CutterCore::breakpointsChanged, this, [this]() { refresh(); });
     connect(Core(), &CutterCore::stackChanged, this, [this]() { refresh(); });
     connect(Core(), &CutterCore::registersChanged, this, [this]() { refresh(); });
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

The important modifications and additions in this PR are:
1. Saves the previous function's address and if the newly decompiled function is the same as the previous one, the scroll position will remain the same.
2. Modified signal `breakpointsChanged()` to `breakpointsChanged(RVA offset)`. Removed `emit instructionChanged` from all functions that emit `breakpointsChanged`.
<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Display jumps while toggling breakpoint (Before)
![BeforeFixingDisplayJumping](https://user-images.githubusercontent.com/18501167/88939657-68074d80-d2a4-11ea-9c4c-7b5eb64f00bf.gif)
Display position doesn't change while toggling breakpoint (After)
![AfterFixingDisplayJumping](https://user-images.githubusercontent.com/18501167/88939698-76ee0000-d2a4-11ea-8b4b-0fbab9300b4d.gif)

You can notice the same change in other actions also, e.g. Add/Rename/Remove names, Refresh, Add/Delete/Modify comments, etc.

**Test plan (required)**
1. Test to make sure that the breakpoints are toggled and highlighted properly in the decompiler and ensure if the display position is getting changed.
2. See if the display position is changing when the view is refreshed using the refresh button.
3. Notice the changes in the display that happens when an instruction is modified. For example, change an if condition from `je address` to `jne address` and see if the display changes in an undesirable way.
4. Open the following three widgets in sync (Decompiler, Disassembly, Graph). Toggle breakpoints and make sure that every single change is reflected properly in all the widgets.
<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->


<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**
closes #2270 
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
