### PR TITLE
Refactor old style macro based signal connect.

### DIFF
--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -165,7 +165,7 @@ void MainWindow::initUI()
 
     // Period goes to command entry
     QShortcut *cmd_shortcut = new QShortcut(QKeySequence(Qt::Key_Period), this);
-    connect(cmd_shortcut, SIGNAL(activated()), consoleDock, SLOT(focusInputLineEdit()));
+    connect(cmd_shortcut, &QShortcut::activated, consoleDock, &ConsoleWidget::focusInputLineEdit);
 
     // G and S goes to goto entry
     QShortcut *goto_shortcut = new QShortcut(QKeySequence(Qt::Key_G), this);
@@ -173,26 +173,26 @@ void MainWindow::initUI()
     QShortcut *seek_shortcut = new QShortcut(QKeySequence(Qt::Key_S), this);
     connect(seek_shortcut, SIGNAL(activated()), this->omnibar, SLOT(setFocus()));
     QShortcut *seek_to_func_end_shortcut = new QShortcut(QKeySequence(Qt::Key_Dollar), this);
-    connect(seek_to_func_end_shortcut, SIGNAL(activated()), SLOT(seekToFunctionLastInstruction()));
+    connect(seek_to_func_end_shortcut, &QShortcut::activated, this, &MainWindow::seekToFunctionLastInstruction);
     QShortcut *seek_to_func_start_shortcut = new QShortcut(QKeySequence(Qt::Key_AsciiCircum), this);
-    connect(seek_to_func_start_shortcut, SIGNAL(activated()), SLOT(seekToFunctionStart()));
+    connect(seek_to_func_start_shortcut, &QShortcut::activated, this, &MainWindow::seekToFunctionStart);
 
     QShortcut *refresh_shortcut = new QShortcut(QKeySequence(QKeySequence::Refresh), this);
-    connect(refresh_shortcut, SIGNAL(activated()), this, SLOT(refreshAll()));
+    connect(refresh_shortcut, &QShortcut::activated, this, &MainWindow::refreshAll);
 
-    connect(ui->actionZoomIn, SIGNAL(triggered()), this, SLOT(onZoomIn()));
-    connect(ui->actionZoomOut, SIGNAL(triggered()), this, SLOT(onZoomOut()));
-    connect(ui->actionZoomReset, SIGNAL(triggered()), this, SLOT(onZoomReset()));
+    connect(ui->actionZoomIn, &QAction::triggered, this, &MainWindow::onZoomIn);
+    connect(ui->actionZoomOut, &QAction::triggered, this, &MainWindow::onZoomOut);
+    connect(ui->actionZoomReset, &QAction::triggered, this, &MainWindow::onZoomReset);
 
     connect(core, SIGNAL(projectSaved(bool, const QString &)), this, SLOT(projectSaved(bool,
                                                                                        const QString &)));
 
     connect(core, &CutterCore::toggleDebugView, this, &MainWindow::toggleDebugView);
 
-    connect(core, SIGNAL(newMessage(const QString &)),
-            this->consoleDock, SLOT(addOutput(const QString &)));
-    connect(core, SIGNAL(newDebugMessage(const QString &)),
-            this->consoleDock, SLOT(addDebugOutput(const QString &)));
+    connect(core, &CutterCore::newMessage,
+            this->consoleDock, &ConsoleWidget::addOutput);
+    connect(core, &CutterCore::newDebugMessage,
+            this->consoleDock, &ConsoleWidget::addDebugOutput);
 
     connect(core, &CutterCore::showMemoryWidgetRequested,
             this, static_cast<void(MainWindow::*)()>(&MainWindow::showMemoryWidget));

--- a/src/dialogs/AsyncTaskDialog.cpp
+++ b/src/dialogs/AsyncTaskDialog.cpp
@@ -24,7 +24,7 @@ AsyncTaskDialog::AsyncTaskDialog(AsyncTask::Ptr task, QWidget *parent)
 
     updateLog(task->getLog());
 
-    connect(&timer, SIGNAL(timeout()), this, SLOT(updateProgressTimer()));
+    connect(&timer, &QTimer::timeout, this, &AsyncTaskDialog::updateProgressTimer);
     timer.setInterval(1000);
     timer.setSingleShot(false);
     timer.start();

--- a/src/dialogs/AttachProcDialog.cpp
+++ b/src/dialogs/AttachProcDialog.cpp
@@ -198,12 +198,12 @@ AttachProcDialog::AttachProcDialog(QWidget *parent) :
 
     // focus on filter line
     ui->filterLineEdit->setFocus();
