### PR TITLE
Disable Plugins menu if no plugins are installed (#2318)

### DIFF
--- a/docs/source/user-docs/menus/menu-bar/plugins-menu.rst
+++ b/docs/source/user-docs/menus/menu-bar/plugins-menu.rst
@@ -3,6 +3,6 @@ Plugins Menu
 
 Plugins Sub-Menu
 ----------------------------------------
-**Description:** This menu will contain the windows and views created by the loaded plugins. By default, this menu is empty and disabled unless plugins added their actions and items to the menu.    
+**Description:** This menu will contain the windows and views created by the loaded plugins. By default, this menu is empty unless plugins added their actions and items to the menu.    
 
 **Steps:** Windows -> Plugins

--- a/docs/source/user-docs/menus/menu-bar/plugins-menu.rst
+++ b/docs/source/user-docs/menus/menu-bar/plugins-menu.rst
@@ -3,6 +3,6 @@ Plugins Menu
 
 Plugins Sub-Menu
 ----------------------------------------
-**Description:** This menu will contain the windows and views created by the loaded plugins. By default, this menu is empty unless plugins added their actions and items to the menu.    
+**Description:** This menu will contain the windows and views created by the loaded plugins. By default, this menu is empty and disabled unless plugins added their actions and items to the menu.    
 
 **Steps:** Windows -> Plugins

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -237,10 +237,8 @@ void MainWindow::initUI()
 
     /* Setup plugins interfaces */
     const auto &plugins = Plugins()->getPlugins();
-    if (!plugins.empty()) {
-        for (auto &plugin : plugins) {
-            plugin->setupInterface(this);
-        }
+    for (auto &plugin : plugins) {
+        plugin->setupInterface(this);
     }
 
     // Check if plugins are loaded and display tooltips accordingly

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -247,11 +247,11 @@ void MainWindow::initUI()
     ui->menuWindows->setToolTipsVisible(true);
     if (plugins.empty()) {
         ui->menuPlugins->menuAction()->setToolTip(
-                "No plugins are installed. Check the plugins section on Cutter documentation to learn more.");
+                tr("No plugins are installed. Check the plugins section on Cutter documentation to learn more."));
         ui->menuPlugins->setEnabled(false);
     } else if (ui->menuPlugins->isEmpty()) {
         ui->menuPlugins->menuAction()->setToolTip(
-                "Plugins are installed. No entries haven been added to this menu however.");
+                tr("Plugins are installed. No entries haven been added to this menu however."));
         ui->menuPlugins->setEnabled(false);
     }
 

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -238,11 +238,21 @@ void MainWindow::initUI()
     /* Setup plugins interfaces */
     const auto &plugins = Plugins()->getPlugins();
     if (!plugins.empty()) {
-      ui->menuPlugins->setEnabled(true); // disabled by default
+        for (auto &plugin : plugins) {
+            plugin->setupInterface(this);
+        }
+    }
 
-      for (auto &plugin : plugins) {
-        plugin->setupInterface(this);
-      }
+    // Check if plugins are loaded and display tooltips accordingly
+    ui->menuWindows->setToolTipsVisible(true);
+    if (plugins.empty()) {
+        ui->menuPlugins->menuAction()->setToolTip(
+                "No plugins are installed. Check the plugins section on Cutter documentation to learn more.");
+        ui->menuPlugins->setEnabled(false);
+    } else if (ui->menuPlugins->isEmpty()) {
+        ui->menuPlugins->menuAction()->setToolTip(
+                "Plugins are installed. No entries haven been added to this menu however.");
+        ui->menuPlugins->setEnabled(false);
     }
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 7, 0)

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -236,8 +236,13 @@ void MainWindow::initUI()
     connect(ui->actionDocumentation, &QAction::triggered, this, &MainWindow::documentationClicked);
 
     /* Setup plugins interfaces */
-    for (auto &plugin : Plugins()->getPlugins()) {
+    const auto &plugins = Plugins()->getPlugins();
+    if (!plugins.empty()) {
+      ui->menuPlugins->setEnabled(true); // disabled by default
+
+      for (auto &plugin : plugins) {
         plugin->setupInterface(this);
+      }
     }
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 7, 0)

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -251,7 +251,7 @@ void MainWindow::initUI()
         ui->menuPlugins->setEnabled(false);
     } else if (ui->menuPlugins->isEmpty()) {
         ui->menuPlugins->menuAction()->setToolTip(
-                tr("Plugins are installed. No entries haven been added to this menu however."));
+                tr("The installed plugins didn't add entries to this menu."));
         ui->menuPlugins->setEnabled(false);
     }
 

--- a/src/core/MainWindow.ui
+++ b/src/core/MainWindow.ui
@@ -151,9 +151,6 @@
      <property name="title">
       <string>Plugins</string>
      </property>
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
     </widget>
     <widget class="QMenu" name="menuAddInfoWidgets">
      <property name="title">

--- a/src/core/MainWindow.ui
+++ b/src/core/MainWindow.ui
@@ -151,6 +151,9 @@
      <property name="title">
       <string>Plugins</string>
      </property>
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
     </widget>
     <widget class="QMenu" name="menuAddInfoWidgets">
      <property name="title">


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**
The `Windows -> Plugins` entry is now disabled by default and only enabled if there are plugins available to load from (see this [issue](https://github.com/radareorg/cutter/issues/2318) for more information). Note that I was unable to set a Tooltip, not sure if that's how you do it in QT (being new to it) but here's the code I implemented and then deleted after I had no success with it:
```C++
      ui->menuPlugins->setToolTip(QString("tooltip test"));
      ui->menuPlugins->setToolTipsVisible(true);
```

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

**Test plan (required)**
a) Open Cutter __with__ plugins loaded and check if `Windows -> Plugins` is enabled
b) Open Cutter __without__ any plugins loaded and check if `Windows -> Plugins` is disabled

![before_after](https://user-images.githubusercontent.com/29666622/90797777-619f4b00-e311-11ea-902c-00c75b23df45.png)

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->


<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**
closes #2318 
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
