### PR TITLE
Get rid of circular include between Cutter.h and CutterPlugin.h

### DIFF
--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -23,7 +23,6 @@ class Decompiler;
 class R2Task;
 class R2TaskDialog;
 
-#include "plugins/CutterPlugin.h"
 #include "common/BasicBlockHighlighter.h"
 #include "common/R2Task.h"
 #include "common/Helpers.h"

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -11,6 +11,7 @@
 #include "common/TempConfig.h"
 #include "common/RunScriptTask.h"
 #include "common/PythonManager.h"
+#include "plugins/CutterPlugin.h"
 #include "plugins/PluginManager.h"
 #include "CutterConfig.h"
 #include "CutterApplication.h"

--- a/src/menus/AddressableItemContextMenu.h
+++ b/src/menus/AddressableItemContextMenu.h
@@ -5,6 +5,8 @@
 #include <QMenu>
 #include <QKeySequence>
 
+class MainWindow;
+
 class CUTTER_EXPORT AddressableItemContextMenu : public QMenu
 {
     Q_OBJECT

--- a/src/menus/DisassemblyContextMenu.h
+++ b/src/menus/DisassemblyContextMenu.h
@@ -6,6 +6,8 @@
 #include <QMenu>
 #include <QKeySequence>
 
+class MainWindow;
+
 class CUTTER_EXPORT DisassemblyContextMenu : public QMenu
 {
     Q_OBJECT

--- a/src/plugins/CutterPlugin.h
+++ b/src/plugins/CutterPlugin.h
@@ -1,10 +1,8 @@
 #ifndef CUTTERPLUGIN_H
 #define CUTTERPLUGIN_H
 
-class CutterPlugin;
 class MainWindow;
 
-#include "core/Cutter.h"
 #include "widgets/CutterDockWidget.h"
 
 class CUTTER_EXPORT CutterPlugin

--- a/src/plugins/PluginManager.cpp
+++ b/src/plugins/PluginManager.cpp
@@ -10,11 +10,13 @@
 #include "PluginManager.h"
 #include "CutterPlugin.h"
 #include "CutterConfig.h"
+#include "common/Helpers.h"
 
 #include <QDir>
 #include <QCoreApplication>
 #include <QPluginLoader>
 #include <QStandardPaths>
+#include <QDebug>
 
 Q_GLOBAL_STATIC(PluginManager, uniqueInstance)
 

--- a/src/plugins/PluginManager.h
+++ b/src/plugins/PluginManager.h
@@ -7,7 +7,7 @@
 #include <memory>
 #include <vector>
 
-class CutterPlugin;
+#include "plugins/CutterPlugin.h"
 
 class PluginManager: public QObject
 {


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**
Remove unnecessary circular include.

**Test plan (required)**
Cutter compiles in the CI.
**Closing issues**

closes #2384 
