### PR TITLE
Fix an off by 1 bug during hexwidget cursor blinking.

### DIFF
--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -415,7 +415,7 @@ void HexWidget::paintEvent(QPaintEvent *event)
     if (xOffset > 0)
         painter.translate(QPoint(-xOffset, 0));
 
-    if (event->rect() == cursor.screenPos) {
+    if (event->rect() == cursor.screenPos.toAlignedRect()) {
         /* Cursor blink */
         drawCursor(painter);
         return;
@@ -640,7 +640,7 @@ void HexWidget::onCursorBlinked()
     if (!cursorEnabled)
         return;
     cursor.blink();
-    QRect cursorRect(cursor.screenPos.x(), cursor.screenPos.y(), cursor.screenPos.width(), cursor.screenPos.height());
+    QRect cursorRect = cursor.screenPos.toAlignedRect();
     viewport()->update(cursorRect.translated(-horizontalScrollBar()->value(), 0));
 }
 


### PR DESCRIPTION


<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**
1 pixel line sometimes remained on during hexwidget cursor blinking. Most likely due to incorrect floating point to integer rounding or it differing between partial redraw calculation and actual drawing.

**Test plan (required)**
* Make sure that cursor in hexwidget turns off completely during blinking, try with different cursor positions, window positions, screen scaling factors. Before the fix problem wasn't completely reliable.
* Test that redraw fast-path which only redraws the cursor still works by adding debug print inside it.

Before:
![bad_hex](https://user-images.githubusercontent.com/7101031/89308338-ce141c00-d67a-11ea-9f17-f7302aa5a03c.gif)
After:
![good_hex](https://user-images.githubusercontent.com/7101031/89308340-ceacb280-d67a-11ea-9b3e-e8883c2fd947.gif)



<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
