### PR TITLE
Save layout of the Decompiler Widgets

### DIFF
--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -157,6 +157,8 @@ void MainWindow::initUI()
     widgetTypeToConstructorMap.insert(DisassemblyWidget::getWidgetType(),
                                       getNewInstance<DisassemblyWidget>);
     widgetTypeToConstructorMap.insert(HexdumpWidget::getWidgetType(), getNewInstance<HexdumpWidget>);
+    widgetTypeToConstructorMap.insert(DecompilerWidget::getWidgetType(),
+                                      getNewInstance<DecompilerWidget>);
 
     initToolBar();
     initDocks();
@@ -654,7 +656,12 @@ void MainWindow::finalizeOpen()
         auto disasmWidget = qobject_cast<DisassemblyWidget *>(dockWidget);
         if (disasmWidget && dockWidget->isVisibleToUser()) {
             disasmWidget->raiseMemoryWidget();
-            // continue looping in case there is a graph wiget
+            // continue looping in case there is a graph widget
+        }
+        auto decompilerWidget = qobject_cast<DecompilerWidget *>(dockWidget);
+        if (decompilerWidget && dockWidget->isVisibleToUser()) {
+            decompilerWidget->raiseMemoryWidget();
+            // continue looping in case there is a graph widget
         }
     }
 }
@@ -885,7 +892,8 @@ bool MainWindow::isExtraMemoryWidget(QDockWidget *dock) const
 {
     return qobject_cast<GraphWidget*>(dock) ||
             qobject_cast<HexdumpWidget*>(dock) ||
-            qobject_cast<DisassemblyWidget*>(dock);
+            qobject_cast<DisassemblyWidget*>(dock) ||
+            qobject_cast<DecompilerWidget*>(dock);
 }
 
 MemoryWidgetType MainWindow::getMemoryWidgetTypeToRestore()
@@ -1341,7 +1349,8 @@ void MainWindow::setViewLayout(const CutterLayout &layout)
         docksToCreate = QStringList {
             DisassemblyWidget::getWidgetType(),
             GraphWidget::getWidgetType(),
-            HexdumpWidget::getWidgetType()
+            HexdumpWidget::getWidgetType(),
+            DecompilerWidget::getWidgetType()
         };
     } else {
         docksToCreate = layout.viewProperties.keys();

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -108,6 +108,11 @@ DecompilerWidget::DecompilerWidget(MainWindow *main) :
 
 DecompilerWidget::~DecompilerWidget() = default;
 
+QString DecompilerWidget::getWidgetType()
+{
+    return "Decompiler";
+}
+
 Decompiler *DecompilerWidget::getCurrentDecompiler()
 {
     return Core()->getDecompilerById(ui->decompilerComboBox->currentData().toString());

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -34,8 +34,8 @@ DecompilerWidget::DecompilerWidget(MainWindow *main) :
 {
     ui->setupUi(this);
     setObjectName(main
-                  ? main->getUniqueObjectName(tr("Decompiler"))
-                  : tr("Decompiler"));
+                  ? main->getUniqueObjectName(getWidgetType())
+                  : getWidgetType());
     updateWindowTitle();
 
     syntaxHighlighter = Config()->createSyntaxHighlighter(ui->textEdit->document());

--- a/src/widgets/DecompilerWidget.h
+++ b/src/widgets/DecompilerWidget.h
@@ -27,6 +27,7 @@ protected:
 public:
     explicit DecompilerWidget(MainWindow *main);
     ~DecompilerWidget();
+    static QString getWidgetType();
 public slots:
     void showDecompilerContextMenu(const QPoint &pt);
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**
The decompiler widget was made sync-able and the support for multiple decompiler widgets was implemented by PR #2402. However, the layout management was not implemented in that PR, and because of this layouts were not restored. This PR aims to solve this issue.

Even though this PR will restore the layout, in case multiple widgets are open with multiple decompilers, all widgets will be opened with the last opened decompiler. The logic for implementing the ideal situation where the decompiler will also be restored will require complex refactorings. I don't intend to do that by this PR. This is not a big deal for now considering the fact that we are not restoring seek.
<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

**Test plan (required)**
1. Compile PR and test if the layout gets restored as it should.
2. I'm not sure if there is anything else that I should add, so please have a quick look at how other memory widgets store and restore layouts and check if anything relevant is missing in this PR.
<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->


<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
