### PR TITLE
Make parsing tab in hexdump widget read-only

### DIFF
--- a/src/widgets/HexdumpWidget.ui
+++ b/src/widgets/HexdumpWidget.ui
@@ -260,6 +260,9 @@
                <pointsize>13</pointsize>
               </font>
              </property>
+             <property name="readOnly">
+              <bool>true</bool>
+             </property>
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
              </property>


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

- [x ] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x ] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)

Change src/widgets/HexdumpWidget.ui to make the widget read-only.