-    connect(ui->filterLineEdit, SIGNAL(textChanged(const QString &)), processProxyModel,
-            SLOT(setFilterWildcard(const QString &)));
+    connect(ui->filterLineEdit, &QLineEdit::textChanged, processProxyModel,
+            &QSortFilterProxyModel::setFilterWildcard);
 
     // Update the processes every 'updateIntervalMs' seconds
     timer = new QTimer(this);
-    connect(timer, SIGNAL(timeout()), this, SLOT(updateModelData()));
+    connect(timer, &QTimer::timeout, this, &AttachProcDialog::updateModelData);
     timer->start(updateIntervalMs);
 }
 

--- a/src/dialogs/EditInstructionDialog.cpp
+++ b/src/dialogs/EditInstructionDialog.cpp
@@ -12,8 +12,7 @@ EditInstructionDialog::EditInstructionDialog(InstructionEditMode editMode, QWidg
     ui->instructionLabel->setWordWrap(true);
     setWindowFlags(windowFlags() & (~Qt::WindowContextHelpButtonHint));
 
-    connect(ui->lineEdit, SIGNAL(textEdited(const QString &)), this,
-            SLOT(updatePreview(const QString &)));
+    connect(ui->lineEdit, &QLineEdit::textEdited, this, &EditInstructionDialog::updatePreview);
 }
 
 EditInstructionDialog::~EditInstructionDialog() {}

--- a/src/dialogs/EditVariablesDialog.cpp
+++ b/src/dialogs/EditVariablesDialog.cpp
@@ -12,7 +12,7 @@ EditVariablesDialog::EditVariablesDialog(RVA offset, QString initialVar, QWidget
     ui(new Ui::EditVariablesDialog)
 {
     ui->setupUi(this);
-    connect(ui->buttonBox, SIGNAL(accepted()), this, SLOT(applyFields()));
+    connect(ui->buttonBox, &QDialogButtonBox::accepted, this, &EditVariablesDialog::applyFields);
     connect(ui->dropdownLocalVars, SIGNAL(currentIndexChanged(int)), SLOT(updateFields()));
 
     QString fcnName = Core()->cmdRawAt("afn.", offset).trimmed();

--- a/src/dialogs/InitialOptionsDialog.cpp
+++ b/src/dialogs/InitialOptionsDialog.cpp
@@ -85,11 +85,11 @@ InitialOptionsDialog::InitialOptionsDialog(MainWindow *main):
 
     updatePDBLayout();
 
-    connect(ui->pdbCheckBox, SIGNAL(stateChanged(int)), this, SLOT(updatePDBLayout()));
+    connect(ui->pdbCheckBox, &QCheckBox::stateChanged, this, &InitialOptionsDialog::updatePDBLayout);
 
     updateScriptLayout();
 
-    connect(ui->scriptCheckBox, SIGNAL(stateChanged(int)), this, SLOT(updateScriptLayout()));
+    connect(ui->scriptCheckBox, &QCheckBox::stateChanged, this, &InitialOptionsDialog::updateScriptLayout);
 
     connect(ui->cancelButton, SIGNAL(clicked()), this, SLOT(reject()));
 

--- a/src/dialogs/R2TaskDialog.cpp
+++ b/src/dialogs/R2TaskDialog.cpp
@@ -16,7 +16,7 @@ R2TaskDialog::R2TaskDialog(R2Task::Ptr task, QWidget *parent)
         close();
     });
 
-    connect(&timer, SIGNAL(timeout()), this, SLOT(updateProgressTimer()));
+    connect(&timer, &QTimer::timeout, this, &R2TaskDialog::updateProgressTimer);
     timer.setInterval(1000);
     timer.setSingleShot(false);
     timer.start();

--- a/src/dialogs/XrefsDialog.cpp
+++ b/src/dialogs/XrefsDialog.cpp
@@ -35,9 +35,9 @@ XrefsDialog::XrefsDialog(MainWindow *main, QWidget *parent) :
     setupPreviewFont();
 
     // Highlight current line
-    connect(ui->previewTextEdit, SIGNAL(cursorPositionChanged()), this, SLOT(highlightCurrentLine()));
-    connect(Config(), SIGNAL(fontsUpdated()), this, SLOT(setupPreviewFont()));
-    connect(Config(), SIGNAL(colorsUpdated()), this, SLOT(setupPreviewColors()));
+    connect(ui->previewTextEdit, &QPlainTextEdit::cursorPositionChanged, this, &XrefsDialog::highlightCurrentLine);
+    connect(Config(), &Configuration::fontsUpdated, this, &XrefsDialog::setupPreviewFont);
+    connect(Config(), &Configuration::colorsUpdated, this, &XrefsDialog::setupPreviewColors);
 
     connect(ui->toTreeWidget->selectionModel(), &QItemSelectionModel::selectionChanged,
             this, &XrefsDialog::onToTreeWidgetItemSelectionChanged);

