### PR TITLE
Adding Labels to Graph Blocks in Disassembly

### DIFF
--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -780,3 +780,13 @@ bool Configuration::getOutputRedirectionEnabled() const
 {
     return outputRedirectEnabled;
 }
+
+bool Configuration::getGraphBlockEntryOffset()
+{
+    return s.value("graphBlockEntryOffset", true).value<bool>();
+}
+
+void Configuration::setGraphBlockEntryOffset(bool enabled)
+{
+    s.setValue("graphBlockEntryOffset", enabled);
+}

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -153,7 +153,7 @@ public:
      */
     void setConfig(const QString &key, const QVariant &value);
     bool isFirstExecution();
-    
+
     /**
      * @return id of the last selected decompiler (see CutterCore::getDecompilerById)
      */
@@ -186,6 +186,11 @@ public:
     void setGraphSpacing(QPoint blockSpacing, QPoint edgeSpacing);
     QPoint getGraphBlockSpacing();
     QPoint getGraphEdgeSpacing();
+    /**
+     * @brief Getter and setter for graph block entry offset
+     */
+    bool getGraphBlockEntryOffset();
+    void setGraphBlockEntryOffset(bool enabled);
 
     /**
      * @brief Enable or disable Cutter output redirection.

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -132,7 +132,7 @@ public:
     QString getColorTheme() const     { return s.value("theme", "cutter").toString(); }
     void setColorTheme(const QString &theme);
     /**
-     * @brief Change current color theme if it doesnt't much native theme's darkness.
+     * @brief Change current color theme if it doesn't much native theme's darkness.
      */
     void adjustColorThemeDarkness();
     int colorThemeDarkness(const QString &colorTheme) const;
@@ -186,15 +186,22 @@ public:
     void setGraphSpacing(QPoint blockSpacing, QPoint edgeSpacing);
     QPoint getGraphBlockSpacing();
     QPoint getGraphEdgeSpacing();
+
     /**
-     * @brief Getter and setter for graph block entry offset
+     * @brief Gets whether the entry offset of each block has to be displayed or not
+     * @return true if the entry offset has to be displayed, false otherwise
      */
     bool getGraphBlockEntryOffset();
+
+    /**
+     * @brief Enable or disable the displaying of the entry offset in each graph block
+     * @param enabled set this to true for displaying the entry offset in each graph block, false otherwise
+     */
     void setGraphBlockEntryOffset(bool enabled);
 
     /**
      * @brief Enable or disable Cutter output redirection.
-     * Output redirection state can only be changed early during Cutter initalization.
+     * Output redirection state can only be changed early during Cutter initialization.
      * Changing it later will have no effect
      * @param enabled set this to false for disabling output redirection
      */

--- a/src/dialogs/preferences/GraphOptionsWidget.cpp
+++ b/src/dialogs/preferences/GraphOptionsWidget.cpp
@@ -15,11 +15,13 @@ GraphOptionsWidget::GraphOptionsWidget(PreferencesDialog *dialog)
 {
     ui->setupUi(this);
     ui->checkTransparent->setChecked(Config()->getBitmapTransparentState());
+    ui->blockEntryCheckBox->setChecked(Config()->getGraphBlockEntryOffset());
     ui->bitmapGraphScale->setValue(Config()->getBitmapExportScaleFactor()*100.0);
     updateOptionsFromVars();
 
     connect<void(QDoubleSpinBox::*)(double)>(ui->bitmapGraphScale, (&QDoubleSpinBox::valueChanged), this, &GraphOptionsWidget::bitmapGraphScaleValueChanged);
     connect(ui->checkTransparent, &QCheckBox::stateChanged, this, &GraphOptionsWidget::checkTransparentStateChanged);
+    connect(ui->blockEntryCheckBox, &QCheckBox::stateChanged, this, &GraphOptionsWidget::checkGraphBlockEntryOffsetChanged);
 
     connect(Core(), &CutterCore::graphOptionsChanged, this, &GraphOptionsWidget::updateOptionsFromVars);
     QSpinBox* graphSpacingWidgets[] = {
@@ -89,3 +91,8 @@ void GraphOptionsWidget::layoutSpacingChanged()
     triggerOptionsChanged();
 }
 
+void GraphOptionsWidget::checkGraphBlockEntryOffsetChanged(bool checked)
+{
+    Config()->setGraphBlockEntryOffset(checked);
+    triggerOptionsChanged();
+}

--- a/src/dialogs/preferences/GraphOptionsWidget.h
+++ b/src/dialogs/preferences/GraphOptionsWidget.h
@@ -34,6 +34,7 @@ private slots:
 
     void checkTransparentStateChanged(int checked);
     void bitmapGraphScaleValueChanged(double value);
+    void checkGraphBlockEntryOffsetChanged(bool checked);
     void layoutSpacingChanged();
 };
 

