### PR TITLE
Show border when omnibar in focus

### DIFF
--- a/src/widgets/Omnibar.cpp
+++ b/src/widgets/Omnibar.cpp
@@ -16,7 +16,11 @@ Omnibar::Omnibar(MainWindow *main, QWidget *parent) :
     this->setMinimumHeight(16);
     this->setFrame(false);
     this->setPlaceholderText(tr("Type flag name or address here"));
-    this->setStyleSheet("border-radius: 5px; padding: 0 8px; margin: 5px 0;");
+
+    // Make the Omnibar with round edges and make sure it has a border when in focus.
+    this->setStyleSheet("QLineEdit {border-radius: 5px; padding: 0 8px; margin: 5px 0;}"
+                        "QLineEdit:focus {border: 2px solid #006080;}");
+                        
     this->setTextMargins(10, 0, 0, 0);
     this->setClearButtonEnabled(true);
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**
This sinple cosmetic PR makes sure that the Mmnibar will have a border when in focus, as other QLineEdit items have. This helps the user to notice that something happened after pressing <kbd>S</kbd> or <kbd>G</kbd>.

**Test plan (required)**
1. Focus on omnibar using your mouse, notice the border
2. Lose focus by moving ot another widget
3. Press S or G to navigate to the Omnibar and observe that it has a border


