### PR TITLE
Do not change the internal widget name to preserve layout.

### DIFF
--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -111,7 +111,7 @@ DecompilerWidget::~DecompilerWidget() = default;
 
 QString DecompilerWidget::getWidgetType()
 {
-    return "Decompiler";
+    return "DecompilerWidget";
 }
 
 Decompiler *DecompilerWidget::getCurrentDecompiler()


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Keep the same decompiler widget name as previously to preserve old layouts. It is never displayed in UI.

**Test plan (required)**

* open Cutter 1.11.1
* reset settings
* open decompiler widget in obvious place like on the side of other widgets
* close cutter
* open the patched Cutter
* make sure decompiler widget is in the same place as with old cutter

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
