### PR TITLE
Add preview functionality to DisassemblyWidget when hovering code, mu…

### DIFF
--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -698,14 +698,9 @@ bool DisassemblyWidget::eventFilter(QObject *obj, QEvent *event)
                     const QFont &fnt = Config()->getFont();
                     QFontMetrics fm{ fnt };
 
-                    QString toolTipContent =
-                        QString("<html><div style=\"font-family: %1; font-size: %2pt; white-space: nowrap;\">")
-                            .arg(fnt.family()).arg(qMax(6, fnt.pointSize() - 1));
-                    toolTipContent +=
-                        tr("<div style=\"margin-bottom: 10px;\"><strong>Disassembly Preview</strong>:<br>%1<div>")
-                            .arg(disasmPreview.join("<br>"));
-
-                    QToolTip::showText(helpEvent->globalPos(), toolTipContent, this, QRect(), 3500);
+                    QString tooltip = QString("<html><div style=\"font-family: %1; font-size: %2pt; white-space: nowrap;\"><div style=\"margin-bottom: 10px;\"><strong>Disassembly Preview</strong>:<br>%3<div>")
+                        .arg(fnt.family()).arg(qMax(6, fnt.pointSize() - 1)).arg(disasmPreview.join("<br>"));
+                    QToolTip::showText(helpEvent->globalPos(), tooltip, this, QRect(), 3500);
                 }
             }
         }

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -666,7 +666,6 @@ bool DisassemblyWidget::eventFilter(QObject *obj, QEvent *event)
         return true;
     } else if (event->type() == QEvent::ToolTip
          &&  obj == mDisasTextEdit->viewport()) {
-        //For future reference : https://github.com/radareorg/cutter/pull/2459
         QHelpEvent *helpEvent = static_cast<QHelpEvent*>(event);
 
         auto cursorForWord = mDisasTextEdit->cursorForPosition(helpEvent->pos());
@@ -689,19 +688,19 @@ bool DisassemblyWidget::eventFilter(QObject *obj, QEvent *event)
                     .arg(offsetFrom).arg(refs.at(0).from);
             }
 
