### PR TITLE
Output colors in rgb:nnnnnn format instead of #nnnnnn.

### DIFF
--- a/src/common/ColorThemeWorker.cpp
+++ b/src/common/ColorThemeWorker.cpp
@@ -122,26 +122,27 @@ QString ColorThemeWorker::save(const QJsonDocument &theme, const QString &themeN
     }
 
     QJsonObject obj = theme.object();
-    QString line;
-    QColor::NameFormat format;
     for (auto it = obj.constBegin(); it != obj.constEnd(); it++) {
-        if (cutterSpecificOptions.contains(it.key())) {
-            line = "#~%1 %2\n";
-            format = QColor::HexArgb;
-        } else {
-            line = "ec %1 %2\n";
-            format = QColor::HexRgb;
-        }
+
         QJsonArray arr = it.value().toArray();
+        QColor color;
         if (arr.isEmpty()) {
-            fOut.write(line.arg(it.key())
-                       .arg(it.value().toVariant().value<QColor>().name(format)).toUtf8());
+            color = it.value().toVariant().value<QColor>();
         } else if (arr.size() == 4) {
-            fOut.write(line.arg(it.key())
-                       .arg(QColor(arr[0].toInt(), arr[1].toInt(), arr[2].toInt(), arr[3].toInt()).name(format)).toUtf8());
+            color = QColor(arr[0].toInt(), arr[1].toInt(), arr[2].toInt(), arr[3].toInt());
         } else if (arr.size() == 3) {
-            fOut.write(line.arg(it.key())
-                       .arg(QColor(arr[0].toInt(), arr[1].toInt(), arr[2].toInt()).name(format)).toUtf8());
+            color = QColor(arr[0].toInt(), arr[1].toInt(), arr[2].toInt());
+        } else {
+            continue;
+        }
+        if (cutterSpecificOptions.contains(it.key())) {
+            fOut.write(QString("#~%1 rgb:%2\n")
+                       .arg(it.key(), color.name(QColor::HexArgb).remove('#'))
+                       .toUtf8());
+        } else {
+            fOut.write(QString("ec %1 rgb:%2\n")
+                       .arg(it.key(), color.name(QColor::HexRgb).remove('#'))
+                       .toUtf8());
         }
     }
 


### PR DESCRIPTION
ec name #nnnnnn can get mixed up with comment.

<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

**Test plan (required)**

* Perform the steps described in #2372 
* Make sure messages similar to following are not printed to console widget:
```
(ucall)(COLOR)
(ujmp)(COLOR)
(usrcmt)(COLOR)
```
* Change Cutter specific color in the color theme and restart Cutter, make sure it was properly loaded
* Change R2 color in the color theme restart Cutter make sure it was properly loaded
* Copy color theme X
* Switch to color theme Y
* Switch to color theme "X copy"
* Switch back and forth between "X" and "X copy" make sure nothing changes

**Closing issues**

Closes #2372 