### PR TITLE
Xrefs enhancement

### DIFF
--- a/src/dialogs/XrefsDialog.cpp
+++ b/src/dialogs/XrefsDialog.cpp
@@ -134,8 +134,8 @@ void XrefsDialog::updatePreview(RVA addr)
 
 void XrefsDialog::updateLabels(QString name)
 {
-    ui->label_xTo->setText(tr("X-Refs to %1:").arg(name));
-    ui->label_xFrom->setText(tr("X-Refs from %1:").arg(name));
+    ui->label_xTo->setText(tr("X-Refs to %1 (%2 results):").arg(name).arg(toModel.rowCount()));
+    ui->label_xFrom->setText(tr("X-Refs from %1 (%2 results):").arg(name).arg(fromModel.rowCount()));
 }
 
 void XrefsDialog::updateLabelsForVariables(QString name)
@@ -147,10 +147,11 @@ void XrefsDialog::updateLabelsForVariables(QString name)
 void XrefsDialog::fillRefsForAddress(RVA addr, QString name, bool whole_function)
 {
     setWindowTitle(tr("X-Refs for %1").arg(name));
-    updateLabels(name);
 
     toModel.readForOffset(addr, true, whole_function);
     fromModel.readForOffset(addr, false, whole_function);
+
+    updateLabels(name);
 
     // Adjust columns to content
     qhelpers::adjustColumns(ui->fromTreeWidget, fromModel.columnCount(), 0);

--- a/src/dialogs/XrefsDialog.cpp
+++ b/src/dialogs/XrefsDialog.cpp
@@ -8,7 +8,7 @@
 
 #include <QJsonArray>
 
-XrefsDialog::XrefsDialog(MainWindow *main, QWidget *parent) :
+XrefsDialog::XrefsDialog(MainWindow *main, QWidget *parent, bool hideXrefFrom) :
     QDialog(parent),
     addr(0),
     toModel(this),
@@ -52,6 +52,10 @@ XrefsDialog::XrefsDialog(MainWindow *main, QWidget *parent) :
 
     connect(ui->toTreeWidget, &QAbstractItemView::doubleClicked, this, &QWidget::close);
     connect(ui->fromTreeWidget, &QAbstractItemView::doubleClicked, this, &QWidget::close);
+
+    if (hideXrefFrom) {
+        hideXrefFromSection();
+    }
 }
 
 XrefsDialog::~XrefsDialog() { }
@@ -142,6 +146,12 @@ void XrefsDialog::updateLabelsForVariables(QString name)
 {
     ui->label_xTo->setText(tr("Writes to %1").arg(name));
     ui->label_xFrom->setText(tr("Reads from %1").arg(name));
+}
+
+void XrefsDialog::hideXrefFromSection()
+{
+    ui->label_xFrom->hide();
+    ui->fromTreeWidget->hide();
 }
 
 void XrefsDialog::fillRefsForAddress(RVA addr, QString name, bool whole_function)

--- a/src/dialogs/XrefsDialog.h
+++ b/src/dialogs/XrefsDialog.h
@@ -44,7 +44,7 @@ class XrefsDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit XrefsDialog(MainWindow *main, QWidget *parent);
+    explicit XrefsDialog(MainWindow *main, QWidget *parent, bool hideXrefFrom=false);
     ~XrefsDialog();
 
     void fillRefsForAddress(RVA addr, QString name, bool whole_function);
@@ -78,6 +78,7 @@ private:
     void updateLabels(QString name);
     void updateLabelsForVariables(QString name);
     void updatePreview(RVA addr);
+    void hideXrefFromSection();
 };
 
 #endif // XREFSDIALOG_H

--- a/src/menus/AddressableItemContextMenu.cpp
+++ b/src/menus/AddressableItemContextMenu.cpp
@@ -85,7 +85,7 @@ void AddressableItemContextMenu::onActionCopyAddress()
 void AddressableItemContextMenu::onActionShowXrefs()
 {
     emit xrefsTriggered();
-    XrefsDialog dialog(mainWindow, nullptr);
+    XrefsDialog dialog(mainWindow, nullptr, true);
     QString tmpName = name;
     if (name.isEmpty()) {
         name = RAddressString(offset);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**
This pull request solves #2353 issue and i have added extra small feature for printing the number of found results in xref dialog.
For the new feature i have just added a new argument for the 'X-Refs From' and 'X-Refs To' in setText inside updateLabels function.
For the #2353 i have solve this issue by adding a boolean variable for hiding the X-Refs From (default is false) then i changed AddressableItemContextMenu::onActionShowXrefs to call the XrefsDialog with hide eq to _true_.
and for DisassemblyContextMenu i didn't change anything because the new variable is default to _false_.
<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

**Test plan (required)**

Found results for X-Refs Dialog:

![found-results](https://user-images.githubusercontent.com/69148052/89199539-6052ec00-d5b7-11ea-922f-a0c81cb4b39d.png)

X-Refs From is hidden when we open xref dialog from StringWidget or FunctionWidget or SymbolsWidget:

![xref-from](https://user-images.githubusercontent.com/69148052/89199793-c3448300-d5b7-11ea-86f5-35b39bf94492.png)



<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->


<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**
closes #2353

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
