### PR TITLE
Make deploy_translations script more verbose

### DIFF
--- a/scripts/deploy_translations.sh
+++ b/scripts/deploy_translations.sh
@@ -1,21 +1,33 @@
 #!/bin/sh
+#########
+#### Push new translation files to cutter-translations
+#### so Crowdin can fetch them
 
-#######################
-#### Push new translation files
+log() {
+    echo "[TRANSLATIONS] $1"
+}
+
+log "Script started"
 
 # Update submodule
+log "Updating translations..."
 cd ${TRAVIS_BUILD_DIR}/src
 git submodule update translations
 cd translations
 git pull origin master
 
 # Generate Crowdin single translation file from cutter_fr.ts
+log "Generating single translation file"
 lupdate ../Cutter.pro
 cp ./fr/cutter_fr_FR.ts ./Translations.ts
 
 # Push it so Crowdin can find new strings, and later push updated translations
+log "Commiting..."
 git add Translations.ts
 git commit -m "Updated translations"
+log "Pushing..."
 export GIT_SSH_COMMAND="/usr/bin/ssh -i $TRAVIS_BUILD_DIR/scripts/deploy_translations_rsa"
-echo "Pushing new translation strings..."
 git push "git@github.com:radareorg/cutter-translations.git" HEAD:refs/heads/master
+
+log "Script done!"
+

--- a/scripts/deploy_translations.sh
+++ b/scripts/deploy_translations.sh
@@ -22,7 +22,7 @@ lupdate ../Cutter.pro
 cp ./fr/cutter_fr_FR.ts ./Translations.ts
 
 # Push it so Crowdin can find new strings, and later push updated translations
-log "Commiting..."
+log "Committing..."
 git add Translations.ts
 git commit -m "Updated translations"
 log "Pushing..."
@@ -30,4 +30,3 @@ export GIT_SSH_COMMAND="/usr/bin/ssh -i $TRAVIS_BUILD_DIR/scripts/deploy_transla
 git push "git@github.com:radareorg/cutter-translations.git" HEAD:refs/heads/master
 
 log "Script done!"
-


### PR DESCRIPTION
I am surprised there were no changes to cutter-translations despite recent merges, I just want to make sure `deploy_translations.sh` is verbose enough so we can check if anything went wrong.