--- a/src/dialogs/preferences/GraphOptionsWidget.ui
+++ b/src/dialogs/preferences/GraphOptionsWidget.ui
@@ -231,17 +231,16 @@
   </layout>
  </widget>
  <tabstops>
+  <tabstop>blockEntryCheckBox</tabstop>
+  <tabstop>graphOffsetCheckBox</tabstop>
+  <tabstop>maxColsSpinBox</tabstop>
   <tabstop>horizontalBlockSpacing</tabstop>
   <tabstop>verticalBlockSpacing</tabstop>
   <tabstop>horizontalEdgeSpacing</tabstop>
   <tabstop>verticalEdgeSpacing</tabstop>
-  <tabstop>blockEntryCheckBox</tabstop>
-  <tabstop>graphOffsetCheckBox</tabstop> 
-  <tabstop>maxColsSpinBox</tabstop>
   <tabstop>checkTransparent</tabstop>
   <tabstop>bitmapGraphScale</tabstop>
  </tabstops>
  <resources/>
  <connections/>
 </ui>
-  

--- a/src/dialogs/preferences/GraphOptionsWidget.ui
+++ b/src/dialogs/preferences/GraphOptionsWidget.ui
@@ -28,7 +28,7 @@
         <item>
          <widget class="QCheckBox" name="blockEntryCheckBox">
           <property name="toolTip">
-           <string>The address of the first instruction is shown in the header of each graph block</string>
+           <string>The offset of the first instruction of a graph block is shown in the header of the respective graph block</string>
           </property>
           <property name="text">
            <string>Show offset of the first instruction in each graph block</string>

--- a/src/dialogs/preferences/GraphOptionsWidget.ui
+++ b/src/dialogs/preferences/GraphOptionsWidget.ui
@@ -79,6 +79,13 @@
     </widget>
    </item>
    <item>
+    <widget class="QCheckBox" name="blockEntryCheckBox">
+     <property name="text">
+      <string>Show block entry offset</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
       <string>Layout</string>

--- a/src/dialogs/preferences/GraphOptionsWidget.ui
+++ b/src/dialogs/preferences/GraphOptionsWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>403</width>
-    <height>296</height>
+    <width>742</width>
+    <height>698</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,170 +15,205 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>
-    <layout class="QFormLayout" name="formLayout">
-     <item row="0" column="0">
-      <widget class="QLabel" name="maxColsLabel">
-       <property name="text">
-        <string>Maximum Line Length:</string>
+    <layout class="QVBoxLayout" name="verticalLayout_8">
+     <item>
+      <widget class="QGroupBox" name="GraphBlockOptions">
+       <property name="title">
+        <string>Graph Block Options </string>
        </property>