--- a/src/dialogs/preferences/AsmOptionsWidget.cpp
+++ b/src/dialogs/preferences/AsmOptionsWidget.cpp
@@ -142,9 +142,9 @@ void AsmOptionsWidget::resetToDefault()
 
 void AsmOptionsWidget::triggerAsmOptionsChanged()
 {
-    disconnect(Core(), SIGNAL(asmOptionsChanged()), this, SLOT(updateAsmOptionsFromVars()));
+    disconnect(Core(), &CutterCore::asmOptionsChanged, this, &AsmOptionsWidget::updateAsmOptionsFromVars);
     Core()->triggerAsmOptionsChanged();
-    connect(Core(), SIGNAL(asmOptionsChanged()), this, SLOT(updateAsmOptionsFromVars()));
+    connect(Core(), &CutterCore::asmOptionsChanged, this, &AsmOptionsWidget::updateAsmOptionsFromVars);
 }
 
 void AsmOptionsWidget::on_cmtcolSpinBox_valueChanged(int value)

--- a/src/dialogs/preferences/GraphOptionsWidget.cpp
+++ b/src/dialogs/preferences/GraphOptionsWidget.cpp
@@ -52,9 +52,9 @@ void GraphOptionsWidget::updateOptionsFromVars()
 
 void GraphOptionsWidget::triggerOptionsChanged()
 {
-    disconnect(Core(), SIGNAL(graphOptionsChanged()), this, SLOT(updateOptionsFromVars()));
+    disconnect(Core(), &CutterCore::graphOptionsChanged, this, &GraphOptionsWidget::updateOptionsFromVars);
     Core()->triggerGraphOptionsChanged();
-    connect(Core(), SIGNAL(graphOptionsChanged()), this, SLOT(updateOptionsFromVars()));
+    connect(Core(), &CutterCore::graphOptionsChanged, this, &GraphOptionsWidget::updateOptionsFromVars);
 }
 
 void GraphOptionsWidget::on_maxColsSpinBox_valueChanged(int value)

--- a/src/dialogs/preferences/PreferencesDialog.cpp
+++ b/src/dialogs/preferences/PreferencesDialog.cpp
@@ -65,12 +65,10 @@ PreferencesDialog::PreferencesDialog(QWidget *parent)
         c.addItem(*ui->configCategories, *ui->configPanel);
     }
 
-    connect(ui->configCategories,
-            SIGNAL(currentItemChanged(QTreeWidgetItem *, QTreeWidgetItem *)),
-            this, SLOT(changePage(QTreeWidgetItem *, QTreeWidgetItem *)));
-    connect(ui->saveButtons,
-            SIGNAL(accepted()),
-            this, SLOT(close()));
+    connect(ui->configCategories, &QTreeWidget::currentItemChanged,
+            this, &PreferencesDialog::changePage);
+    connect(ui->saveButtons, &QDialogButtonBox::accepted,
+            this, &QWidget::close);
 
     QTreeWidgetItem *defitem = ui->configCategories->topLevelItem(0);
     ui->configCategories->setCurrentItem(defitem, 0);

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -128,8 +128,8 @@ DisassemblyContextMenu::DisassemblyContextMenu(QWidget *parent, MainWindow *main
     addSetBitsMenu();
 
     structureOffsetMenu = addMenu(tr("Structure offset"));
-    connect(structureOffsetMenu, SIGNAL(triggered(QAction*)),
-            this, SLOT(on_actionStructureOffsetMenu_triggered(QAction*)));
+    connect(structureOffsetMenu, &QMenu::triggered,
+            this, &DisassemblyContextMenu::on_actionStructureOffsetMenu_triggered);
 
     initAction(&actionLinkType, tr("Link Type to Address"),
                SLOT(on_actionLinkType_triggered()), getLinkTypeSequence());

--- a/src/widgets/ConsoleWidget.cpp
+++ b/src/widgets/ConsoleWidget.cpp
@@ -101,25 +101,25 @@ ConsoleWidget::ConsoleWidget(MainWindow *main) :
 
     // Set console output context menu
     ui->outputTextEdit->setContextMenuPolicy(Qt::CustomContextMenu);
-    connect(ui->outputTextEdit, SIGNAL(customContextMenuRequested(const QPoint &)),
-            this, SLOT(showCustomContextMenu(const QPoint &)));
+    connect(ui->outputTextEdit, &QWidget::customContextMenuRequested,
+            this, &ConsoleWidget::showCustomContextMenu);
 
     // Esc clears r2InputLineEdit and debugeeInputLineEdit (like OmniBar)
     QShortcut *r2_clear_shortcut = new QShortcut(QKeySequence(Qt::Key_Escape), ui->r2InputLineEdit);
-    connect(r2_clear_shortcut, SIGNAL(activated()), this, SLOT(clear()));
+    connect(r2_clear_shortcut, &QShortcut::activated, this, &ConsoleWidget::clear);
     r2_clear_shortcut->setContext(Qt::WidgetShortcut);
 
     QShortcut *debugee_clear_shortcut = new QShortcut(QKeySequence(Qt::Key_Escape), ui->debugeeInputLineEdit);
-    connect(debugee_clear_shortcut, SIGNAL(activated()), this, SLOT(clear()));
+    connect(debugee_clear_shortcut, &QShortcut::activated, this, &ConsoleWidget::clear);
     debugee_clear_shortcut->setContext(Qt::WidgetShortcut);
 
     // Up and down arrows show history
     historyUpShortcut = new QShortcut(QKeySequence(Qt::Key_Up), ui->r2InputLineEdit);
-    connect(historyUpShortcut, SIGNAL(activated()), this, SLOT(historyPrev()));
+    connect(historyUpShortcut, &QShortcut::activated, this, &ConsoleWidget::historyPrev);
     historyUpShortcut->setContext(Qt::WidgetShortcut);
 
     historyDownShortcut = new QShortcut(QKeySequence(Qt::Key_Down), ui->r2InputLineEdit);
-    connect(historyDownShortcut, SIGNAL(activated()), this, SLOT(historyNext()));
+    connect(historyDownShortcut, &QShortcut::activated, this, &ConsoleWidget::historyNext);
     historyDownShortcut->setContext(Qt::WidgetShortcut);
 
     QShortcut *completionShortcut = new QShortcut(QKeySequence(Qt::Key_Tab), ui->r2InputLineEdit);
@@ -481,5 +481,5 @@ void ConsoleWidget::redirectOutput()
     pipeSocket->connectToServer(QIODevice::ReadOnly);
 #endif
 
-    connect(pipeSocket, SIGNAL(readyRead()), this, SLOT(processQueuedOutput()));
+    connect(pipeSocket, &QIODevice::readyRead, this, &ConsoleWidget::processQueuedOutput);
 }