-            // Only if the offset we point *to* is different from the one the cursor is
-            // currently on *and* the former is a valid offset, we are allowed to show a tooltip
+            // Only if the offset we point *to* is different from the one the cursor is currently
+            // on *and* the former is a valid offset, we are allowed to get a preview of offsetTo
             if(offsetTo != offsetFrom && offsetTo != RVA_INVALID) {
-                const QFont &fnt = Config()->getFont();
-                QFontMetrics fm{ fnt };
-
-                QString toolTipContent =
-                    QString("<html><div style=\"font-family: %1; font-size: %2pt; white-space: nowrap;\">")
-                        .arg(fnt.family()).arg(qMax(6, fnt.pointSize() - 1));
-
                 QStringList disasmPreview = Core()->getDisassemblyPreview(offsetTo, 10);
 
+                // Last check to make sure the returned preview isn't an empty text (QStringList)
                 if (!disasmPreview.isEmpty()) {
+                    const QFont &fnt = Config()->getFont();
+                    QFontMetrics fm{ fnt };
+
+                    QString toolTipContent =
+                        QString("<html><div style=\"font-family: %1; font-size: %2pt; white-space: nowrap;\">")
+                            .arg(fnt.family()).arg(qMax(6, fnt.pointSize() - 1));
                     toolTipContent +=
                         tr("<div style=\"margin-bottom: 10px;\"><strong>Disassembly Preview</strong>:<br>%1<div>")
                             .arg(disasmPreview.join("<br>"));

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -666,15 +666,16 @@ bool DisassemblyWidget::eventFilter(QObject *obj, QEvent *event)
     } else if (event->type() == QEvent::ToolTip
               &&  obj == mDisasTextEdit->viewport()) {
 
-        QHelpEvent * helpEvent = static_cast<QHelpEvent*>(event);
+        QHelpEvent *helpEvent = static_cast<QHelpEvent*>(event);
 
         auto cursorForWord = mDisasTextEdit->cursorForPosition(helpEvent->pos());
         cursorForWord.select(QTextCursor::WordUnderCursor);
 
-        RVA offsetFrom, offsetTo = readDisassemblyOffset( cursorForWord );
+        RVA offsetFrom = readDisassemblyOffset(cursorForWord);
+        RVA offsetTo = RVA_INVALID;
         bool offsetsDiffer = false; //Do these 2 values differ?
 
-        QList<XrefDescription> refs = Core()->getXRefs( offsetTo, false, false);
+        QList<XrefDescription> refs = Core()->getXRefs(offsetFrom, false, false);
 
         if (refs.length()) {
             if (refs.length() > 1) {
@@ -682,7 +683,6 @@ bool DisassemblyWidget::eventFilter(QObject *obj, QEvent *event)
                     .arg(refs.length());
             }
             offsetTo = refs.at(0).to;
-            offsetFrom = refs.at(0).from;
 
             if( offsetTo != offsetFrom ){
                 offsetsDiffer = true;
@@ -702,7 +702,7 @@ bool DisassemblyWidget::eventFilter(QObject *obj, QEvent *event)
             toolTipContent +=
                 tr("<div style=\"margin-bottom: 10px;\"><strong>Disassembly Preview</strong>:<br>%1<div>").arg(disasmPreview.join("<br>"));
 
-            QToolTip::showText( helpEvent->globalPos(), toolTipContent, this, QRect(), 3500);
+            QToolTip::showText(helpEvent->globalPos(), toolTipContent, this, QRect(), 3500);
         }
 
         return true;


### PR DESCRIPTION
…ch like Hopper does

<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [ x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

I have been experimenting with [Hopper](https://www.hopperapp.com/index.html) and I found a small feature that I liked. It's about previewing the code that is pointed by addresses and string constants when hovering the mouse above them. Hopper needs you to click on the code first in order to focus on the widget and then it can preview code. What I did was that I used the `QToolTip::showText` static function which doesn't need the `DisassemblyWidget` to have focus.

 So I discovered that the `FunctionsWidget` has what I am looking for. I 've read the code (I have to admit I reused a lot of it) and after tweaking to my purpose, the basic functionality is there. One problem I couldn't solve is that the preview is dark (almost black) unlike the Disassembly Preview of the `FunctionsWidget`. I hope someone here can help me change this.

Right now the feature works but it lacks support in configuration (about colors, fonts, duration or even disabling it). I am willing to write and maintain this code if you think what I 've done here is nice.

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->
I struggled to find a way so that the mouse won't show tooltips all around the place. Every command it pointed, it triggered a preview. If the command didn't contain a `jmp` to some address or a `call` to some function, the tooltip would show the code in the current address that the mouse was hovering.

I finally found a way to suppress the unnecessary tooltips. `readDisassemblyOffset(QTextCursor)` returns the current offset of the code that is under the mouse and that's why the tooltips printed every code I pointed. But in the `XrefDescription` info this function returns, I found it contained both the offset `(RVA) from` where `readDisassemblyOffset` was called and the offset it pointed `to`.

I shamelesly copied this snippet of code and I tweaked to suit my needs:
```cpp
        RVA offsetFrom, offsetTo = readDisassemblyOffset( cursorForWord );
        bool offsetsDiffer = false; //Do these 2 values differ?

        QList<XrefDescription> refs = Core()->getXRefs( offsetTo, false, false);
        if (refs.length()) {
            if (refs.length() > 1) {
                qWarning() << tr("More than one (%1) references here. Weird behaviour expected.")
                    .arg(refs.length());
            }
            offsetTo = refs.at(0).to;
            offsetFrom = refs.at(0).from;

            if( offsetTo != offsetFrom ){
                offsetsDiffer = true;
            }
        }
```

Basically what this code does is that after extracting the needed info about the offsets, it compares them and assign the boolean result to a variable. This variable is latter checked and if the offset **_from_** which this code path was triggered is different from the offset that we are pointing **_to_** (ie it won't preview the code at 0x0003f2 but rather it will preview the code at the offset 0x004f5 that is contained in the disassembly line at 0x0003f2).
![Screenshot_20201030_232726](https://user-images.githubusercontent.com/18561627/97761915-bd573300-1b0f-11eb-8f6c-6d566633e1cf.png)
![Screenshot_20201030_232812](https://user-images.githubusercontent.com/18561627/97761853-81bc6900-1b0f-11eb-8e57-74190511fb3a.png)
The original idea.
![Screenshot_20201030_233316](https://user-images.githubusercontent.com/18561627/97762063-20e16080-1b10-11eb-8ac8-4ba4a0602a19.png)

PS. I implemented this inside the `DisassemblyWidget::eventFilter(QObject *obj, QEvent *event)` for several reasons:
 * I didn't want to reimplement `mouseMoveEvent` because in the future we might want to do something else with it, so I chose the `eventFilter` function.
 * At first I used this:
```cpp
    else if (event->type() == QEvent::MouseMove
              &&  obj == mDisasTextEdit->viewport()) {
```
alongside with `setTracking` but the cursor couldn't left-click, drag and select more than one line. It felt weird and buggy. Not to mention that `QEvent::ToolTip` feels more appropriate for... well, a tooltip.
 * I began to write this code inside `DisassemblyTextEdit` widget which felt more natural to me, but soon I realized I needed various functions and data private to `DisassemblyWidget` class, so I abandoned the idea.

<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->
I failed to run astyle: 
```bash
 pwd
/home/petros/projects/CPlus/cutter
astyle --project=./src/Cutter.astylerc src/widgets/DisassemblyWidget.cpp 
Cannot open project option file ./src/Cutter.astylerc
Artistic Style has terminated
```