+       <layout class="QVBoxLayout" name="verticalLayout_9">
+        <property name="topMargin">
+         <number>24</number>
+        </property>
+        <item>
+         <widget class="QCheckBox" name="blockEntryCheckBox">
+          <property name="toolTip">
+           <string>The address of the first instruction is shown in the header of each graph block</string>
+          </property>
+          <property name="text">
+           <string>Show offset of the first instruction in each graph block</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="graphOffsetCheckBox">
+          <property name="text">
+           <string>Show offset for each instruction (graph.offset)</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout">
+          <item>
+           <widget class="QLabel" name="maxColsLabel">
+            <property name="text">
+             <string>Maximum Line Length:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QSpinBox" name="maxColsSpinBox">
+            <property name="minimum">
+             <number>25</number>
+            </property>
+            <property name="maximum">
+             <number>256</number>
+            </property>
+            <property name="value">
+             <number>100</number>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
       </widget>
      </item>
-     <item row="0" column="1">
-      <widget class="QSpinBox" name="maxColsSpinBox">
-       <property name="minimum">
-        <number>25</number>
+     <item>
+      <widget class="QGroupBox" name="LayoutBlock">
+       <property name="title">
+        <string>Graph Layout Options</string>
        </property>
-       <property name="maximum">
-        <number>256</number>
-       </property>
-       <property name="value">
-        <number>100</number>
-       </property>
+       <layout class="QGridLayout" name="gridLayout_2">
+        <item row="1" column="1">
+         <widget class="QSpinBox" name="horizontalBlockSpacing">
+          <property name="maximum">
+           <number>400</number>
+          </property>
+          <property name="singleStep">
+           <number>10</number>
+          </property>
+          <property name="value">
+           <number>10</number>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="2">
+         <widget class="QLabel" name="label_4">
+          <property name="text">
+           <string>Vertical</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QSpinBox" name="horizontalEdgeSpacing">
+          <property name="minimum">
+           <number>1</number>
+          </property>
+          <property name="maximum">
+           <number>400</number>
+          </property>
+          <property name="singleStep">
+           <number>5</number>
+          </property>
+          <property name="value">
+           <number>10</number>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QLabel" name="label_3">
+          <property name="text">
+           <string>Horizontal</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="2">
+         <widget class="QSpinBox" name="verticalEdgeSpacing">
+          <property name="minimum">
+           <number>1</number>
+          </property>
+          <property name="maximum">
+           <number>400</number>
+          </property>
+          <property name="singleStep">
+           <number>5</number>
+          </property>
+          <property name="value">
+           <number>10</number>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="2">
+         <widget class="QSpinBox" name="verticalBlockSpacing">
+          <property name="maximum">
+           <number>400</number>
+          </property>
+          <property name="singleStep">
+           <number>10</number>
+          </property>
+          <property name="value">
+           <number>40</number>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Block spacing:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>Edge spacing</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </widget>
      </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="bitmapGraphScaleLabel">
-       <property name="text">
-        <string>Graph Bitmap Export Scale: </string>
+     <item>
+      <widget class="QGroupBox" name="BitmapExportBlock">
+       <property name="title">
+        <string>Bitmap Export Options</string>
        </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QDoubleSpinBox" name="bitmapGraphScale">
-       <property name="suffix">
-        <string>%</string>
-       </property>
-       <property name="decimals">
-        <number>0</number>
-       </property>
-       <property name="minimum">
-        <double>100.000000000000000</double>
-       </property>
-       <property name="maximum">
-        <double>30000.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>50.000000000000000</double>
-       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_10">
+        <property name="topMargin">
+         <number>24</number>
+        </property>
+        <item>
+         <widget class="QCheckBox" name="checkTransparent">
+          <property name="text">
+           <string>Export Transparent Bitmap Graphs</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_2">
+          <item>
+           <widget class="QLabel" name="bitmapGraphScaleLabel">
+            <property name="text">
+             <string>Graph Bitmap Export Scale: </string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QDoubleSpinBox" name="bitmapGraphScale">
+            <property name="suffix">
+             <string>%</string>
+            </property>
+            <property name="decimals">
+             <number>0</number>
+            </property>
+            <property name="minimum">
+             <double>100.000000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>30000.000000000000000</double>
+            </property>
+            <property name="singleStep">
+             <double>50.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
       </widget>
      </item>
     </layout>
