### PR TITLE
Prevent potential crash when opening theme editor dialog.

### DIFF
--- a/src/dialogs/preferences/ColorThemeEditDialog.cpp
+++ b/src/dialogs/preferences/ColorThemeEditDialog.cpp
@@ -31,7 +31,9 @@ ColorThemeEditDialog::ColorThemeEditDialog(QWidget *parent) :
     previewDisasmWidget->setPreviewMode(true);
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 12, 0))
     // default size limit is acceptable
-    previewDisasmWidget->setMinimumSize(qApp->screenAt(previewDisasmWidget->pos())->size() * 0.5);
+    if (auto screen = qApp->screenAt(previewDisasmWidget->pos())) {
+        previewDisasmWidget->setMinimumSize(screen->size() * 0.5);
+    }
 #endif
     previewDisasmWidget->setWindowTitle(tr("Disassembly Preview"));
     previewDisasmWidget->setFeatures(QDockWidget::NoDockWidgetFeatures);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**
screenAt might return null. I haven't been able to repeat it locally, but @ITAYC0HEN showed a stacktrace where it seems to have happened.

**Test plan (required)**

* Test that theme editor dialog opens (even if the probablem can't be repeated locally)
* Ask the person reporting the problem if patch helps

<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