--- a/src/widgets/Dashboard.cpp
+++ b/src/widgets/Dashboard.cpp
@@ -27,7 +27,7 @@ Dashboard::Dashboard(MainWindow *main) :
 {
     ui->setupUi(this);
 
-    connect(Core(), SIGNAL(refreshAll()), this, SLOT(updateContents()));
+    connect(Core(), &CutterCore::refreshAll, this, &Dashboard::updateContents);
 }
 
 Dashboard::~Dashboard() {}

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -31,9 +31,9 @@ DecompilerWidget::DecompilerWidget(MainWindow *main) :
     setupFonts();
     colorsUpdatedSlot();
 
-    connect(Config(), SIGNAL(fontsUpdated()), this, SLOT(fontsUpdatedSlot()));
-    connect(Config(), SIGNAL(colorsUpdated()), this, SLOT(colorsUpdatedSlot()));
-    connect(Core(), SIGNAL(registersChanged()), this, SLOT(highlightPC()));
+    connect(Config(), &Configuration::fontsUpdated, this, &DecompilerWidget::fontsUpdatedSlot);
+    connect(Config(), &Configuration::colorsUpdated, this, &DecompilerWidget::colorsUpdatedSlot);
+    connect(Core(), &CutterCore::registersChanged, this, &DecompilerWidget::highlightPC);
 
     decompiledFunctionAddr = RVA_INVALID;
     decompilerWasBusy = false;
@@ -81,8 +81,8 @@ DecompilerWidget::DecompilerWidget(MainWindow *main) :
     connectCursorPositionChanged(false);
     connect(Core(), &CutterCore::seekChanged, this, &DecompilerWidget::seekChanged);
     ui->textEdit->setContextMenuPolicy(Qt::CustomContextMenu);