-   </item>
-   <item>
-    <widget class="QCheckBox" name="graphOffsetCheckBox">
-     <property name="text">
-      <string>Show offsets (graph.offset)</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QCheckBox" name="checkTransparent">
-     <property name="text">
-      <string>Export Transparent Bitmap Graphs</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QCheckBox" name="blockEntryCheckBox">
-     <property name="text">
-      <string>Show block entry offset</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox">
-     <property name="title">
-      <string>Layout</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <item row="0" column="1">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Horizontal</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Block spacing</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Edge spacing</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QSpinBox" name="horizontalBlockSpacing">
-        <property name="maximum">
-         <number>400</number>
-        </property>
-        <property name="singleStep">
-         <number>10</number>
-        </property>
-        <property name="value">
-         <number>10</number>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="QSpinBox" name="verticalBlockSpacing">
-        <property name="maximum">
-         <number>400</number>
-        </property>
-        <property name="singleStep">
-         <number>10</number>
-        </property>
-        <property name="value">
-         <number>40</number>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QSpinBox" name="horizontalEdgeSpacing">
-        <property name="minimum">
-         <number>1</number>
-        </property>
-        <property name="maximum">
-         <number>400</number>
-        </property>
-        <property name="singleStep">
-         <number>5</number>
-        </property>
-        <property name="value">
-         <number>10</number>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="2">
-       <widget class="QSpinBox" name="verticalEdgeSpacing">
-        <property name="minimum">
-         <number>1</number>
-        </property>
-        <property name="maximum">
-         <number>400</number>
-        </property>
-        <property name="singleStep">
-         <number>5</number>
-        </property>
-        <property name="value">
-         <number>10</number>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="2">
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>Vertical</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
    </item>
    <item>
     <spacer name="verticalSpacer">
@@ -196,10 +231,6 @@
   </layout>
  </widget>
  <tabstops>
-  <tabstop>maxColsSpinBox</tabstop>
-  <tabstop>bitmapGraphScale</tabstop>
-  <tabstop>graphOffsetCheckBox</tabstop>
-  <tabstop>checkTransparent</tabstop>
   <tabstop>horizontalBlockSpacing</tabstop>
   <tabstop>verticalBlockSpacing</tabstop>
   <tabstop>horizontalEdgeSpacing</tabstop>

--- a/src/dialogs/preferences/GraphOptionsWidget.ui
+++ b/src/dialogs/preferences/GraphOptionsWidget.ui
@@ -235,7 +235,13 @@
   <tabstop>verticalBlockSpacing</tabstop>
   <tabstop>horizontalEdgeSpacing</tabstop>
   <tabstop>verticalEdgeSpacing</tabstop>
+  <tabstop>blockEntryCheckBox</tabstop>
+  <tabstop>graphOffsetCheckBox</tabstop> 
+  <tabstop>maxColsSpinBox</tabstop>
+  <tabstop>checkTransparent</tabstop>
+  <tabstop>bitmapGraphScale</tabstop>
  </tabstops>
  <resources/>
  <connections/>
 </ui>
+  

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -236,8 +236,9 @@ void DisassemblerGraphView::loadCurrentGraph()
         gb.entry = block_entry;
         db.entry = block_entry;
         if (Config()->getGraphBlockEntryOffset()) {
+            // QColor(0,0,0,0) is transparent
             db.header_text = Text("[" + RAddressString(db.entry) + "]", ConfigColor("offset"),
-                                  QColorConstants::Transparent);
+                                  QColor(0, 0, 0, 0));
         }
         db.true_path = RVA_INVALID;
         db.false_path = RVA_INVALID;
