### PR TITLE
Clazy warnings

### DIFF
--- a/src/common/UpdateWorker.cpp
+++ b/src/common/UpdateWorker.cpp
@@ -24,7 +24,7 @@
 UpdateWorker::UpdateWorker(QObject *parent) :
     QObject(parent), pending(false)
 {
-    connect(&t, &QTimer::timeout, [this]() {
+    connect(&t, &QTimer::timeout, this, [this]() {
         if (pending) {
             disconnect(checkReply, nullptr, this, nullptr);
             checkReply->close();
@@ -102,7 +102,7 @@ void UpdateWorker::showUpdateDialog(bool showDontCheckForUpdatesButton)
             QProgressDialog progressDial(tr("Downloading update..."),
                                          tr("Cancel"),
                                          0, 100);
-            connect(this, &UpdateWorker::downloadProcess,
+            connect(this, &UpdateWorker::downloadProcess, &progressDial,
                     [&progressDial](size_t curr, size_t total) {
                 progressDial.setValue(100.0f * curr / total);
             });
@@ -110,7 +110,7 @@ void UpdateWorker::showUpdateDialog(bool showDontCheckForUpdatesButton)
                     this, &UpdateWorker::abortDownload);
             connect(this, &UpdateWorker::downloadFinished,
                     &progressDial, &QProgressDialog::cancel);
-            connect(this, &UpdateWorker::downloadFinished,
+            connect(this, &UpdateWorker::downloadFinished, this,
                     [](QString filePath){
                 QMessageBox info(QMessageBox::Information,
                                  tr("Download finished!"),

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -169,9 +169,9 @@ void MainWindow::initUI()
 
     // G and S goes to goto entry
     QShortcut *goto_shortcut = new QShortcut(QKeySequence(Qt::Key_G), this);
-    connect(goto_shortcut, SIGNAL(activated()), this->omnibar, SLOT(setFocus()));
+    connect(goto_shortcut, &QShortcut::activated, this->omnibar, [this](){ this->omnibar->setFocus(); });
     QShortcut *seek_shortcut = new QShortcut(QKeySequence(Qt::Key_S), this);
-    connect(seek_shortcut, SIGNAL(activated()), this->omnibar, SLOT(setFocus()));
+    connect(seek_shortcut, &QShortcut::activated, this->omnibar, [this](){ this->omnibar->setFocus(); });
     QShortcut *seek_to_func_end_shortcut = new QShortcut(QKeySequence(Qt::Key_Dollar), this);
     connect(seek_to_func_end_shortcut, &QShortcut::activated, this, &MainWindow::seekToFunctionLastInstruction);
     QShortcut *seek_to_func_start_shortcut = new QShortcut(QKeySequence(Qt::Key_AsciiCircum), this);
@@ -184,8 +184,7 @@ void MainWindow::initUI()
     connect(ui->actionZoomOut, &QAction::triggered, this, &MainWindow::onZoomOut);
     connect(ui->actionZoomReset, &QAction::triggered, this, &MainWindow::onZoomReset);
 
-    connect(core, SIGNAL(projectSaved(bool, const QString &)), this, SLOT(projectSaved(bool,
-                                                                                       const QString &)));
+    connect(core, &CutterCore::projectSaved, this, &MainWindow::projectSaved);
 
     connect(core, &CutterCore::toggleDebugView, this, &MainWindow::toggleDebugView);
 
@@ -319,7 +318,7 @@ void MainWindow::initToolBar()
     this->visualNavbar->setMovable(false);
     addToolBarBreak(Qt::TopToolBarArea);
     addToolBar(visualNavbar);
-    QObject::connect(configuration, &Configuration::colorsUpdated, [this]() {
+    QObject::connect(configuration, &Configuration::colorsUpdated, this, [this]() {
         this->visualNavbar->updateGraphicsScene();
     });
     QObject::connect(configuration, &Configuration::interfaceThemeChanged, this, &MainWindow::chooseThemeIcons);
@@ -619,7 +618,6 @@ void MainWindow::finalizeOpen()
     setFocus();
     bool graphContainsFunc = false;
     for (auto dockWidget : dockWidgets) {
-        const QString className = dockWidget->metaObject()->className();
         auto graphWidget = qobject_cast<GraphWidget *>(dockWidget);
         if (graphWidget && dockWidget->isVisibleToUser()) {
             graphContainsFunc = !graphWidget->getGraphView()->getBlocks().empty();

--- a/src/dialogs/EditVariablesDialog.cpp
+++ b/src/dialogs/EditVariablesDialog.cpp
@@ -13,7 +13,8 @@ EditVariablesDialog::EditVariablesDialog(RVA offset, QString initialVar, QWidget
 {
     ui->setupUi(this);
     connect(ui->buttonBox, &QDialogButtonBox::accepted, this, &EditVariablesDialog::applyFields);
-    connect(ui->dropdownLocalVars, SIGNAL(currentIndexChanged(int)), SLOT(updateFields()));
+    connect<void(QComboBox::*)(int)>(ui->dropdownLocalVars, &QComboBox::currentIndexChanged,
+                                     this, &EditVariablesDialog::updateFields);
 
     QString fcnName = Core()->cmdRawAt("afn.", offset).trimmed();
     setWindowTitle(tr("Set Variable Types for Function: %1").arg(fcnName));

--- a/src/dialogs/InitialOptionsDialog.cpp
+++ b/src/dialogs/InitialOptionsDialog.cpp
@@ -91,7 +91,7 @@ InitialOptionsDialog::InitialOptionsDialog(MainWindow *main):
 
     connect(ui->scriptCheckBox, &QCheckBox::stateChanged, this, &InitialOptionsDialog::updateScriptLayout);
 
-    connect(ui->cancelButton, SIGNAL(clicked()), this, SLOT(reject()));
+    connect(ui->cancelButton, &QPushButton::clicked, this, &InitialOptionsDialog::reject);
 
     ui->programLineEdit->setText(main->getFilename());
 }

--- a/src/dialogs/preferences/AsmOptionsWidget.cpp
+++ b/src/dialogs/preferences/AsmOptionsWidget.cpp
@@ -64,7 +64,7 @@ AsmOptionsWidget::AsmOptionsWidget(PreferencesDialog *dialog)
                 &AsmOptionsWidget::asmComboBoxChanged);
     connect(ui->offsetCheckBox, &QCheckBox::toggled, this, &AsmOptionsWidget::offsetCheckBoxToggled);
     connect(ui->relOffsetCheckBox, &QCheckBox::toggled, this, &AsmOptionsWidget::relOffCheckBoxToggled);
-    connect(Core(), SIGNAL(asmOptionsChanged()), this, SLOT(updateAsmOptionsFromVars()));
+    connect(Core(), &CutterCore::asmOptionsChanged, this, &AsmOptionsWidget::updateAsmOptionsFromVars);
     updateAsmOptionsFromVars();
 }
 

--- a/src/dialogs/preferences/DebugOptionsWidget.cpp
+++ b/src/dialogs/preferences/DebugOptionsWidget.cpp
@@ -17,6 +17,9 @@ DebugOptionsWidget::DebugOptionsWidget(PreferencesDialog *dialog)
     ui->setupUi(this);
 
     updateDebugPlugin();
+
+    connect(ui->pluginComboBox, &QComboBox::currentTextChanged,
+            this, &DebugOptionsWidget::onDebugPluginChanged);
 }
 
 DebugOptionsWidget::~DebugOptionsWidget() {}
@@ -24,8 +27,8 @@ DebugOptionsWidget::~DebugOptionsWidget() {}
 void DebugOptionsWidget::updateDebugPlugin()
 {
     ui->esilBreakOnInvalid->setChecked(Config()->getConfigBool("esil.breakoninvalid"));
-    disconnect(ui->pluginComboBox, SIGNAL(currentIndexChanged(const QString &)), this,
-               SLOT(on_pluginComboBox_currentIndexChanged(const QString &)));
+    disconnect(ui->pluginComboBox, &QComboBox::currentTextChanged,
+            this, &DebugOptionsWidget::onDebugPluginChanged);
 
     QStringList plugins = Core()->getDebugPlugins();
     for (const QString &str : plugins)
@@ -34,8 +37,8 @@ void DebugOptionsWidget::updateDebugPlugin()
     QString plugin = Core()->getActiveDebugPlugin();
     ui->pluginComboBox->setCurrentText(plugin);
 
-    connect(ui->pluginComboBox, SIGNAL(currentIndexChanged(const QString &)), this,
-            SLOT(on_pluginComboBox_currentIndexChanged(const QString &)));
+    connect(ui->pluginComboBox, &QComboBox::currentTextChanged,
+            this, &DebugOptionsWidget::onDebugPluginChanged);
 
     QString stackSize = Core()->getConfig("esil.stack.size");
     ui->stackSize->setText(stackSize);
@@ -47,7 +50,7 @@ void DebugOptionsWidget::updateDebugPlugin()
     connect(ui->stackSize, &QLineEdit::editingFinished, this, &DebugOptionsWidget::updateStackSize);
 }
 
-void DebugOptionsWidget::on_pluginComboBox_currentIndexChanged(const QString &plugin)
+void DebugOptionsWidget::onDebugPluginChanged(const QString &plugin)
 {
     Core()->setDebugPlugin(plugin);
 }

--- a/src/dialogs/preferences/DebugOptionsWidget.h
+++ b/src/dialogs/preferences/DebugOptionsWidget.h
@@ -26,6 +26,6 @@ private slots:
     void updateDebugPlugin();
     void updateStackAddr();
     void updateStackSize();
-    void on_pluginComboBox_currentIndexChanged(const QString &index);
+    void onDebugPluginChanged(const QString &index);
     void on_esilBreakOnInvalid_toggled(bool checked);
 };

--- a/src/widgets/ClassesWidget.cpp
+++ b/src/widgets/ClassesWidget.cpp
@@ -590,7 +590,8 @@ ClassesWidget::ClassesWidget(MainWindow *main) :
 
     ui->classSourceCombo->setCurrentIndex(1);
 
-    connect(ui->classSourceCombo, SIGNAL(currentIndexChanged(int)), this, SLOT(refreshClasses()));
+    connect<void(QComboBox::*)(int)>(ui->classSourceCombo, &QComboBox::currentIndexChanged,
+                                     this, &ClassesWidget::refreshClasses);
     connect(ui->classesTreeView, &QTreeView::customContextMenuRequested, this, &ClassesWidget::showContextMenu);
 
     refreshClasses();

--- a/src/widgets/FlagsWidget.cpp
+++ b/src/widgets/FlagsWidget.cpp
@@ -158,7 +158,7 @@ FlagsWidget::FlagsWidget(MainWindow *main) :
 
     // Ctrl-F to move the focus to the Filter search box
     QShortcut *searchShortcut = new QShortcut(QKeySequence::Find, this);
-    connect(searchShortcut, SIGNAL(activated()), ui->filterLineEdit, SLOT(setFocus()));
+    connect(searchShortcut, &QShortcut::activated, ui->filterLineEdit, [this]() { ui->filterLineEdit->setFocus(); });
     searchShortcut->setContext(Qt::WidgetWithChildrenShortcut);
 
     // Esc to clear the filter entry

--- a/src/widgets/Omnibar.cpp
+++ b/src/widgets/Omnibar.cpp
@@ -24,7 +24,7 @@ Omnibar::Omnibar(MainWindow *main, QWidget *parent) :
 
     // Esc clears omnibar
     QShortcut *clear_shortcut = new QShortcut(QKeySequence(Qt::Key_Escape), this);
-    connect(clear_shortcut, SIGNAL(activated()), this, SLOT(clear()));
+    connect(clear_shortcut, &QShortcut::activated, this, &Omnibar::clear);
     clear_shortcut->setContext(Qt::WidgetWithChildrenShortcut);
 }
 

--- a/src/widgets/RegisterRefsWidget.cpp
+++ b/src/widgets/RegisterRefsWidget.cpp
@@ -149,14 +149,16 @@ RegisterRefsWidget::RegisterRefsWidget(MainWindow *main) :
 
     connect(ui->quickFilterView, &QuickFilterView::filterTextChanged,
             registerRefProxyModel, &QSortFilterProxyModel::setFilterWildcard);
-    connect(ui->quickFilterView, SIGNAL(filterClosed()), ui->registerRefTreeView, SLOT(setFocus()));
+    connect(ui->quickFilterView, &QuickFilterView::filterClosed, ui->registerRefTreeView, [this](){
+        ui->registerRefTreeView->setFocus();
+    });
     setScrollMode();
     connect(Core(), &CutterCore::refreshAll, this, &RegisterRefsWidget::refreshRegisterRef);
     connect(Core(), &CutterCore::registersChanged, this, &RegisterRefsWidget::refreshRegisterRef);
-    connect(actionCopyValue, &QAction::triggered, [ = ] () {
+    connect(actionCopyValue, &QAction::triggered, this, [this] () {
         copyClip(RegisterRefModel::ValueColumn);
     });
-    connect(actionCopyRef, &QAction::triggered, [ = ] () {
+    connect(actionCopyRef, &QAction::triggered, this, [this] () {
         copyClip(RegisterRefModel::RefColumn);
     });
     ui->registerRefTreeView->setContextMenuPolicy(Qt::CustomContextMenu);

--- a/src/widgets/SdbWidget.cpp
+++ b/src/widgets/SdbWidget.cpp
@@ -16,7 +16,7 @@ SdbWidget::SdbWidget(MainWindow *main) :
 
     path.clear();
 
-    connect(Core(), SIGNAL(refreshAll()), this, SLOT(reload()));
+    connect(Core(), &CutterCore::refreshAll, this, [this](){ reload(); });
     reload();
 }
 

--- a/src/widgets/VTablesWidget.cpp
+++ b/src/widgets/VTablesWidget.cpp
@@ -155,7 +155,7 @@ VTablesWidget::VTablesWidget(MainWindow *main) :
 
     connect(ui->quickFilterView, &QuickFilterView::filterTextChanged, proxy,
             &QSortFilterProxyModel::setFilterWildcard);
-    connect(ui->quickFilterView, SIGNAL(filterClosed()), ui->vTableTreeView, SLOT(setFocus()));
+    connect(ui->quickFilterView, &QuickFilterView::filterClosed, ui->vTableTreeView, [this](){ ui->vTableTreeView->setFocus(); });
 
     connect(ui->quickFilterView, &QuickFilterView::filterTextChanged, this, [this] {
         tree->showItemsNumber(proxy->rowCount());


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Further reduce amount of old style signal connections. Didn't touch main window and disassembly files for now. Some of those might conflict with changes in decompiler refactoring branch.

**Test plan (required)**
* test shortcut "G" -> focus omnibar
* shortcut "S" -> focus omnibar
* save project -> "Project Saved" message printed
* change color theme -> slot triggered but, can't see effect. Custom color themes seem to be broken in master. #2372 
* click cancel in the initial options dialog -> file open dialog gets shown
* in settings change options, see effect, restart, make sure is was saved
* open debug options, change backend, test it was changed using `e dbg.backend`
* make test c++ executable defining a class with some methods that are called, compile it without optimizations, open using Cutter, in class widget switch between "Binary info (Fixed)" and  "Analysis (Editable)", binary info one should show the class
* Ctrl+F in flags widget -> focus searchbar
* Type something in omnibar, press Esc -> ominbar text cleared
* Open register ref widget, close search bar -> focus changes to table part
* In register ref widget copy register value using context menu -> value gets copied
* In register ref widget copy  register reference using context menu -> value gets copied
* In vtable widget Ctrl-F -> focus on search widget, Esc -> focus back to table


**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
