### PR TITLE
Add "Documentation" button to the "help" menu

### DIFF
--- a/docs/source/user-docs/menus/menu-bar/help-menu.rst
+++ b/docs/source/user-docs/menus/menu-bar/help-menu.rst
@@ -12,3 +12,9 @@ Report an Issue
 **Description:** Quickly report an issue to Cutter's GitHub repository. Clicking this option will navigate your browser to the new-issue page in Cutter's GitHub repository. It will also automatically fill relevant information inside the issue template.    
 
 **Steps:** Help -> Report an issue
+
+Documention
+---------------------------------------
+**Description** Cutter Documention page. This will redirect you to our documentation page on your browser. Strongly suggest to read the docs in any doubts.
+
+**Steps:** Help -> Documention

--- a/docs/source/user-docs/menus/menu-bar/help-menu.rst
+++ b/docs/source/user-docs/menus/menu-bar/help-menu.rst
@@ -17,4 +17,4 @@ Documentation
 ---------------------------------------
 **Description:** Clicking this option will open the user documentation of Cutter in your browser.
 
-**Steps:** Help -> Documention
+**Steps:** Help -> Documentation

--- a/docs/source/user-docs/menus/menu-bar/help-menu.rst
+++ b/docs/source/user-docs/menus/menu-bar/help-menu.rst
@@ -13,8 +13,8 @@ Report an Issue
 
 **Steps:** Help -> Report an issue
 
-Documention
+Documentation
 ---------------------------------------
-**Description** Cutter Documention page. This will redirect you to our documentation page on your browser. Strongly suggest to read the docs in any doubts.
+**Description:** Clicking this option will open the user documentation of Cutter in your browser.
 
 **Steps:** Help -> Documention

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -1577,7 +1577,7 @@ void MainWindow::on_actionIssue_triggered()
 
 void MainWindow::documentation_triggered()
 {
-    QDesktopServices::openUrl(QUrl("https://cutter.re/docs/user-docs.html", QUrl::TolerantMode));
+    QDesktopServices::openUrl(QUrl("https://cutter.re/docs/user-docs"));
 }
 
 void MainWindow::on_actionRefresh_Panels_triggered()

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -231,6 +231,7 @@ void MainWindow::initUI()
   
     connect(ui->actionSaveLayout, &QAction::triggered, this, &MainWindow::saveNamedLayout);
     connect(ui->actionManageLayouts, &QAction::triggered, this, &MainWindow::manageLayouts);
+    connect(ui->actionDocumentation, &QAction::triggered, this, &MainWindow::documentation_triggered);
 
     /* Setup plugins interfaces */
     for (auto &plugin : Plugins()->getPlugins()) {
@@ -1574,11 +1575,9 @@ void MainWindow::on_actionIssue_triggered()
     openIssue();
 }
 
-void MainWindow::on_actionDocumentation_triggered()
+void MainWindow::documentation_triggered()
 {
-    QString url;
-    url = "https://cutter.re/docs/user-docs.html";
-    QDesktopServices::openUrl(QUrl(url, QUrl::TolerantMode));
+    QDesktopServices::openUrl(QUrl("https://cutter.re/docs/user-docs.html", QUrl::TolerantMode));
 }
 
 void MainWindow::on_actionRefresh_Panels_triggered()

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -231,7 +231,7 @@ void MainWindow::initUI()
   
     connect(ui->actionSaveLayout, &QAction::triggered, this, &MainWindow::saveNamedLayout);
     connect(ui->actionManageLayouts, &QAction::triggered, this, &MainWindow::manageLayouts);
-    connect(ui->actionDocumentation, &QAction::triggered, this, &MainWindow::documentation_triggered);
+    connect(ui->actionDocumentation, &QAction::triggered, this, &MainWindow::documentationClicked);
 
     /* Setup plugins interfaces */
     for (auto &plugin : Plugins()->getPlugins()) {
@@ -1575,7 +1575,7 @@ void MainWindow::on_actionIssue_triggered()
     openIssue();
 }
 
-void MainWindow::documentation_triggered()
+void MainWindow::documentationClicked()
 {
     QDesktopServices::openUrl(QUrl("https://cutter.re/docs/user-docs"));
 }

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -1574,6 +1574,13 @@ void MainWindow::on_actionIssue_triggered()
     openIssue();
 }
 
+void MainWindow::on_actionDocumentation_triggered()
+{
+    QString url;
+    url = "https://cutter.re/docs/user-docs.html";
+    QDesktopServices::openUrl(QUrl(url, QUrl::TolerantMode));
+}
+
 void MainWindow::on_actionRefresh_Panels_triggered()
 {
     this->refreshAll();

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -162,7 +162,7 @@ public slots:
 private slots:
     void on_actionAbout_triggered();
     void on_actionIssue_triggered();
-    void documentation_triggered();
+    void documentationClicked();
     void addExtraGraph();
     void addExtraHexdump();
     void addExtraDisassembly();

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -162,7 +162,7 @@ public slots:
 private slots:
     void on_actionAbout_triggered();
     void on_actionIssue_triggered();
-    void on_actionDocumentation_triggered();
+    void documentation_triggered();
     void addExtraGraph();
     void addExtraHexdump();
     void addExtraDisassembly();

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -162,6 +162,7 @@ public slots:
 private slots:
     void on_actionAbout_triggered();
     void on_actionIssue_triggered();
+    void on_actionDocumentation_triggered();
     void addExtraGraph();
     void addExtraHexdump();
     void addExtraDisassembly();

--- a/src/core/MainWindow.ui
+++ b/src/core/MainWindow.ui
@@ -130,6 +130,7 @@
     </property>
     <addaction name="actionAbout"/>
     <addaction name="actionIssue"/>
+    <addaction name="actionDocumentation"/>
    </widget>
    <widget class="QMenu" name="menuEdit">
     <property name="title">


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Added documentation button on help screen

![image](https://user-images.githubusercontent.com/20182642/89870235-348ac400-dbbe-11ea-9f71-690d5f9d61c2.png)



**Test plan (required)**

1. Checkout the pr on your machine and compile it.
2. Open Cutter
3. Go the the "Help" menu and click on the "Documentation" button
4. Observe that your browser was opened with the user-documentation of Cutter


**Closing issues**
closes #2343