@@ -439,7 +440,7 @@ void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block,
 
                 qreal highlightWidth = tokenWidth;
                 if (charWidth * 3 + widthBefore + tokenWidth >= block.width - (10 + padding)) {
-                    highlightWidth = block.width - widthBefore - (10 +  2 * padding);
+                    highlightWidth = block.width - widthBefore - (10 + 2 * padding);
                 }
 
                 QColor selectionColor = ConfigColor("wordHighlight");
@@ -569,7 +570,7 @@ DisassemblerGraphView::Instr *DisassemblerGraphView::getInstrForMouseEvent(
     int cur_row = 0;
 
     for (Instr &instr : db.instrs) {
-        if (mouse_row < cur_row + (int)instr.text.lines.size()) {
+        if (mouse_row < cur_row + (int) instr.text.lines.size()) {
             return &instr;
         }
         cur_row += instr.text.lines.size();

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -235,6 +235,8 @@ void DisassemblerGraphView::loadCurrentGraph()
         GraphBlock gb;
         gb.entry = block_entry;
         db.entry = block_entry;
+        db.header_text = Text("[" + RAddressString(db.entry) + "]", ConfigColor("offset"),
+                              QColorConstants::Transparent);
         db.true_path = RVA_INVALID;
         db.false_path = RVA_INVALID;
         if (block_fail) {

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -538,8 +538,8 @@ RVA DisassemblerGraphView::getAddrForMouseEvent(GraphBlock &block, QPoint *point
     int text_point_y = point->y() - off_y;
     int mouse_row = text_point_y / charHeight;
 
-    int cur_row = static_cast<int>(db.header_text.lines.size());
-    if (mouse_row < cur_row) {
+    // If mouse coordinate is in header region or margin above
+    if (mouse_row < 0) {
         return db.entry;
     }
 
@@ -563,7 +563,8 @@ DisassemblerGraphView::Instr *DisassemblerGraphView::getInstrForMouseEvent(
     int text_point_y = point->y() - off_y;
     int mouse_row = text_point_y / charHeight;
 
-    int cur_row = static_cast<int>(db.header_text.lines.size());
+    // Row in actual text
+    int cur_row = 0;
 
     for (Instr &instr : db.instrs) {
         if (mouse_row < cur_row + (int)instr.text.lines.size()) {

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -235,8 +235,10 @@ void DisassemblerGraphView::loadCurrentGraph()
         GraphBlock gb;
         gb.entry = block_entry;
         db.entry = block_entry;
-        db.header_text = Text("[" + RAddressString(db.entry) + "]", ConfigColor("offset"),
-                              QColorConstants::Transparent);
+        if (Config()->getGraphBlockEntryOffset()) {
+            db.header_text = Text("[" + RAddressString(db.entry) + "]", ConfigColor("offset"),
+                                  QColorConstants::Transparent);
+        }
         db.true_path = RVA_INVALID;
         db.false_path = RVA_INVALID;
         if (block_fail) {


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Note: I am open to suggestions from the community for design and implementation choices as this is my first time contributing to the project
<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->
- Added block entry address as the header_text of Disassembly Block. (Prior to this change the header_text element was never modified anywhere else) 
- Used "offset" color from theme to display it
- Right clicking on the entry address has the same context menu as that of first instruction
- Changed Graph Options Preferences Layout
- Current Result:
<img width="1245" alt="Screenshot 2020-11-20 at 1 59 43 PM" src="https://user-images.githubusercontent.com/56169176/99780246-390b3500-2b3c-11eb-9f2d-de191367fb25.png">

- Working on 
	- Fixing build errors

**Test plan (required)**
<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->
- The block entry offset is visible on all platforms (I tested this on MacOS Catalina) and its right click context menu works as expected
- The rest of the instructions in the graph block have the correct right click context after enabling or disabling the block entry offset
- The graph menu option for hiding and showing the block entry offset works and reflects changes in real time
- The new layout of graph menu option layout looks well without any issues on different platforms + theme combinations

<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**
Closes #1646 
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