-    connect(ui->textEdit, SIGNAL(customContextMenuRequested(const QPoint &)),
-            this, SLOT(showDisasContextMenu(const QPoint &)));
+    connect(ui->textEdit, &QWidget::customContextMenuRequested,
+            this, &DecompilerWidget::showDisasContextMenu);
 
     // refresh the widget when an action in this menu is triggered
     connect(mCtxMenu, &QMenu::triggered, this, &DecompilerWidget::refreshDecompiler);

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -57,23 +57,23 @@ DisassemblerGraphView::DisassemblerGraphView(QWidget *parent, CutterSeekable *se
     // ESC for previous
     QShortcut *shortcut_escape = new QShortcut(QKeySequence(Qt::Key_Escape), this);
     shortcut_escape->setContext(Qt::WidgetShortcut);
-    connect(shortcut_escape, SIGNAL(activated()), seekable, SLOT(seekPrev()));
+    connect(shortcut_escape, &QShortcut::activated, seekable, &CutterSeekable::seekPrev);
 
     // Branch shortcuts
     QShortcut *shortcut_take_true = new QShortcut(QKeySequence(Qt::Key_T), this);
     shortcut_take_true->setContext(Qt::WidgetShortcut);
-    connect(shortcut_take_true, SIGNAL(activated()), this, SLOT(takeTrue()));
+    connect(shortcut_take_true, &QShortcut::activated, this, &DisassemblerGraphView::takeTrue);
     QShortcut *shortcut_take_false = new QShortcut(QKeySequence(Qt::Key_F), this);
     shortcut_take_false->setContext(Qt::WidgetShortcut);
-    connect(shortcut_take_false, SIGNAL(activated()), this, SLOT(takeFalse()));
+    connect(shortcut_take_false, &QShortcut::activated, this, &DisassemblerGraphView::takeFalse);
 
     // Navigation shortcuts
     QShortcut *shortcut_next_instr = new QShortcut(QKeySequence(Qt::Key_J), this);
     shortcut_next_instr->setContext(Qt::WidgetShortcut);
-    connect(shortcut_next_instr, SIGNAL(activated()), this, SLOT(nextInstr()));
+    connect(shortcut_next_instr, &QShortcut::activated, this, &DisassemblerGraphView::nextInstr);
     QShortcut *shortcut_prev_instr = new QShortcut(QKeySequence(Qt::Key_K), this);
     shortcut_prev_instr->setContext(Qt::WidgetShortcut);
-    connect(shortcut_prev_instr, SIGNAL(activated()), this, SLOT(prevInstr()));
+    connect(shortcut_prev_instr, &QShortcut::activated, this, &DisassemblerGraphView::prevInstr);
     shortcuts.append(shortcut_escape);
     shortcuts.append(shortcut_next_instr);
     shortcuts.append(shortcut_prev_instr);

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -131,12 +131,12 @@ DisassemblyWidget::DisassemblyWidget(MainWindow *main)
 
     // Set Disas context menu
     mDisasTextEdit->setContextMenuPolicy(Qt::CustomContextMenu);
-    connect(mDisasTextEdit, SIGNAL(customContextMenuRequested(const QPoint &)),
-            this, SLOT(showDisasContextMenu(const QPoint &)));
+    connect(mDisasTextEdit, &QWidget::customContextMenuRequested,
+            this, &DisassemblyWidget::showDisasContextMenu);
 
 
-    connect(mDisasScrollArea, SIGNAL(scrollLines(int)), this, SLOT(scrollInstructions(int)));
-    connect(mDisasScrollArea, SIGNAL(disassemblyResized()), this, SLOT(updateMaxLines()));
+    connect(mDisasScrollArea, &DisassemblyScrollArea::scrollLines, this, &DisassemblyWidget::scrollInstructions);
+    connect(mDisasScrollArea, &DisassemblyScrollArea::disassemblyResized, this, &DisassemblyWidget::updateMaxLines);
 
     connectCursorPositionChanged(false);
     connect(mDisasTextEdit->verticalScrollBar(), &QScrollBar::valueChanged, this, [ = ](int value) {
@@ -159,15 +159,15 @@ DisassemblyWidget::DisassemblyWidget(MainWindow *main)
     });
     connect(Core(), SIGNAL(refreshCodeViews()), this, SLOT(refreshDisasm()));
 
-    connect(Config(), SIGNAL(fontsUpdated()), this, SLOT(fontsUpdatedSlot()));
-    connect(Config(), SIGNAL(colorsUpdated()), this, SLOT(colorsUpdatedSlot()));
+    connect(Config(), &Configuration::fontsUpdated, this, &DisassemblyWidget::fontsUpdatedSlot);
+    connect(Config(), &Configuration::colorsUpdated, this, &DisassemblyWidget::colorsUpdatedSlot);
 
     connect(Core(), &CutterCore::refreshAll, this, [this]() {
         refreshDisasm(seekable->getOffset());
     });
     refreshDisasm(seekable->getOffset());
 
-    connect(mCtxMenu, SIGNAL(copy()), mDisasTextEdit, SLOT(copy()));
+    connect(mCtxMenu, &DisassemblyContextMenu::copy, mDisasTextEdit, &QPlainTextEdit::copy);
 
     mCtxMenu->addSeparator();
     mCtxMenu->addAction(&syncAction);
@@ -517,10 +517,10 @@ void DisassemblyWidget::updateCursorPosition()
 void DisassemblyWidget::connectCursorPositionChanged(bool disconnect)
 {
     if (disconnect) {
-        QObject::disconnect(mDisasTextEdit, SIGNAL(cursorPositionChanged()), this,
-                            SLOT(cursorPositionChanged()));
+        QObject::disconnect(mDisasTextEdit, &QPlainTextEdit::cursorPositionChanged,
+                            this, &DisassemblyWidget::cursorPositionChanged);
     } else {
-        connect(mDisasTextEdit, SIGNAL(cursorPositionChanged()), this, SLOT(cursorPositionChanged()));
+        connect(mDisasTextEdit, &QPlainTextEdit::cursorPositionChanged, this, &DisassemblyWidget::cursorPositionChanged);
     }
 }
 

--- a/src/widgets/FlagsWidget.cpp
+++ b/src/widgets/FlagsWidget.cpp
@@ -150,8 +150,8 @@ FlagsWidget::FlagsWidget(MainWindow *main) :
 
     flags_model = new FlagsModel(&flags, this);
     flags_proxy_model = new FlagsSortFilterProxyModel(flags_model, this);
-    connect(ui->filterLineEdit, SIGNAL(textChanged(const QString &)), flags_proxy_model,
-            SLOT(setFilterWildcard(const QString &)));
+    connect(ui->filterLineEdit, &QLineEdit::textChanged,
+            flags_proxy_model, &QSortFilterProxyModel::setFilterWildcard);
     ui->flagsTreeView->setMainWindow(mainWindow);
     ui->flagsTreeView->setModel(flags_proxy_model);
     ui->flagsTreeView->sortByColumn(FlagsModel::OFFSET, Qt::AscendingOrder);

--- a/src/widgets/FunctionsWidget.cpp
+++ b/src/widgets/FunctionsWidget.cpp
@@ -37,9 +37,9 @@ FunctionModel::FunctionModel(QList<FunctionDescription> *functions, QSet<RVA> *i
       currentIndex(-1)
 
 {
-    connect(Core(), SIGNAL(seekChanged(RVA)), this, SLOT(seekChanged(RVA)));
-    connect(Core(), SIGNAL(functionRenamed(const QString &, const QString &)), this,
-            SLOT(functionRenamed(QString, QString)));
+    connect(Core(), &CutterCore::seekChanged, this, &FunctionModel::seekChanged);
+    connect(Core(), &CutterCore::functionRenamed,
+            this, &FunctionModel::functionRenamed);
 }
 
 QModelIndex FunctionModel::index(int row, int column, const QModelIndex &parent) const
@@ -435,7 +435,7 @@ FunctionsWidget::FunctionsWidget(MainWindow *main) :
     setObjectName("FunctionsWidget");
 
     setTooltipStylesheet();
-    connect(Config(), SIGNAL(colorsUpdated()), this, SLOT(setTooltipStylesheet()));
+    connect(Config(), &Configuration::colorsUpdated, this, &FunctionsWidget::setTooltipStylesheet);
 
     QFontInfo font_info = ui->treeView->fontInfo();
     QFont default_font = QFont(font_info.family(), font_info.pointSize());
@@ -476,8 +476,8 @@ FunctionsWidget::FunctionsWidget(MainWindow *main) :
     // Use a custom context menu on the dock title bar
     actionHorizontal.setChecked(true);
     this->setContextMenuPolicy(Qt::CustomContextMenu);
-    connect(this, SIGNAL(customContextMenuRequested(const QPoint &)),
-            this, SLOT(showTitleContextMenu(const QPoint &)));
+    connect(this, &QWidget::customContextMenuRequested,
+            this, &FunctionsWidget::showTitleContextMenu);
 
     connect(Core(), &CutterCore::functionsChanged, this, &FunctionsWidget::refreshTree);
     connect(Core(), &CutterCore::codeRebased, this, &FunctionsWidget::refreshTree);

--- a/src/widgets/Omnibar.cpp
+++ b/src/widgets/Omnibar.cpp
@@ -20,7 +20,7 @@ Omnibar::Omnibar(MainWindow *main, QWidget *parent) :
     this->setTextMargins(10, 0, 0, 0);
     this->setClearButtonEnabled(true);
 
-    connect(this, SIGNAL(returnPressed()), this, SLOT(on_gotoEntry_returnPressed()));
+    connect(this, &QLineEdit::returnPressed, this, &Omnibar::on_gotoEntry_returnPressed);
 
     // Esc clears omnibar
     QShortcut *clear_shortcut = new QShortcut(QKeySequence(Qt::Key_Escape), this);

--- a/src/widgets/OverviewView.cpp
+++ b/src/widgets/OverviewView.cpp
@@ -10,7 +10,7 @@
 OverviewView::OverviewView(QWidget *parent)
     : GraphView(parent)
 {
-    connect(Config(), SIGNAL(colorsUpdated()), this, SLOT(colorsUpdatedSlot()));
+    connect(Config(), &Configuration::colorsUpdated, this, &OverviewView::colorsUpdatedSlot);
     colorsUpdatedSlot();
 }
 

--- a/src/widgets/OverviewWidget.cpp
+++ b/src/widgets/OverviewWidget.cpp
@@ -13,7 +13,7 @@ OverviewWidget::OverviewWidget(MainWindow *main) :
     setWidget(graphView);
     targetGraphWidget = nullptr;
 
-    connect(graphView, SIGNAL(mouseMoved()), this, SLOT(updateTargetView()));
+    connect(graphView, &OverviewView::mouseMoved, this, &OverviewWidget::updateTargetView);
 
     graphDataRefreshDeferrer = createRefreshDeferrer([this]() {
         updateGraphData();

--- a/src/widgets/RegisterRefsWidget.cpp
+++ b/src/widgets/RegisterRefsWidget.cpp
@@ -147,8 +147,8 @@ RegisterRefsWidget::RegisterRefsWidget(MainWindow *main) :
     connect(search_shortcut, &QShortcut::activated, ui->quickFilterView, &QuickFilterView::showFilter);
     search_shortcut->setContext(Qt::WidgetWithChildrenShortcut);
 
-    connect(ui->quickFilterView, SIGNAL(filterTextChanged(const QString &)), registerRefProxyModel,
-            SLOT(setFilterWildcard(const QString &)));
+    connect(ui->quickFilterView, &QuickFilterView::filterTextChanged,
+            registerRefProxyModel, &QSortFilterProxyModel::setFilterWildcard);
     connect(ui->quickFilterView, SIGNAL(filterClosed()), ui->registerRefTreeView, SLOT(setFocus()));
     setScrollMode();
     connect(Core(), &CutterCore::refreshAll, this, &RegisterRefsWidget::refreshRegisterRef);

--- a/src/widgets/ResourcesWidget.cpp
+++ b/src/widgets/ResourcesWidget.cpp
@@ -114,7 +114,7 @@ ResourcesWidget::ResourcesWidget(MainWindow *main) :
     // Configure widget
     this->setWindowTitle(tr("Resources"));
 
-    connect(Core(), SIGNAL(refreshAll()), this, SLOT(refreshResources()));
+    connect(Core(), &CutterCore::refreshAll, this, &ResourcesWidget::refreshResources);
 }
 
 void ResourcesWidget::refreshResources()

--- a/src/widgets/StackWidget.cpp
+++ b/src/widgets/StackWidget.cpp
@@ -40,9 +40,8 @@ StackWidget::StackWidget(MainWindow *main) :
     connect(Core(), &CutterCore::registersChanged, this, &StackWidget::updateContents);
     connect(Core(), &CutterCore::stackChanged, this, &StackWidget::updateContents);
     connect(Config(), &Configuration::fontsUpdated, this, &StackWidget::fontsUpdatedSlot);
-    connect(viewStack, SIGNAL(doubleClicked(const QModelIndex &)), this,
-            SLOT(onDoubleClicked(const QModelIndex &)));
-    connect(viewStack, SIGNAL(customContextMenuRequested(QPoint)), SLOT(customMenuRequested(QPoint)));
+    connect(viewStack, &QAbstractItemView::doubleClicked, this, &StackWidget::onDoubleClicked);
+    connect(viewStack, &QWidget::customContextMenuRequested, this, &StackWidget::customMenuRequested);
     connect(editAction, &QAction::triggered, this, &StackWidget::editStack);
     connect(viewStack->selectionModel(), &QItemSelectionModel::currentChanged,
             this, &StackWidget::onCurrentChanged);

--- a/src/widgets/StringsWidget.cpp
+++ b/src/widgets/StringsWidget.cpp
@@ -156,7 +156,7 @@ StringsWidget::StringsWidget(MainWindow *main) :
         toggleDockWidget(true);
     });
 
-    connect(ui->actionCopy_String, SIGNAL(triggered()), this, SLOT(on_actionCopy()));
+    connect(ui->actionCopy_String, &QAction::triggered, this, &StringsWidget::on_actionCopy);
 
     ui->actionFilter->setShortcut(QKeySequence::Find);
 
@@ -172,8 +172,8 @@ StringsWidget::StringsWidget(MainWindow *main) :
     auto menu = ui->stringsTreeView->getItemContextMenu();
     menu->addAction(ui->actionCopy_String);
 
-    connect(ui->quickFilterView, SIGNAL(filterTextChanged(const QString &)), proxyModel,
-            SLOT(setFilterWildcard(const QString &)));
+    connect(ui->quickFilterView, &ComboQuickFilterView::filterTextChanged,
+            proxyModel, &QSortFilterProxyModel::setFilterWildcard);
 
     connect(ui->quickFilterView, &ComboQuickFilterView::filterTextChanged, this, [this] {
         tree->showItemsNumber(proxyModel->rowCount());

--- a/src/widgets/TypesWidget.cpp
+++ b/src/widgets/TypesWidget.cpp
@@ -150,14 +150,14 @@ TypesWidget::TypesWidget(MainWindow *main) :
     setScrollMode();
 
     // Setup custom context menu
-    connect(ui->typesTreeView, SIGNAL(customContextMenuRequested(const QPoint &)),
-            this, SLOT(showTypesContextMenu(const QPoint &)));
+    connect(ui->typesTreeView, &QWidget::customContextMenuRequested,
+            this, &TypesWidget::showTypesContextMenu);
 
     ui->typesTreeView->setContextMenuPolicy(Qt::CustomContextMenu);
 
 
-    connect(ui->quickFilterView, SIGNAL(filterTextChanged(const QString &)), types_proxy_model,
-            SLOT(setFilterWildcard(const QString &)));
+    connect(ui->quickFilterView, &ComboQuickFilterView::filterTextChanged, types_proxy_model,
+            &QSortFilterProxyModel::setFilterWildcard);
 
     connect(ui->quickFilterView, &ComboQuickFilterView::filterTextChanged, this, [this] {
         tree->showItemsNumber(types_proxy_model->rowCount());
@@ -171,7 +171,7 @@ TypesWidget::TypesWidget(MainWindow *main) :
     connect(clearShortcut, &QShortcut::activated, ui->quickFilterView, &ComboQuickFilterView::clearFilter);
     clearShortcut->setContext(Qt::WidgetWithChildrenShortcut);
 
-    connect(Core(), SIGNAL(refreshAll()), this, SLOT(refreshTypes()));
+    connect(Core(), &CutterCore::refreshAll, this, &TypesWidget::refreshTypes);
 
     connect(
         ui->quickFilterView->comboBox(), &QComboBox::currentTextChanged, this,

--- a/src/widgets/VTablesWidget.cpp
+++ b/src/widgets/VTablesWidget.cpp
@@ -153,8 +153,8 @@ VTablesWidget::VTablesWidget(MainWindow *main) :
     connect(search_shortcut, &QShortcut::activated, ui->quickFilterView, &QuickFilterView::showFilter);
     search_shortcut->setContext(Qt::WidgetWithChildrenShortcut);
 
-    connect(ui->quickFilterView, SIGNAL(filterTextChanged(const QString &)), proxy,
-            SLOT(setFilterWildcard(const QString &)));
+    connect(ui->quickFilterView, &QuickFilterView::filterTextChanged, proxy,
+            &QSortFilterProxyModel::setFilterWildcard);
     connect(ui->quickFilterView, SIGNAL(filterClosed()), ui->vTableTreeView, SLOT(setFocus()));
 
     connect(ui->quickFilterView, &QuickFilterView::filterTextChanged, this, [this] {

--- a/src/widgets/VisualNavbar.cpp
+++ b/src/widgets/VisualNavbar.cpp
@@ -42,11 +42,11 @@ VisualNavbar::VisualNavbar(MainWindow *main, QWidget *parent) :
     addWidget(this->graphicsView);
     //addWidget(addsCombo);
 
-    connect(Core(), SIGNAL(seekChanged(RVA)), this, SLOT(on_seekChanged(RVA)));
-    connect(Core(), SIGNAL(registersChanged()), this, SLOT(drawPCCursor()));
-    connect(Core(), SIGNAL(refreshAll()), this, SLOT(fetchAndPaintData()));
-    connect(Core(), SIGNAL(functionsChanged()), this, SLOT(fetchAndPaintData()));
-    connect(Core(), SIGNAL(flagsChanged()), this, SLOT(fetchAndPaintData()));
+    connect(Core(), &CutterCore::seekChanged, this, &VisualNavbar::on_seekChanged);
+    connect(Core(), &CutterCore::registersChanged, this, &VisualNavbar::drawPCCursor);
+    connect(Core(), &CutterCore::refreshAll, this, &VisualNavbar::fetchAndPaintData);
+    connect(Core(), &CutterCore::functionsChanged, this, &VisualNavbar::fetchAndPaintData);
+    connect(Core(), &CutterCore::flagsChanged, this, &VisualNavbar::fetchAndPaintData);
 
     graphicsScene = new QGraphicsScene(this);
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Old style macro based signal connecting is error prone. Cutter developer docs explain that new code should prefer the new style. But as has been demonstrated multiple times people don't read instructions carefully and examples have a stronger impact - so reduce amount of bad examples.

Refactoring done using clazy. There are a few trickier cases remaining that need manual inspection, those can be done separately.

**Test plan (required)**

Code compiles and nothing is terribly broken when opening an executable.


<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
